### PR TITLE
Include Item-NBT-API

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -44,6 +44,7 @@
         <depend_version.adventure-api>4.10.1</depend_version.adventure-api>
         <depend_version.adventure-platform>4.1.0</depend_version.adventure-platform>
         <depend_version.adventure-minimessage>4.10.0</depend_version.adventure-minimessage>
+        <depend_version.nbt-api>2.9.2</depend_version.nbt-api>
     </properties>
 
     <build>
@@ -180,6 +181,25 @@
             <groupId>net.kyori</groupId>
             <artifactId>adventure-text-minimessage</artifactId>
             <version>${depend_version.adventure-minimessage}</version>
+            <scope>provided</scope>
+        </dependency>
+        <!-- NBT -->
+        <dependency>
+            <groupId>de.tr7zw</groupId>
+            <artifactId>item-nbt-api-plugin</artifactId>
+            <version>${depend_version.nbt-api}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>de.tr7zw</groupId>
+            <artifactId>nbt-data-api</artifactId>
+            <version>${depend_version.nbt-api}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>de.tr7zw</groupId>
+            <artifactId>nbt-injector</artifactId>
+            <version>${depend_version.nbt-api}</version>
             <scope>provided</scope>
         </dependency>
     </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -32,6 +32,7 @@
         <plugin_version.compile>3.10.1</plugin_version.compile>
         <plugin_version.shade>3.3.0</plugin_version.shade>
         <plugin_version.specialsource>1.2.4</plugin_version.specialsource>
+        <plugin_version.license>2.0.0</plugin_version.license>
         <!-- The dependency versions -->
         <depend_version.spigotapi>1.18.1-R0.1-SNAPSHOT</depend_version.spigotapi>
         <depend_version.mojang-authlib>1.5.21</depend_version.mojang-authlib>

--- a/wolfyutils-spigot/pom.xml
+++ b/wolfyutils-spigot/pom.xml
@@ -31,6 +31,22 @@
         </resources>
         <plugins>
             <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>license-maven-plugin</artifactId>
+                <version>${plugin_version.license}</version>
+                <executions>
+                    <execution>
+                        <phase>generate-resources</phase>
+                        <goals>
+                            <goal>add-third-party</goal>
+                        </goals>
+                        <configuration>
+                            <excludeTransitiveDependencies>true</excludeTransitiveDependencies>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-shade-plugin</artifactId>
                 <version>${plugin_version.shade}</version>
@@ -59,7 +75,7 @@
                             </artifactSet>
                             <relocations>
                                 <relocation>
-                                    <pattern>de.tr7zw.changeme.nbtapi</pattern>
+                                    <pattern>de.tr7zw</pattern>
                                     <shadedPattern>com.wolfyscript.lib.nbt</shadedPattern>
                                 </relocation>
                                 <relocation>
@@ -88,6 +104,12 @@
                                     <artifact>*:*</artifact>
                                     <excludes>
                                         <exclude>META-INF/*</exclude>
+                                    </excludes>
+                                </filter>
+                                <filter>
+                                    <artifact>de.tr7zw</artifact>
+                                    <excludes>
+                                        <exclude>LICENSE</exclude>
                                     </excludes>
                                 </filter>
                             </filters>

--- a/wolfyutils-spigot/pom.xml
+++ b/wolfyutils-spigot/pom.xml
@@ -2,14 +2,14 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>wolfyutils-spigot</artifactId>
     <parent>
         <artifactId>wolfyutils-parent</artifactId>
         <groupId>com.wolfyscript.wolfyutils.spigot</groupId>
         <version>4.16.2-SNAPSHOT</version>
     </parent>
-    <modelVersion>4.0.0</modelVersion>
-
-    <artifactId>wolfyutils-spigot</artifactId>
 
     <build>
         <resources>
@@ -54,12 +54,17 @@
                                     <include>org.reflections</include>
                                     <include>org.javassist</include>
                                     <include>net.kyori</include>
+                                    <include>de.tr7zw</include>
                                 </includes>
                             </artifactSet>
                             <relocations>
                                 <relocation>
+                                    <pattern>de.tr7zw.changeme.nbtapi</pattern>
+                                    <shadedPattern>com.wolfyscript.lib.nbt</shadedPattern>
+                                </relocation>
+                                <relocation>
                                     <pattern>org.bstats</pattern>
-                                    <shadedPattern>me.wolfyscript.utilities.main.metrics</shadedPattern>
+                                    <shadedPattern>com.wolfyscript.utilities.main.metrics</shadedPattern>
                                 </relocation>
                                 <relocation>
                                     <pattern>org.reflections</pattern>
@@ -177,6 +182,25 @@
             <groupId>net.kyori</groupId>
             <artifactId>adventure-text-minimessage</artifactId>
             <version>${depend_version.adventure-minimessage}</version>
+            <scope>compile</scope>
+        </dependency>
+        <!-- NBT -->
+        <dependency>
+            <groupId>de.tr7zw</groupId>
+            <artifactId>item-nbt-api-plugin</artifactId>
+            <version>${depend_version.nbt-api}</version>
+            <scope>compile</scope>
+        </dependency>
+        <dependency>
+            <groupId>de.tr7zw</groupId>
+            <artifactId>nbt-data-api</artifactId>
+            <version>${depend_version.nbt-api}</version>
+            <scope>compile</scope>
+        </dependency>
+        <dependency>
+            <groupId>de.tr7zw</groupId>
+            <artifactId>nbt-injector</artifactId>
+            <version>${depend_version.nbt-api}</version>
             <scope>compile</scope>
         </dependency>
         <!-- PlaceholderAPI -->


### PR DESCRIPTION
Starting with this update WolfyUtilities uses tr7zw/Item-NBT-API instead of its own NBT implementation, to better maintain compatibility and provide more functionality.