### PR TITLE
Improved Permission handling of GUIs

### DIFF
--- a/core/src/main/java/com/wolfyscript/utilities/bukkit/WolfyUtilsBukkit.java
+++ b/core/src/main/java/com/wolfyscript/utilities/bukkit/WolfyUtilsBukkit.java
@@ -61,6 +61,7 @@ public class WolfyUtilsBukkit extends WolfyUtils {
 
     public final void initialize() {
         Bukkit.getPluginManager().registerEvents(this.inventoryAPI, plugin);
+        permissions.initRootPerm(getName().toLowerCase(Locale.ROOT).replace(" ", "_") + ".*");
     }
 
     @Override

--- a/core/src/main/java/me/wolfyscript/utilities/api/Permissions.java
+++ b/core/src/main/java/me/wolfyscript/utilities/api/Permissions.java
@@ -28,11 +28,24 @@ import java.util.Locale;
 public class Permissions {
 
     private final WolfyUtils wolfyUtilities;
-    private String permissionKey;
+    private Permission rootPermission;
 
     public Permissions(WolfyUtils wolfyUtilities) {
         this.wolfyUtilities = wolfyUtilities;
-        this.permissionKey = wolfyUtilities.getName().toLowerCase(Locale.ROOT).replace(" ", "_");
+        this.rootPermission = null;
+    }
+
+    public void initRootPerm(String permName) {
+        var rootPerm = Bukkit.getPluginManager().getPermission(permName);
+        if (rootPerm == null) {
+            rootPerm = new Permission(permName);
+            Bukkit.getPluginManager().addPermission(rootPerm);
+        }
+        this.rootPermission = rootPerm;
+    }
+
+    public Permission getRootPermission() {
+        return rootPermission;
     }
 
     /**
@@ -41,27 +54,24 @@ public class Permissions {
      *
      * @return the first permission key
      */
+    @Deprecated
     public String getPermissionKey() {
-        return permissionKey;
+        return rootPermission.getName();
     }
 
     /**
      * @param permissionKey
      */
-    public void setPermissionKey(String permissionKey) {
-        this.permissionKey = permissionKey;
+    @Deprecated
+    public void setPermissionKey(String permName) {
+        initRootPerm(permName);
     }
 
+    /**
+     * @deprecated Just use {@link CommandSender#hasPermission(String)}
+     */
+    @Deprecated
     public boolean hasPermission(CommandSender sender, String permCode) {
-        if (sender.hasPermission("*")) return true;
-        StringBuilder permission = new StringBuilder();
-        for (String s : permCode.split("\\.")) {
-            permission.append(s);
-            if (sender.hasPermission(permission.toString()) || sender.hasPermission(permission + ".*")) {
-                return true;
-            }
-            permission.append(".");
-        }
-        return false;
+        return sender.hasPermission(permCode);
     }
 }

--- a/core/src/main/java/me/wolfyscript/utilities/api/inventory/gui/GuiHandler.java
+++ b/core/src/main/java/me/wolfyscript/utilities/api/inventory/gui/GuiHandler.java
@@ -332,7 +332,7 @@ public class GuiHandler<C extends CustomCache> implements Listener {
         }
         final GuiCluster<C> cluster = window.getCluster();
         Player player1 = getPlayer();
-        if (api.getPermissions().hasPermission(player1, (api.getPlugin().getName() + ".inv." + window.getNamespacedKey().toString(".")))) {
+        if (player1.hasPermission(window.getPermission())) {
             var currentWindow = getWindow(cluster);
             if (currentWindow == null || !currentWindow.getNamespacedKey().equals(window.getNamespacedKey())) {
                 getHistory(cluster).add(0, window);
@@ -342,7 +342,7 @@ public class GuiHandler<C extends CustomCache> implements Listener {
             window.create(this);
             return;
         }
-        api.getChat().sendMessage(player1, Component.text("You don't have the permission ", NamedTextColor.RED).append(Component.text(api.getPlugin().getName() + ".inv." + window.getNamespacedKey().toString("."), NamedTextColor.DARK_RED)));
+        window.getChat().sendMessage(player1, Component.text("You lack the permission ", NamedTextColor.RED).append(Component.text(window.getPermission().getName(), NamedTextColor.DARK_RED)));
     }
 
     /**

--- a/core/src/main/java/me/wolfyscript/utilities/api/inventory/gui/GuiWindow.java
+++ b/core/src/main/java/me/wolfyscript/utilities/api/inventory/gui/GuiWindow.java
@@ -127,8 +127,7 @@ public abstract class GuiWindow<C extends CustomCache> extends GuiMenuComponent<
         this.inventoryType = inventoryType;
         this.size = size;
         this.forceSyncUpdate = forceSyncUpdate;
-        this.permission = new Permission(inventoryAPI.getPlugin().getName().toLowerCase(Locale.ROOT) + ".inv." + namespacedKey.toString("."));
-        loadPermission();
+        this.permission = loadPermission();
         Bukkit.getPluginManager().registerEvents(this, wolfyUtilities.getPlugin());
 
         //Check if the old title update method is used.
@@ -144,19 +143,25 @@ public abstract class GuiWindow<C extends CustomCache> extends GuiMenuComponent<
         }
     }
 
-    private void loadPermission() {
-        var parentPermName = inventoryAPI.getPlugin().getName().toLowerCase(Locale.ROOT) + ".inv.*";
-        var parentPerm = Bukkit.getPluginManager().getPermission(parentPermName);
-        if (parentPerm == null) {
-            parentPerm = new Permission(parentPermName);
-            parentPerm.addParent(wolfyUtilities.getPermissions().getRootPermission(), true);
-            Bukkit.getPluginManager().addPermission(parentPerm);
+    private Permission loadPermission() {
+        var permName = inventoryAPI.getPlugin().getName().toLowerCase(Locale.ROOT) + ".inv." + namespacedKey.toString(".");
+        var perm = Bukkit.getPluginManager().getPermission(permName);
+        if (perm == null) {
+            var parentPermName = inventoryAPI.getPlugin().getName().toLowerCase(Locale.ROOT) + ".inv.*";
+            var parentPerm = Bukkit.getPluginManager().getPermission(parentPermName);
+            if (parentPerm == null) {
+                parentPerm = new Permission(parentPermName);
+                parentPerm.addParent(wolfyUtilities.getPermissions().getRootPermission(), true);
+                Bukkit.getPluginManager().addPermission(parentPerm);
+            }
+            var wildcardPermName = inventoryAPI.getPlugin().getName().toLowerCase(Locale.ROOT) + ".inv." + namespacedKey.getNamespace() + ".*";
+            var wildcardPerm = new Permission(wildcardPermName);
+            wildcardPerm.addParent(parentPerm, true);
+            perm = new Permission(permName);
+            perm.addParent(wildcardPerm, true);
+            Bukkit.getPluginManager().addPermission(perm);
         }
-        var wildcardPermName = inventoryAPI.getPlugin().getName().toLowerCase(Locale.ROOT) + ".inv." + namespacedKey.getNamespace() + ".*";
-        var wildcardPerm = new Permission(wildcardPermName);
-        wildcardPerm.addParent(parentPerm, true);
-        this.permission.addParent(wildcardPerm, true);
-        Bukkit.getPluginManager().addPermission(this.permission);
+        return perm;
     }
 
     /**


### PR DESCRIPTION
Each GUI window will properly register its permission now. If the specific permission is already available it instead uses that already defined permission. 
So you can define it manually via the plugin.yml to configure its default value and permission and the menu will link to it.

The Permissions class doesn't really serve a huge purpose anymore it just initates the root permission of the plugin.