### PR TITLE
Further Adventure compatibility improvements & backwards compatibility

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -61,4 +61,16 @@
         </dependency>
     </dependencies>
 
+    <build>
+        <resources>
+            <resource>
+                <directory>${project.basedir}/src/main/java</directory>
+                <includes>
+                    <include>**/*.java</include>
+                    <include>**/*.gwt.xml</include>
+                </includes>
+            </resource>
+        </resources>
+    </build>
+
 </project>

--- a/core/src/main/java/com/wolfyscript/utilities/bukkit/chat/ChatImpl.java
+++ b/core/src/main/java/com/wolfyscript/utilities/bukkit/chat/ChatImpl.java
@@ -4,6 +4,7 @@ import com.wolfyscript.utilities.common.WolfyUtils;
 import com.wolfyscript.utilities.bukkit.adapters.PlayerImpl;
 import me.wolfyscript.utilities.api.chat.ChatImplOld;
 import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.minimessage.tag.resolver.TagResolver;
 import org.bukkit.entity.Player;
 import org.jetbrains.annotations.NotNull;
 
@@ -42,6 +43,21 @@ public final class ChatImpl extends ChatImplOld {
     @Override
     public void sendMessages(com.wolfyscript.utilities.common.adapters.Player player, boolean legacyColor, Component... components) {
         checkAndExc(player, player1 -> sendMessages(player, legacyColor, components));
+    }
+
+    @Override
+    public Component translated(String key) {
+        return languageAPI.getComponent(key);
+    }
+
+    @Override
+    public Component translated(String key, TagResolver... tagResolvers) {
+        return languageAPI.getComponent(key, tagResolvers);
+    }
+
+    @Override
+    public Component translated(String key, TagResolver tagResolver) {
+        return languageAPI.getComponent(key, tagResolver);
     }
 
     /**

--- a/core/src/main/java/com/wolfyscript/utilities/bukkit/language/LangAPISpigot.java
+++ b/core/src/main/java/com/wolfyscript/utilities/bukkit/language/LangAPISpigot.java
@@ -158,19 +158,19 @@ public class LangAPISpigot extends LanguageAPI {
     }
 
     public String getButtonName(@NotNull NamespacedKey window, String buttonKey) {
-        return BukkitComponentSerializer.legacy().serialize(getComponent(String.format(ButtonState.BUTTON_WINDOW_KEY + ButtonState.NAME_KEY, window.getNamespace(), window.getKey(), buttonKey), true));
+        return BukkitComponentSerializer.legacy().serialize(getComponent(String.format(ButtonState.BUTTON_WINDOW_KEY + ButtonState.NAME_KEY, window.getNamespace(), window.getKey(), buttonKey)));
     }
 
     public String getButtonName(String clusterId, String buttonKey) {
-        return BukkitComponentSerializer.legacy().serialize(getComponent(String.format(ButtonState.BUTTON_CLUSTER_KEY + ButtonState.NAME_KEY, clusterId, buttonKey), true));
+        return BukkitComponentSerializer.legacy().serialize(getComponent(String.format(ButtonState.BUTTON_CLUSTER_KEY + ButtonState.NAME_KEY, clusterId, buttonKey)));
     }
 
     public List<String> getButtonLore(@NotNull NamespacedKey window, String buttonKey) {
-        return getComponents(String.format(ButtonState.BUTTON_WINDOW_KEY + ButtonState.NAME_KEY, window.getNamespace(), window.getKey(), buttonKey), true).stream().map(component -> BukkitComponentSerializer.legacy().serialize(component)).collect(Collectors.toList());
+        return getComponents(String.format(ButtonState.BUTTON_WINDOW_KEY + ButtonState.NAME_KEY, window.getNamespace(), window.getKey(), buttonKey)).stream().map(component -> BukkitComponentSerializer.legacy().serialize(component)).collect(Collectors.toList());
     }
 
     public List<String> getButtonLore(String clusterId, String buttonKey) {
-        return getComponents(String.format(ButtonState.BUTTON_CLUSTER_KEY + ButtonState.LORE_KEY, clusterId, buttonKey), true).stream().map(component -> BukkitComponentSerializer.legacy().serialize(component)).collect(Collectors.toList());
+        return getComponents(String.format(ButtonState.BUTTON_CLUSTER_KEY + ButtonState.LORE_KEY, clusterId, buttonKey)).stream().map(component -> BukkitComponentSerializer.legacy().serialize(component)).collect(Collectors.toList());
     }
 
 }

--- a/core/src/main/java/com/wolfyscript/utilities/bukkit/language/LangAPISpigot.java
+++ b/core/src/main/java/com/wolfyscript/utilities/bukkit/language/LangAPISpigot.java
@@ -112,7 +112,7 @@ public class LangAPISpigot extends LanguageAPI {
     }
 
     @Override
-    protected String convertLegacyToMiniMessage(String legacyText) {
+    public String convertLegacyToMiniMessage(String legacyText) {
         String rawLegacy = ChatColor.convert(legacyText);
         Matcher matcher = LEGACY_PLACEHOLDER_PATTERN.matcher(rawLegacy);
         Map<String, String> foundPlaceholders = new HashMap<>();

--- a/core/src/main/java/com/wolfyscript/utilities/bukkit/language/LangAPISpigot.java
+++ b/core/src/main/java/com/wolfyscript/utilities/bukkit/language/LangAPISpigot.java
@@ -89,23 +89,23 @@ public class LangAPISpigot extends LanguageAPI {
                 for (String key : keys) {
                     JsonNode node = getNodeAt(key.replace("$", ""));
                     if (node.isTextual()) {
-                        result.add(ChatColor.convert(s.replace(key, node.asText())));
+                        result.add(s.replace(key, node.asText()));
                     } else if (node.isArray()) {
                         StringBuilder sB = new StringBuilder();
                         node.elements().forEachRemaining(n -> sB.append(' ').append(n.asText()));
-                        result.add(ChatColor.convert(s.replace(key, sB.toString())));
+                        result.add(s.replace(key, sB.toString()));
                     }
                 }
             } else if (!keys.isEmpty()) {
                 String key = keys.get(0);
                 JsonNode node = getNodeAt(key.replace("$", ""));
                 if (node.isTextual()) {
-                    result.add(ChatColor.convert(s.replace(key, node.asText())));
+                    result.add(s.replace(key, node.asText()));
                 } else if (node.isArray()) {
                     node.elements().forEachRemaining(n -> result.add(n.asText()));
                 }
             } else {
-                result.add(ChatColor.convert(s));
+                result.add(s);
             }
         });
         return result;

--- a/core/src/main/java/me/wolfyscript/utilities/api/chat/ChatImplOld.java
+++ b/core/src/main/java/me/wolfyscript/utilities/api/chat/ChatImplOld.java
@@ -338,7 +338,7 @@ public abstract class ChatImplOld extends me.wolfyscript.utilities.api.chat.Chat
                 char[] chars = placeholder.toCharArray();
                 boolean passedFirstGroup = false;
                 for (char currentChar : chars) {
-                    Matcher charMatch = ADVENTURE_PLACEHOLDER_PATTERN.matcher("" + currentChar);
+                    Matcher charMatch = ADVENTURE_PLACEHOLDER_PATTERN.matcher(String.valueOf(currentChar));
                     if (!charMatch.matches()) continue;
                     if (!passedFirstGroup) {
                         passedFirstGroup = true;

--- a/core/src/main/java/me/wolfyscript/utilities/api/chat/ChatImplOld.java
+++ b/core/src/main/java/me/wolfyscript/utilities/api/chat/ChatImplOld.java
@@ -198,26 +198,6 @@ public abstract class ChatImplOld extends me.wolfyscript.utilities.api.chat.Chat
     }
 
     @Override
-    public Component translated(String key) {
-        return languageAPI.getComponent(key);
-    }
-
-    @Override
-    public Component translated(String key, boolean translateLegacyColor) {
-        return languageAPI.getComponent(key, translateLegacyColor, List.of());
-    }
-
-    @Override
-    public Component translated(String key, List<? extends TagResolver> resolvers) {
-        return languageAPI.getComponent(key, resolvers);
-    }
-
-    @Override
-    public Component translated(String key, boolean translateLegacyColor, List<? extends TagResolver> resolvers) {
-        return languageAPI.getComponent(key, translateLegacyColor, resolvers);
-    }
-
-    @Override
     public net.kyori.adventure.text.event.ClickEvent executable(com.wolfyscript.utilities.common.adapters.Player player, boolean b, ClickActionCallback clickActionCallback) {
         return null;
     }

--- a/core/src/main/java/me/wolfyscript/utilities/api/inventory/gui/GuiCluster.java
+++ b/core/src/main/java/me/wolfyscript/utilities/api/inventory/gui/GuiCluster.java
@@ -135,13 +135,12 @@ public abstract class GuiCluster<C extends CustomCache> extends GuiMenuComponent
      * If it is not available it returns an empty component.
      *
      * @param key The key in the language.
-     * @param templates The placeholders and values in the message.
-     * @param translateLegacyColor If it should translate legacy '&' color codes.
+     * @param resolver The placeholders and values in the message.
      * @return The component set for the key; empty component if not available.
      */
     @Override
-    public Component translatedMsgKey(String key, boolean translateLegacyColor, List<? extends TagResolver> templates) {
-        return getChat().translated("inventories." + id + ".global_messages." + key, translateLegacyColor, templates);
+    public Component translatedMsgKey(String key, TagResolver resolver) {
+        return getChat().translated("inventories." + id + ".global_messages." + key, resolver);
     }
 
     /**

--- a/core/src/main/java/me/wolfyscript/utilities/api/inventory/gui/GuiMenuComponent.java
+++ b/core/src/main/java/me/wolfyscript/utilities/api/inventory/gui/GuiMenuComponent.java
@@ -138,9 +138,35 @@ public abstract class GuiMenuComponent<C extends CustomCache> {
      * If it is not available it returns an empty component.
      *
      * @param key The key in the language.
-     * @param translateLegacyColor If it should translate legacy '&' color codes.
+     * @param resolver The placeholders and values in the message.
      * @return The component set for the key; empty component if not available.
      */
+    public abstract Component translatedMsgKey(String key, TagResolver resolver);
+
+    /**
+     * Creates a {@link Component} of the specified language key.<br>
+     * If the key exists in the language it will be translated and returns the according component.
+     * If it is not available it returns an empty component.
+     *
+     * @param key The key in the language.
+     * @param resolvers The placeholders and values in the message.
+     * @return The component set for the key; empty component if not available.
+     */
+    public Component translatedMsgKey(String key, TagResolver... resolvers) {
+        return translatedMsgKey(key, TagResolver.resolver(resolvers));
+    }
+
+    /**
+     * Creates a {@link Component} of the specified language key.<br>
+     * If the key exists in the language it will be translated and returns the according component.
+     * If it is not available it returns an empty component.
+     *
+     * @param key The key in the language.
+     * @param translateLegacyColor If it should translate legacy '&' color codes.
+     * @deprecated The translateLegacyColor param no longer affects the message! Replaced by {@link #translatedMsgKey(String)}
+     * @return The component set for the key; empty component if not available.
+     */
+    @Deprecated
     public Component translatedMsgKey(String key, boolean translateLegacyColor) {
         return translatedMsgKey(key, translateLegacyColor, List.of());
     }
@@ -150,10 +176,12 @@ public abstract class GuiMenuComponent<C extends CustomCache> {
      * If the key exists in the language it will be translated and returns the according component.
      * If it is not available it returns an empty component.
      *
+     * @deprecated This method causes an inefficient conversion to an array. Replaced by {@link #translatedMsgKey(String, TagResolver...)}
      * @param key The key in the language.
      * @param templates The placeholders and values in the message.
      * @return The component set for the key; empty component if not available.
      */
+    @Deprecated
     public Component translatedMsgKey(String key, List<? extends TagResolver> templates) {
         return translatedMsgKey(key, false, templates);
     }
@@ -163,12 +191,17 @@ public abstract class GuiMenuComponent<C extends CustomCache> {
      * If the key exists in the language it will be translated and returns the according component.
      * If it is not available it returns an empty component.
      *
+     * @deprecated The translateLegacyColor param no longer affects the message and this method causes an inefficient conversion to an array. Replaced by {@link #translatedMsgKey(String, TagResolver...)}
      * @param key The key in the language.
      * @param templates The placeholders and values in the message.
      * @param translateLegacyColor If it should translate legacy '&' color codes.
      * @return The component set for the key; empty component if not available.
      */
-    public abstract Component translatedMsgKey(String key, boolean translateLegacyColor, List<? extends TagResolver> templates);
+    @Deprecated
+    public Component translatedMsgKey(String key, boolean translateLegacyColor, List<? extends TagResolver> templates) {
+        return translatedMsgKey(key, templates.toArray(new TagResolver[0]));
+    }
+
 
     /**
      * Opens the chat, send the player the defined message and waits for the input of the player.

--- a/core/src/main/java/me/wolfyscript/utilities/api/inventory/gui/GuiWindow.java
+++ b/core/src/main/java/me/wolfyscript/utilities/api/inventory/gui/GuiWindow.java
@@ -132,7 +132,7 @@ public abstract class GuiWindow<C extends CustomCache> extends GuiMenuComponent<
         try {
             Class<?> newTitleMethodClass = getClass().getMethod("onUpdateTitle", Player.class, GUIInventory.class, GuiHandler.class).getDeclaringClass();
             Class<?> oldTitleMethodClass = getClass().getMethod("onUpdateTitle", String.class, GUIInventory.class, GuiHandler.class).getDeclaringClass();
-            if (newTitleMethodClass.equals(getClass()) && !oldTitleMethodClass.equals(getClass())) {
+            if (!newTitleMethodClass.equals(getClass()) && oldTitleMethodClass.equals(getClass())) {
                 wolfyUtilities.getConsole().getLogger().warning("GuiWindow " + namespacedKey + " is using deprecated title method!");
                 useLegacyTitleUpdate = true;
             }

--- a/core/src/main/java/me/wolfyscript/utilities/api/inventory/gui/GuiWindow.java
+++ b/core/src/main/java/me/wolfyscript/utilities/api/inventory/gui/GuiWindow.java
@@ -416,14 +416,17 @@ public abstract class GuiWindow<C extends CustomCache> extends GuiMenuComponent<
     }
 
     /**
-     * Creates a new Component of the given language message key.
+     * Creates a {@link Component} of the specified language key.<br>
+     * If the key exists in the language it will be translated and returns the according component.
+     * If it is not available it returns an empty component.
      *
-     * @param key The key of the message in the language.
-     * @return The translated Component of that message; Or empty Component if non-existing.
+     * @param key The key in the language.
+     * @param resolver The placeholders and values in the message.
+     * @return The component set for the key; empty component if not available.
      */
     @Override
-    public Component translatedMsgKey(String key, boolean translateLegacyColor, List<? extends TagResolver> templates) {
-        return getChat().translated("inventories." + getNamespacedKey().getNamespace() + "." + getNamespacedKey().getKey() + ".messages." + key, translateLegacyColor, templates);
+    public Component translatedMsgKey(String key, TagResolver resolver) {
+        return getChat().translated("inventories." + getNamespacedKey().getNamespace() + "." + getNamespacedKey().getKey() + ".messages." + key, resolver);
     }
 
     /**

--- a/core/src/main/java/me/wolfyscript/utilities/api/inventory/gui/button/ButtonState.java
+++ b/core/src/main/java/me/wolfyscript/utilities/api/inventory/gui/button/ButtonState.java
@@ -54,7 +54,8 @@ public class ButtonState<C extends CustomCache> {
     public static final String BUTTON_CLUSTER_KEY = "inventories.%s.global_items.%s";
 
     private WolfyUtilities wolfyUtilities;
-    private String clusterID;
+    private String clusterID = null;
+    private NamespacedKey windowID = null;
     private String key;
     private final ItemStack presetIcon;
     private ItemStack icon;
@@ -406,6 +407,9 @@ public class ButtonState<C extends CustomCache> {
 
     public void init(GuiWindow<C> window) {
         this.wolfyUtilities = window.wolfyUtilities;
+        if (this.windowID == null) {
+            this.windowID = window.getNamespacedKey();
+        }
         createIcon(window);
     }
 
@@ -419,10 +423,42 @@ public class ButtonState<C extends CustomCache> {
         }
     }
 
+    public ItemStack constructIcon() {
+        return ItemUtils.createItem(presetIcon, getName(), getLore());
+    }
+
+    public ItemStack constructIcon(TagResolver tagResolver) {
+        return ItemUtils.createItem(presetIcon, getName(tagResolver), getLore(tagResolver));
+    }
+
+    /**
+     * Gets the name of this state. The name may vary depending on if it was initiated in a {@link GuiCluster} or {@link GuiWindow}.
+     *
+     * @return The display name of this state.
+     */
+    public Component getName() {
+        return getName(TagResolver.empty());
+    }
+
+    /**
+     * Gets the name of this state. The name may vary depending on if it was initiated in a {@link GuiCluster} or {@link GuiWindow}.
+     *
+     * @param tagResolver The resolver used to handle tags when deserializing the raw value.
+     * @return The display name of this state.
+     */
+    public Component getName(TagResolver tagResolver) {
+        if (clusterID != null) {
+            return wolfyUtilities.getLanguageAPI().getComponent(String.format(BUTTON_CLUSTER_KEY + NAME_KEY, clusterID, key), tagResolver);
+        }
+        return windowID != null ? wolfyUtilities.getLanguageAPI().getComponent(String.format(BUTTON_WINDOW_KEY + NAME_KEY, windowID.getNamespace(), windowID.getKey(), key), tagResolver) : Component.text("");
+    }
+
+    @Deprecated
     public Component getName(GuiWindow<C> window) {
         return getName(window, List.of());
     }
 
+    @Deprecated
     public Component getName(GuiWindow<C> window, List<? extends TagResolver> templates) {
         if (clusterID != null) {
             return wolfyUtilities.getLanguageAPI().getComponent(String.format(BUTTON_CLUSTER_KEY + NAME_KEY, clusterID, key), true, templates);
@@ -430,10 +466,34 @@ public class ButtonState<C extends CustomCache> {
         return wolfyUtilities.getLanguageAPI().getComponent(String.format(BUTTON_WINDOW_KEY + NAME_KEY, window.getNamespacedKey().getNamespace(), window.getNamespacedKey().getKey(), key), true, templates);
     }
 
+    /**
+     * Gets the lore of this state. The lore may vary depending on if it was initiated in a {@link GuiCluster} or {@link GuiWindow}.
+     *
+     * @return The lore (description) of this state.
+     */
+    public List<Component> getLore() {
+        return getLore(TagResolver.empty());
+    }
+
+    /**
+     * Gets the lore of this state. The lore may vary depending on if it was initiated in a {@link GuiCluster} or {@link GuiWindow}.
+     *
+     * @param tagResolver The resolver used to handle tags when deserializing the raw value.
+     * @return The lore (description) of this state.
+     */
+    public List<Component> getLore(TagResolver tagResolver) {
+        if (clusterID != null) {
+            return wolfyUtilities.getLanguageAPI().getComponents(String.format(BUTTON_CLUSTER_KEY + LORE_KEY, clusterID, key), tagResolver);
+        }
+        return wolfyUtilities.getLanguageAPI().getComponents(String.format(BUTTON_WINDOW_KEY + LORE_KEY, windowID.getNamespace(), windowID.getKey(), key), tagResolver);
+    }
+
+    @Deprecated
     public List<Component> getLore(GuiWindow<C> window) {
         return getLore(window, List.of());
     }
 
+    @Deprecated
     public List<Component> getLore(GuiWindow<C> window, List<? extends TagResolver> templates) {
         if (clusterID != null) {
             return wolfyUtilities.getLanguageAPI().getComponents(String.format(BUTTON_CLUSTER_KEY + LORE_KEY, clusterID, key), true, templates);

--- a/core/src/main/java/me/wolfyscript/utilities/api/inventory/gui/button/CallbackButtonRender.java
+++ b/core/src/main/java/me/wolfyscript/utilities/api/inventory/gui/button/CallbackButtonRender.java
@@ -24,8 +24,10 @@ import me.wolfyscript.utilities.api.nms.inventory.GUIInventory;
 import net.kyori.adventure.text.minimessage.tag.resolver.TagResolver;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.ItemStack;
+import org.jetbrains.annotations.Nullable;
 
 import java.util.HashMap;
+import java.util.Optional;
 
 /**
  * @param <C> The type of the {@link CustomCache}
@@ -60,19 +62,19 @@ public interface CallbackButtonRender<C extends CustomCache> extends ButtonRende
     class UpdateResult {
 
         private final ItemStack itemStack;
-        private final TagResolver[] resolvers;
+        private final TagResolver resolver;
 
-        private UpdateResult(ItemStack itemStack, TagResolver... resolvers) {
+        private UpdateResult(@Nullable ItemStack itemStack, @Nullable TagResolver resolver) {
             this.itemStack = itemStack;
-            this.resolvers = resolvers;
+            this.resolver = resolver;
         }
 
-        private UpdateResult(ItemStack itemStack, TagResolver resolver) {
-            this(itemStack, new TagResolver[] { resolver });
+        private UpdateResult(@Nullable ItemStack itemStack, TagResolver... resolvers) {
+            this(itemStack, resolvers == null || resolvers.length == 0 ? null : TagResolver.resolver(resolvers));
         }
 
-        private UpdateResult(ItemStack itemStack) {
-            this(itemStack, new TagResolver[0]);
+        private UpdateResult(@Nullable ItemStack itemStack) {
+            this(itemStack, (TagResolver) null);
         }
 
         /**
@@ -80,9 +82,13 @@ public interface CallbackButtonRender<C extends CustomCache> extends ButtonRende
          *
          * @param itemStack The ItemStack to render.
          * @param resolvers The TagResolvers to use to replace tags in display name and lore.
+         * @deprecated TagResolvers should <b>not be used</b> together with a custom ItemStack!
+         * They cause a very resource intensive conversion for each lore line and the display name of the item!
+         *
          * @return a new {@link UpdateResult} instance.
          */
-        public static UpdateResult of(ItemStack itemStack, TagResolver... resolvers) {
+        @Deprecated
+        public static UpdateResult of(@Nullable ItemStack itemStack, TagResolver... resolvers) {
             return new UpdateResult(itemStack, resolvers);
         }
 
@@ -91,9 +97,12 @@ public interface CallbackButtonRender<C extends CustomCache> extends ButtonRende
          *
          * @param itemStack The ItemStack to render.
          * @param resolver The TagResolver to use to replace tags in display name and lore.
+         * @deprecated TagResolvers should <b>not be used</b> together with a custom ItemStack!
+         * They cause a very resource intensive conversion for each lore line and the display name of the item!
          * @return a new {@link UpdateResult} instance.
          */
-        public static UpdateResult of(ItemStack itemStack, TagResolver resolver) {
+        @Deprecated
+        public static UpdateResult of(@Nullable ItemStack itemStack, TagResolver resolver) {
             return new UpdateResult(itemStack, resolver);
         }
 
@@ -103,8 +112,20 @@ public interface CallbackButtonRender<C extends CustomCache> extends ButtonRende
          * @param itemStack The ItemStack to render.
          * @return a new {@link UpdateResult} instance.
          */
-        public static UpdateResult of(ItemStack itemStack) {
+        public static UpdateResult of(@Nullable ItemStack itemStack) {
             return new UpdateResult(itemStack);
+        }
+
+        public static UpdateResult of() {
+            return new UpdateResult(null);
+        }
+
+        public static UpdateResult of(TagResolver resolver) {
+            return new UpdateResult(null, resolver);
+        }
+
+        public static UpdateResult of(TagResolver... resolvers) {
+            return new UpdateResult(null, resolvers);
         }
 
         /**
@@ -112,6 +133,26 @@ public interface CallbackButtonRender<C extends CustomCache> extends ButtonRende
          *
          * @return the ItemStack of this result.
          */
+        public Optional<ItemStack> getCustomStack() {
+            return Optional.ofNullable(itemStack);
+        }
+
+        /**
+         * The {@link TagResolver} to use to replace tags in the display name and lore of the item.
+         *
+         * @return An array of all the {@link TagResolver}s of this result.
+         */
+        public Optional<TagResolver> getTagResolver() {
+            return Optional.ofNullable(resolver);
+        }
+
+        /**
+         * The ItemStack of this result, that is rendered in the inventory.
+         *
+         * @return the ItemStack of this result.
+         */
+        @Deprecated
+        @Nullable
         public ItemStack getItemStack() {
             return itemStack;
         }
@@ -121,8 +162,9 @@ public interface CallbackButtonRender<C extends CustomCache> extends ButtonRende
          *
          * @return An array of all the {@link TagResolver}s of this result.
          */
+        @Deprecated
         public TagResolver[] getResolvers() {
-            return resolvers;
+            return new TagResolver[] { resolver };
         }
     }
 }

--- a/core/src/main/java/me/wolfyscript/utilities/util/inventory/ItemUtils.java
+++ b/core/src/main/java/me/wolfyscript/utilities/util/inventory/ItemUtils.java
@@ -127,14 +127,33 @@ public class ItemUtils {
         var itemMeta = itemBuilder.getItemMeta();
         if (itemMeta != null) {
             itemBuilder.setDisplayName(BukkitComponentSerializer.legacy().serialize(displayName));
-            itemBuilder.setLore(lore.stream().map(line -> BukkitComponentSerializer.legacy().serialize(line)).toList());
+            if (!lore.isEmpty()) {
+                itemBuilder.setLore(lore.stream().map(line -> BukkitComponentSerializer.legacy().serialize(line)).toList());
+            }
         }
         return itemBuilder.create();
     }
 
-    public static ItemStack replaceNameAndLore(MiniMessage miniMessage, ItemStack itemStack, @NotNull TagResolver... tagResolvers) {
+    @Deprecated
+    public static ItemStack replaceNameAndLore(MiniMessage miniMessage, ItemStack itemStack, @NotNull TagResolver tagResolver) {
         var itemMeta = itemStack.getItemMeta();
-        return itemMeta != null ? applyNameAndLore(itemStack, miniMessage.deserialize(itemMeta.getDisplayName(), tagResolvers), itemMeta.hasLore() ? itemMeta.getLore().stream().map(s -> miniMessage.deserialize(s, tagResolvers)).toList() : new LinkedList<>()) : itemStack;
+        if (itemMeta != null) {
+            Component name = convertLegacyTextWithTagResolversToComponent(miniMessage, itemMeta.getDisplayName(), tagResolver);
+            List<Component> legacyLore = itemMeta.hasLore() ? itemMeta.getLore().stream().map(s -> convertLegacyTextWithTagResolversToComponent(miniMessage, s, tagResolver)).toList() : new LinkedList<>();
+            return applyNameAndLore(itemStack, name, legacyLore);
+        }
+        return itemStack;
+    }
+
+    @Deprecated
+    public static ItemStack replaceNameAndLore(MiniMessage miniMessage, ItemStack itemStack, @NotNull TagResolver... tagResolvers) {
+        return replaceNameAndLore(miniMessage, itemStack, TagResolver.resolver(tagResolvers));
+    }
+
+    private static Component convertLegacyTextWithTagResolversToComponent(MiniMessage miniMessage, String value, TagResolver tagResolver) {
+        Component lore = miniMessage.deserialize(value.replace("§", "&"), tagResolver);
+        String converted = BukkitComponentSerializer.legacy().serialize(lore);
+        return BukkitComponentSerializer.legacy().deserialize(converted.replace("&", "§"));
     }
 
 }

--- a/wolfyutils-spigot/pom.xml
+++ b/wolfyutils-spigot/pom.xml
@@ -15,9 +15,10 @@
         <resources>
             <resource>
                 <directory>${project.basedir}/src/main/java</directory>
-                <excludes>
-                    <exclude>**/*.java</exclude>
-                </excludes>
+                <includes>
+                    <include>**/*.java</include>
+                    <include>**/*.gwt.xml</include>
+                </includes>
             </resource>
             <resource>
                 <directory>${project.basedir}/src/main/resources</directory>


### PR DESCRIPTION
- Improved the way ButtonStates are initiated and rendered.
- UpdateResults no longer require an ItemStack.
- Added UpdateResult#of methods that accept one TagResolver argument.
  Those should be used before falling back to the ItemStack.
- Fixed detection of deprecated title update method.
- Added GuiMenuComponent#translatedMsgKey methods that replace the old List<TagResolver> parameters.
- LangAPISpigot#replaceKeys no longer converts legacy color codes
- Made LangAPISpigot#convertLegacyToMiniMessage public
- Added source to final jar and artifact.
This provides the documentation when used as a dependency.
