### PR TITLE
Fixed ExecutableItems ItemRef Issues

### DIFF
--- a/plugin-compatibility/plugin-compatibility-artifact/src/main/java/me/wolfyscript/utilities/compatibility/plugins/executableitems/ExecutableItemsRef.java
+++ b/plugin-compatibility/plugin-compatibility-artifact/src/main/java/me/wolfyscript/utilities/compatibility/plugins/executableitems/ExecutableItemsRef.java
@@ -35,7 +35,7 @@ public class ExecutableItemsRef extends APIReference {
 
     @Override
     public boolean isValidItem(ItemStack itemStack) {
-        return manager.getExecutableItem(itemStack).isPresent();
+        return manager.getExecutableItem(itemStack).map(exeItem -> exeItem.getId().equals(id)).orElse(false);
     }
 
     @Override


### PR DESCRIPTION
The ItemRef for ExecutableItems are no longer valid for all the items from EI. Now it properly checks if the id is correct.

Resolves WolfyScript/CustomCrafting#135 – Executable Items issue