### PR TITLE
Changed the reset of chat input prompts

### DIFF
--- a/core/src/main/java/me/wolfyscript/utilities/api/inventory/gui/GuiHandler.java
+++ b/core/src/main/java/me/wolfyscript/utilities/api/inventory/gui/GuiHandler.java
@@ -29,10 +29,8 @@ import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.format.NamedTextColor;
 import org.bukkit.Bukkit;
 import org.bukkit.entity.Player;
-import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
 import org.bukkit.event.inventory.InventoryCloseEvent;
-import org.bukkit.event.player.PlayerCommandPreprocessEvent;
 import org.bukkit.scheduler.BukkitTask;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -333,6 +331,8 @@ public class GuiHandler<C extends CustomCache> implements Listener {
         final GuiCluster<C> cluster = window.getCluster();
         Player player1 = getPlayer();
         if (player1.hasPermission(window.getPermission())) {
+            // Cancels the chat input when a new window is opened to prevent
+            cancelChatInput();
             var currentWindow = getWindow(cluster);
             if (currentWindow == null || !currentWindow.getNamespacedKey().equals(window.getNamespacedKey())) {
                 getHistory(cluster).add(0, window);
@@ -525,13 +525,6 @@ public class GuiHandler<C extends CustomCache> implements Listener {
             } else {
                 this.isWindowOpen = false;
             }
-        }
-    }
-
-    @EventHandler
-    private void onCommand(PlayerCommandPreprocessEvent event) {
-        if (!event.getMessage().startsWith("/wua") && !event.getMessage().startsWith("/wui") && event.getPlayer().getUniqueId().equals(uuid) && isChatEventActive()) {
-            cancelChatInput();
         }
     }
 }

--- a/core/src/main/java/me/wolfyscript/utilities/api/inventory/gui/InventoryAPI.java
+++ b/core/src/main/java/me/wolfyscript/utilities/api/inventory/gui/InventoryAPI.java
@@ -293,6 +293,7 @@ public class InventoryAPI<C extends CustomCache> implements Listener {
      * It cancels the event and passes the message into the /wui command.
      * <strong>It is recommended to use the /wui command instead of typing directly into the chat.</strong>
      */
+    @Deprecated(forRemoval = true)
     @EventHandler(priority = EventPriority.LOWEST, ignoreCancelled = true)
     public void onPreChat(AsyncPlayerChatEvent event) {
         if (hasGuiHandler(event.getPlayer())) {


### PR DESCRIPTION
- Commands no longer cancel chat input. Instead, those are cancelled when a window is opened.
- Deprecated InventoryAPI#onPreChat. In the future /wui will be the only way to input something.