### PR TITLE
Better Player Head Texture apply method

### DIFF
--- a/core/src/main/java/me/wolfyscript/utilities/util/inventory/PlayerHeadUtils.java
+++ b/core/src/main/java/me/wolfyscript/utilities/util/inventory/PlayerHeadUtils.java
@@ -66,6 +66,7 @@ public class PlayerHeadUtils {
      * @param skullMeta the {@link SkullMeta} the texture value should be added to
      * @return the original skullMeta with the new texture value
      */
+    @Deprecated
     public static SkullMeta getSkullMeta(String value, SkullMeta skullMeta) {
         if (value != null && !value.isEmpty()) {
             String texture = value;
@@ -91,6 +92,7 @@ public class PlayerHeadUtils {
         return skullMeta;
     }
 
+    @Deprecated
     public static String getTextureValue(SkullMeta skullMeta) {
         GameProfile profile = null;
         Field profileField;

--- a/core/src/main/java/me/wolfyscript/utilities/util/inventory/item_builder/AbstractItemBuilder.java
+++ b/core/src/main/java/me/wolfyscript/utilities/util/inventory/item_builder/AbstractItemBuilder.java
@@ -20,8 +20,10 @@ package me.wolfyscript.utilities.util.inventory.item_builder;
 
 import com.fasterxml.jackson.annotation.JsonAutoDetect;
 import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.mojang.authlib.GameProfile;
-import com.mojang.authlib.properties.Property;
+import de.tr7zw.changeme.nbtapi.NBTCompound;
+import de.tr7zw.changeme.nbtapi.NBTCompoundList;
+import de.tr7zw.changeme.nbtapi.NBTItem;
+import de.tr7zw.changeme.nbtapi.NBTListCompound;
 import me.wolfyscript.utilities.api.WolfyUtilCore;
 import me.wolfyscript.utilities.util.EncryptionUtils;
 import net.kyori.adventure.platform.bukkit.BukkitComponentSerializer;
@@ -337,20 +339,20 @@ public abstract class AbstractItemBuilder<T extends AbstractItemBuilder<?>> {
     }
 
     public String getPlayerHeadValue() {
-        if (getItemMeta() instanceof SkullMeta skullMeta) {
-            GameProfile profile = null;
-            Field profileField;
-            try {
-                profileField = skullMeta.getClass().getDeclaredField("profile");
-                profileField.setAccessible(true);
-                profile = (GameProfile) profileField.get(skullMeta);
-            } catch (NoSuchFieldException | SecurityException | IllegalAccessException ex) {
-                ex.printStackTrace();
-            }
-            if (profile != null && !profile.getProperties().get("textures").isEmpty()) {
-                for (Property property : profile.getProperties().get("textures")) {
-                    if (!property.getValue().isEmpty())
-                        return property.getValue();
+        if (getItemMeta() instanceof SkullMeta) {
+            NBTItem nbtItem = new NBTItem(getItemStack());
+            NBTCompound skull = nbtItem.getCompound("SkullOwner");
+            if (skull != null) {
+                if(skull.hasKey("Properties")) {
+                    NBTCompound properties = skull.getCompound("Properties");
+                    if (properties.hasKey("textures")) {
+                        NBTCompoundList textures = properties.getCompoundList("textures");
+                        if (textures.size() > 0) {
+                            NBTCompound object = textures.get(0);
+                            String value = object.getString("Value");
+                            return value != null ? value : "";
+                        }
+                    }
                 }
             }
         }
@@ -358,25 +360,18 @@ public abstract class AbstractItemBuilder<T extends AbstractItemBuilder<?>> {
     }
 
     public T setPlayerHeadValue(String value) {
-        if (getItemMeta() instanceof SkullMeta skullMeta) {
-            if (value != null && !value.isEmpty()) {
-                String texture = value;
-                if (value.startsWith("https://") || value.startsWith("http://")) {
-                    texture = EncryptionUtils.getBase64EncodedString(String.format("{textures:{SKIN:{url:\"%s\"}}}", value));
-                }
-                GameProfile profile = new GameProfile(UUID.randomUUID(), null);
-                profile.getProperties().put("textures", new Property("textures", texture));
-                Field profileField = null;
-                try {
-                    profileField = skullMeta.getClass().getDeclaredField("profile");
-                    profileField.setAccessible(true);
-                    profileField.set(skullMeta, profile);
-                } catch (NoSuchFieldException | SecurityException | IllegalAccessException e) {
-                    e.printStackTrace();
-                }
-            }
-            return setItemMeta(skullMeta);
+        String textureValue = value;
+        if (value.startsWith("https://") || value.startsWith("http://")) {
+            textureValue = EncryptionUtils.getBase64EncodedString(String.format("{textures:{SKIN:{url:\"%s\"}}}", value));
         }
+        NBTItem nbtItem = new NBTItem(getItemStack(), true);
+        NBTCompound skull = nbtItem.addCompound("SkullOwner");
+        skull.setString("Name", "");
+        skull.setString("Id", UUID.randomUUID().toString());
+        // The UUID, note that skulls with the same UUID but different textures will misbehave and only one texture will load
+        // (They'll share it), if skulls have different UUIDs and same textures they won't stack. See UUID.randomUUID();
+        NBTListCompound texture = skull.addCompound("Properties").getCompoundList("textures").addCompound();
+        texture.setString("Value",  textureValue);
         return get();
     }
 


### PR DESCRIPTION
This new method applies the player head texture using the Item-NBT-API instead of the reflection profile mess.
Even though 1.19 provides an API for it now, I still use this method for backwards compatibility.