### PR TITLE
Fixed Plugin Integration Detection & Initialisation

### DIFF
--- a/wolfyutils-spigot/src/main/resources/plugin.yml
+++ b/wolfyutils-spigot/src/main/resources/plugin.yml
@@ -26,11 +26,9 @@ softdepend:
   - mcMMO
   - Oraxen
   - ItemsAdder
-  - ExecutableItems
   - PlaceholderAPI
   - eco
   - zAuctionHouseV3
-  - ExecutableItems
   - SCore
 
 commands:


### PR DESCRIPTION
The plugin integration handler wasn't able to detect plugins being enabled after their associated integration has been created. That caused the DependenciesLoadedEvent to not be called.