### PR TITLE
ItemsAdder CustomStack Wrapper Improvements

### DIFF
--- a/core/src/main/java/me/wolfyscript/utilities/compatibility/plugins/ItemsAdderIntegration.java
+++ b/core/src/main/java/me/wolfyscript/utilities/compatibility/plugins/ItemsAdderIntegration.java
@@ -21,12 +21,15 @@ package me.wolfyscript.utilities.compatibility.plugins;
 import me.wolfyscript.utilities.compatibility.PluginIntegration;
 import me.wolfyscript.utilities.compatibility.plugins.itemsadder.CustomStack;
 import org.bukkit.inventory.ItemStack;
+import org.jetbrains.annotations.Nullable;
 
 public interface ItemsAdderIntegration extends PluginIntegration {
 
     String KEY = "ItemsAdder";
 
+    @Nullable
     CustomStack getByItemStack(ItemStack itemStack);
 
+    @Nullable
     CustomStack getInstance(String namespacedID);
 }

--- a/plugin-compatibility/itemsadder/src/main/java/me/wolfyscript/utilities/compatibility/plugins/ItemsAdderImpl.java
+++ b/plugin-compatibility/itemsadder/src/main/java/me/wolfyscript/utilities/compatibility/plugins/ItemsAdderImpl.java
@@ -64,11 +64,11 @@ public class ItemsAdderImpl extends PluginIntegrationAbstract implements ItemsAd
 
     @Override
     public CustomStack getByItemStack(ItemStack itemStack) {
-        return new CustomStackWrapper(dev.lone.itemsadder.api.CustomStack.byItemStack(itemStack));
+        return CustomStackWrapper.wrapStack(dev.lone.itemsadder.api.CustomStack.byItemStack(itemStack));
     }
 
     @Override
     public CustomStack getInstance(String namespacedID) {
-        return new CustomStackWrapper(dev.lone.itemsadder.api.CustomStack.getInstance(namespacedID));
+        return CustomStackWrapper.wrapStack(dev.lone.itemsadder.api.CustomStack.getInstance(namespacedID));
     }
 }

--- a/plugin-compatibility/itemsadder/src/main/java/me/wolfyscript/utilities/compatibility/plugins/itemsadder/CustomStackWrapper.java
+++ b/plugin-compatibility/itemsadder/src/main/java/me/wolfyscript/utilities/compatibility/plugins/itemsadder/CustomStackWrapper.java
@@ -20,13 +20,20 @@ package me.wolfyscript.utilities.compatibility.plugins.itemsadder;
 
 import org.bukkit.inventory.ItemStack;
 import dev.lone.itemsadder.api.CustomStack;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 public class CustomStackWrapper implements me.wolfyscript.utilities.compatibility.plugins.itemsadder.CustomStack {
 
     private final CustomStack item;
 
-    public CustomStackWrapper(CustomStack item) {
+    private CustomStackWrapper(@NotNull CustomStack item) {
         this.item = item;
+    }
+
+    @Nullable
+    public static CustomStackWrapper wrapStack(@Nullable CustomStack customStack) {
+        return customStack != null ? new CustomStackWrapper(customStack) : null;
     }
 
     @Override


### PR DESCRIPTION
The `ItemsAdderIntegration#getByItemStack` and `ItemsAdderIntegration#getInstance` were wrapping null CustomStacks, that would cause NPEs later on.

From now on these method return null incase the CustomStack is null.