### PR TITLE
ItemsAdder CustomBlock Wrapper

### DIFF
--- a/core/src/main/java/me/wolfyscript/utilities/compatibility/plugins/ItemsAdderIntegration.java
+++ b/core/src/main/java/me/wolfyscript/utilities/compatibility/plugins/ItemsAdderIntegration.java
@@ -19,9 +19,13 @@
 package me.wolfyscript.utilities.compatibility.plugins;
 
 import me.wolfyscript.utilities.compatibility.PluginIntegration;
+import me.wolfyscript.utilities.compatibility.plugins.itemsadder.CustomBlock;
 import me.wolfyscript.utilities.compatibility.plugins.itemsadder.CustomStack;
+import org.bukkit.block.Block;
 import org.bukkit.inventory.ItemStack;
 import org.jetbrains.annotations.Nullable;
+
+import java.util.Optional;
 
 public interface ItemsAdderIntegration extends PluginIntegration {
 
@@ -32,4 +36,13 @@ public interface ItemsAdderIntegration extends PluginIntegration {
 
     @Nullable
     CustomStack getInstance(String namespacedID);
+
+    @Nullable
+    Optional<CustomBlock> getBlockByItemStack(ItemStack itemStack);
+
+    @Nullable
+    Optional<CustomBlock> getBlockPlaced(Block block);
+
+    @Nullable
+    Optional<CustomBlock> getBlockInstance(String namespacedID);
 }

--- a/core/src/main/java/me/wolfyscript/utilities/compatibility/plugins/itemsadder/CustomBlock.java
+++ b/core/src/main/java/me/wolfyscript/utilities/compatibility/plugins/itemsadder/CustomBlock.java
@@ -1,0 +1,32 @@
+package me.wolfyscript.utilities.compatibility.plugins.itemsadder;
+
+import org.bukkit.Location;
+import org.bukkit.block.Block;
+import org.bukkit.block.data.BlockData;
+import org.bukkit.inventory.ItemStack;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface CustomBlock {
+
+    Optional<CustomBlock> place(Location location);
+
+    boolean remove();
+
+    BlockData generateBlockData();
+
+    Block getBlock();
+
+    boolean isPlaced();
+
+    List<ItemStack> getLoot(boolean includeSelfBlock);
+
+    List<ItemStack> getLoot();
+
+    List<ItemStack> getLoot(ItemStack tool, boolean includeSelfBlock);
+
+    int getOriginalLightLevel();
+
+    void setCurrentLightLevel(int level);
+}

--- a/core/src/main/java/me/wolfyscript/utilities/compatibility/plugins/itemsadder/CustomStack.java
+++ b/core/src/main/java/me/wolfyscript/utilities/compatibility/plugins/itemsadder/CustomStack.java
@@ -34,6 +34,8 @@ public interface CustomStack {
 
     boolean hasPermission();
 
+    boolean isBlock();
+
     boolean isBlockAllEnchants();
 
     boolean hasUsagesAttribute();

--- a/plugin-compatibility/itemsadder/src/main/java/me/wolfyscript/utilities/compatibility/plugins/ItemsAdderImpl.java
+++ b/plugin-compatibility/itemsadder/src/main/java/me/wolfyscript/utilities/compatibility/plugins/ItemsAdderImpl.java
@@ -23,14 +23,19 @@ import me.wolfyscript.utilities.annotations.WUPluginIntegration;
 import me.wolfyscript.utilities.api.WolfyUtilCore;
 import me.wolfyscript.utilities.api.inventory.custom_items.references.APIReference;
 import me.wolfyscript.utilities.compatibility.PluginIntegrationAbstract;
+import me.wolfyscript.utilities.compatibility.plugins.itemsadder.CustomBlock;
 import me.wolfyscript.utilities.compatibility.plugins.itemsadder.CustomStack;
 import me.wolfyscript.utilities.compatibility.plugins.itemsadder.CustomStackWrapper;
 import me.wolfyscript.utilities.compatibility.plugins.itemsadder.ItemsAdderRefImpl;
 import org.bukkit.Bukkit;
+import org.bukkit.block.Block;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.plugin.Plugin;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.Optional;
 
 @WUPluginIntegration(pluginName = ItemsAdderIntegration.KEY)
 public class ItemsAdderImpl extends PluginIntegrationAbstract implements ItemsAdderIntegration, Listener {
@@ -70,5 +75,20 @@ public class ItemsAdderImpl extends PluginIntegrationAbstract implements ItemsAd
     @Override
     public CustomStack getInstance(String namespacedID) {
         return CustomStackWrapper.wrapStack(dev.lone.itemsadder.api.CustomStack.getInstance(namespacedID));
+    }
+
+    @Override
+    public @Nullable Optional<CustomBlock> getBlockByItemStack(ItemStack itemStack) {
+        return Optional.empty();
+    }
+
+    @Override
+    public @Nullable Optional<CustomBlock> getBlockPlaced(Block block) {
+        return Optional.empty();
+    }
+
+    @Override
+    public @Nullable Optional<CustomBlock> getBlockInstance(String namespacedID) {
+        return Optional.empty();
     }
 }

--- a/plugin-compatibility/itemsadder/src/main/java/me/wolfyscript/utilities/compatibility/plugins/itemsadder/CustomBlockWrapper.java
+++ b/plugin-compatibility/itemsadder/src/main/java/me/wolfyscript/utilities/compatibility/plugins/itemsadder/CustomBlockWrapper.java
@@ -1,0 +1,79 @@
+package me.wolfyscript.utilities.compatibility.plugins.itemsadder;
+
+import org.bukkit.Location;
+import org.bukkit.block.Block;
+import org.bukkit.block.data.BlockData;
+import org.bukkit.inventory.ItemStack;
+import org.jetbrains.annotations.NotNull;
+import dev.lone.itemsadder.api.CustomBlock;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.List;
+import java.util.Optional;
+
+public class CustomBlockWrapper implements me.wolfyscript.utilities.compatibility.plugins.itemsadder.CustomBlock {
+
+    private final CustomBlock iaBlock;
+
+    private CustomBlockWrapper(@NotNull CustomBlock iaBlock) {
+        this.iaBlock = iaBlock;
+    }
+
+    public static Optional<CustomBlockWrapper> wrapBlock(@Nullable CustomBlock iaBlock) {
+        return Optional.ofNullable(wrapNullableBlock(iaBlock));
+    }
+
+    private static CustomBlockWrapper wrapNullableBlock(@Nullable CustomBlock iaBlock) {
+        return iaBlock != null ? new CustomBlockWrapper(iaBlock) : null;
+    }
+
+    @Override
+    public Optional<me.wolfyscript.utilities.compatibility.plugins.itemsadder.CustomBlock> place(Location location) {
+        return Optional.ofNullable(wrapNullableBlock(iaBlock.place(location)));
+    }
+
+    @Override
+    public boolean remove() {
+        return iaBlock.remove();
+    }
+
+    @Override
+    public BlockData generateBlockData() {
+        return iaBlock.generateBlockData();
+    }
+
+    @Override
+    public Block getBlock() {
+        return iaBlock.getBlock();
+    }
+
+    @Override
+    public boolean isPlaced() {
+        return iaBlock.isPlaced();
+    }
+
+    @Override
+    public List<ItemStack> getLoot(boolean includeSelfBlock) {
+        return iaBlock.getLoot(includeSelfBlock);
+    }
+
+    @Override
+    public List<ItemStack> getLoot() {
+        return iaBlock.getLoot();
+    }
+
+    @Override
+    public List<ItemStack> getLoot(ItemStack tool, boolean includeSelfBlock) {
+        return iaBlock.getLoot(tool, includeSelfBlock);
+    }
+
+    @Override
+    public int getOriginalLightLevel() {
+        return iaBlock.getOriginalLightLevel();
+    }
+
+    @Override
+    public void setCurrentLightLevel(int level) {
+        iaBlock.setCurrentLightLevel(level);
+    }
+}

--- a/plugin-compatibility/itemsadder/src/main/java/me/wolfyscript/utilities/compatibility/plugins/itemsadder/CustomStackWrapper.java
+++ b/plugin-compatibility/itemsadder/src/main/java/me/wolfyscript/utilities/compatibility/plugins/itemsadder/CustomStackWrapper.java
@@ -110,4 +110,9 @@ public class CustomStackWrapper implements me.wolfyscript.utilities.compatibilit
     public int getMaxDurability() {
         return item.getMaxDurability();
     }
+
+    @Override
+    public boolean isBlock() {
+        return item.isBlock();
+    }
 }


### PR DESCRIPTION
Added a wrapper interface for the ItemsAdder CustomBlock.
Accessable via `ItemsAdderIntegration#getBlockByItemStack`,  `#getBlockPlaced` and `#getBlockInstance`
