### PR TITLE
List TagResolver to insert entries from Lists

### DIFF
--- a/core/src/main/java/com/wolfyscript/utilities/bukkit/TagResolverUtil.java
+++ b/core/src/main/java/com/wolfyscript/utilities/bukkit/TagResolverUtil.java
@@ -7,6 +7,10 @@ import net.kyori.adventure.text.minimessage.tag.Tag;
 import net.kyori.adventure.text.minimessage.tag.resolver.TagResolver;
 import org.bukkit.entity.Player;
 
+import java.util.List;
+import java.util.function.Function;
+import java.util.function.Supplier;
+
 public class TagResolverUtil {
 
     public static TagResolver papi(Player player) {
@@ -17,6 +21,43 @@ public class TagResolverUtil {
                 text = integration.setPlaceholders(player, text);
             }
             return Tag.inserting(Component.text(text));
+        });
+    }
+
+    /**
+     * Creates a {@link TagResolver}, that will replace tags of the syntax: <br>
+     * <code>&lt;list_entry:&lt;index&gt;&gt;</code><br>
+     * This will insert the Component from the specified list and index.<br>
+     * In case the specific index is outbounds, it'll insert an empty Component.<br>
+     * If no index is specified the tag will resolve to the first element of the components list.<br>
+     * If the list itself is empty, it'll insert an empty Component.
+     *
+     * @param descriptionComponents The Components to use for the resolver.
+     * @return The new TagResolver that resolves the <code>&lt;entries:&lt;index&gt;&gt;</code> tags.
+     */
+    public static TagResolver entries(List<Component> descriptionComponents) {
+        return entries(descriptionComponents, Component.empty(), 0);
+    }
+
+    public static TagResolver entries(List<Component> descriptionComponents, int shift) {
+        return entries(descriptionComponents, Component.empty(), shift);
+    }
+
+    public static TagResolver entries(List<Component> descriptionComponents, Component emptyComponent, int shift) {
+        return entries(descriptionComponents, integer -> Tag.inserting(emptyComponent), () -> Tag.inserting(emptyComponent), shift);
+    }
+
+    public static TagResolver entries(List<Component> descriptionComponents, Component outBoundsComponent, Component emptyComponent, int shift) {
+        return entries(descriptionComponents, integer -> Tag.inserting(outBoundsComponent), () -> Tag.inserting(emptyComponent), shift);
+    }
+
+    public static TagResolver entries(List<Component> descriptionComponents, Function<Integer, Tag> outBoundsTag, Supplier<Tag> emptyTag, int shift) {
+        return TagResolver.resolver("list_entry", (argumentQueue, context) -> {
+            if (descriptionComponents.isEmpty()) return emptyTag.get();
+            int index = argumentQueue.hasNext() ? argumentQueue.pop().asInt().orElse(0) : 0;
+            if (index >= descriptionComponents.size()) return outBoundsTag.apply(index);
+            index = (index + shift) % descriptionComponents.size();
+            return Tag.inserting(descriptionComponents.get(index));
         });
     }
 

--- a/core/src/main/java/com/wolfyscript/utilities/bukkit/TagResolverUtil.java
+++ b/core/src/main/java/com/wolfyscript/utilities/bukkit/TagResolverUtil.java
@@ -52,7 +52,11 @@ public class TagResolverUtil {
     }
 
     public static TagResolver entries(List<Component> descriptionComponents, Function<Integer, Tag> outBoundsTag, Supplier<Tag> emptyTag, int shift) {
-        return TagResolver.resolver("list_entry", (argumentQueue, context) -> {
+        return entries("list_entry", descriptionComponents, outBoundsTag, emptyTag, shift);
+    }
+
+    public static TagResolver entries(String tagName, List<Component> descriptionComponents, Function<Integer, Tag> outBoundsTag, Supplier<Tag> emptyTag, int shift) {
+        return TagResolver.resolver(tagName, (argumentQueue, context) -> {
             if (descriptionComponents.isEmpty()) return emptyTag.get();
             int index = argumentQueue.hasNext() ? argumentQueue.pop().asInt().orElse(0) : 0;
             if (index >= descriptionComponents.size()) return outBoundsTag.apply(index);


### PR DESCRIPTION
Added a list entry TagResolver, that can be used to insert specific entries of a list.
Additionally it can shift the entries of the list by a given factor, so it can be used to  cycle through a list accross multiple components.