### PR TITLE
NBTQuery System to fetch specific NBT components

### DIFF
--- a/core/src/main/java/com/wolfyscript/utilities/bukkit/WolfyCoreBukkit.java
+++ b/core/src/main/java/com/wolfyscript/utilities/bukkit/WolfyCoreBukkit.java
@@ -14,6 +14,15 @@ import com.wolfyscript.utilities.bukkit.listeners.PlayerListener;
 import com.wolfyscript.utilities.bukkit.listeners.custom_item.CustomDurabilityListener;
 import com.wolfyscript.utilities.bukkit.listeners.custom_item.CustomItemPlayerListener;
 import com.wolfyscript.utilities.bukkit.listeners.custom_item.CustomParticleListener;
+import com.wolfyscript.utilities.bukkit.nbt.QueryNode;
+import com.wolfyscript.utilities.bukkit.nbt.QueryNodeByte;
+import com.wolfyscript.utilities.bukkit.nbt.QueryNodeDouble;
+import com.wolfyscript.utilities.bukkit.nbt.QueryNodeFloat;
+import com.wolfyscript.utilities.bukkit.nbt.QueryNodeInt;
+import com.wolfyscript.utilities.bukkit.nbt.QueryNodeLong;
+import com.wolfyscript.utilities.bukkit.nbt.QueryNodeObject;
+import com.wolfyscript.utilities.bukkit.nbt.QueryNodeShort;
+import com.wolfyscript.utilities.bukkit.nbt.QueryNodeString;
 import me.wolfyscript.utilities.api.WolfyUtilities;
 import com.wolfyscript.utilities.bukkit.chat.ChatImpl;
 import me.wolfyscript.utilities.api.console.Console;
@@ -283,6 +292,16 @@ public final class WolfyCoreBukkit extends WUPlugin {
         valueProviders.register(ValueProviderStringConst.KEY, ValueProviderStringConst.class);
         valueProviders.register(ValueProviderStringVar.KEY, ValueProviderStringVar.class);
 
+        var nbtQueryNodes = getRegistries().getNbtQueryNodes();
+        nbtQueryNodes.register(QueryNodeByte.TYPE, QueryNodeByte.class);
+        nbtQueryNodes.register(QueryNodeShort.TYPE, QueryNodeShort.class);
+        nbtQueryNodes.register(QueryNodeInt.TYPE, QueryNodeInt.class);
+        nbtQueryNodes.register(QueryNodeLong.TYPE, QueryNodeLong.class);
+        nbtQueryNodes.register(QueryNodeDouble.TYPE, QueryNodeDouble.class);
+        nbtQueryNodes.register(QueryNodeFloat.TYPE, QueryNodeFloat.class);
+        nbtQueryNodes.register(QueryNodeString.TYPE, QueryNodeString.class);
+        nbtQueryNodes.register(QueryNodeObject.TYPE, QueryNodeObject.class);
+
         KeyedTypeIdResolver.registerTypeRegistry(Meta.class, nbtChecks);
         KeyedTypeIdResolver.registerTypeRegistry(Animator.class, particleAnimators);
         KeyedTypeIdResolver.registerTypeRegistry(Shape.class, particleShapes);
@@ -291,6 +310,7 @@ public final class WolfyCoreBukkit extends WUPlugin {
         KeyedTypeIdResolver.registerTypeRegistry((Class<Event<?>>)(Object) Event.class, customItemEvents);
         KeyedTypeIdResolver.registerTypeRegistry(Operator.class, operators);
         KeyedTypeIdResolver.registerTypeRegistry((Class<ValueProvider<?>>) (Object)ValueProvider.class, valueProviders);
+        KeyedTypeIdResolver.registerTypeRegistry((Class<QueryNode<?>>) (Object)QueryNode.class, nbtQueryNodes);
     }
 
     @Override

--- a/core/src/main/java/com/wolfyscript/utilities/bukkit/WolfyCoreBukkit.java
+++ b/core/src/main/java/com/wolfyscript/utilities/bukkit/WolfyCoreBukkit.java
@@ -17,11 +17,19 @@ import com.wolfyscript.utilities.bukkit.listeners.custom_item.CustomParticleList
 import com.wolfyscript.utilities.bukkit.nbt.QueryNode;
 import com.wolfyscript.utilities.bukkit.nbt.QueryNodeBoolean;
 import com.wolfyscript.utilities.bukkit.nbt.QueryNodeByte;
+import com.wolfyscript.utilities.bukkit.nbt.QueryNodeByteArray;
 import com.wolfyscript.utilities.bukkit.nbt.QueryNodeDouble;
 import com.wolfyscript.utilities.bukkit.nbt.QueryNodeFloat;
 import com.wolfyscript.utilities.bukkit.nbt.QueryNodeInt;
+import com.wolfyscript.utilities.bukkit.nbt.QueryNodeIntArray;
+import com.wolfyscript.utilities.bukkit.nbt.QueryNodeListCompound;
+import com.wolfyscript.utilities.bukkit.nbt.QueryNodeListDouble;
+import com.wolfyscript.utilities.bukkit.nbt.QueryNodeListFloat;
+import com.wolfyscript.utilities.bukkit.nbt.QueryNodeListInt;
+import com.wolfyscript.utilities.bukkit.nbt.QueryNodeListLong;
+import com.wolfyscript.utilities.bukkit.nbt.QueryNodeListString;
 import com.wolfyscript.utilities.bukkit.nbt.QueryNodeLong;
-import com.wolfyscript.utilities.bukkit.nbt.QueryNodeObject;
+import com.wolfyscript.utilities.bukkit.nbt.QueryNodeCompound;
 import com.wolfyscript.utilities.bukkit.nbt.QueryNodeShort;
 import com.wolfyscript.utilities.bukkit.nbt.QueryNodeString;
 import me.wolfyscript.utilities.api.WolfyUtilities;
@@ -294,6 +302,9 @@ public final class WolfyCoreBukkit extends WUPlugin {
         valueProviders.register(ValueProviderStringVar.KEY, ValueProviderStringVar.class);
 
         var nbtQueryNodes = getRegistries().getNbtQueryNodes();
+        nbtQueryNodes.register(QueryNodeCompound.TYPE, QueryNodeCompound.class);
+        nbtQueryNodes.register(QueryNodeBoolean.TYPE, QueryNodeBoolean.class);
+        //Primitives
         nbtQueryNodes.register(QueryNodeByte.TYPE, QueryNodeByte.class);
         nbtQueryNodes.register(QueryNodeShort.TYPE, QueryNodeShort.class);
         nbtQueryNodes.register(QueryNodeInt.TYPE, QueryNodeInt.class);
@@ -301,8 +312,17 @@ public final class WolfyCoreBukkit extends WUPlugin {
         nbtQueryNodes.register(QueryNodeDouble.TYPE, QueryNodeDouble.class);
         nbtQueryNodes.register(QueryNodeFloat.TYPE, QueryNodeFloat.class);
         nbtQueryNodes.register(QueryNodeString.TYPE, QueryNodeString.class);
-        nbtQueryNodes.register(QueryNodeObject.TYPE, QueryNodeObject.class);
-        nbtQueryNodes.register(QueryNodeBoolean.TYPE, QueryNodeBoolean.class);
+        //Arrays
+        nbtQueryNodes.register(QueryNodeByteArray.TYPE, QueryNodeByteArray.class);
+        nbtQueryNodes.register(QueryNodeIntArray.TYPE, QueryNodeIntArray.class);
+
+        //Lists
+        nbtQueryNodes.register(QueryNodeListInt.TYPE, QueryNodeListInt.class);
+        nbtQueryNodes.register(QueryNodeListLong.TYPE, QueryNodeListLong.class);
+        nbtQueryNodes.register(QueryNodeListDouble.TYPE, QueryNodeListDouble.class);
+        nbtQueryNodes.register(QueryNodeListFloat.TYPE, QueryNodeListFloat.class);
+        nbtQueryNodes.register(QueryNodeListString.TYPE, QueryNodeListString.class);
+        nbtQueryNodes.register(QueryNodeListCompound.TYPE, QueryNodeListCompound.class);
 
         KeyedTypeIdResolver.registerTypeRegistry(Meta.class, nbtChecks);
         KeyedTypeIdResolver.registerTypeRegistry(Animator.class, particleAnimators);

--- a/core/src/main/java/com/wolfyscript/utilities/bukkit/WolfyCoreBukkit.java
+++ b/core/src/main/java/com/wolfyscript/utilities/bukkit/WolfyCoreBukkit.java
@@ -15,6 +15,7 @@ import com.wolfyscript.utilities.bukkit.listeners.custom_item.CustomDurabilityLi
 import com.wolfyscript.utilities.bukkit.listeners.custom_item.CustomItemPlayerListener;
 import com.wolfyscript.utilities.bukkit.listeners.custom_item.CustomParticleListener;
 import com.wolfyscript.utilities.bukkit.nbt.QueryNode;
+import com.wolfyscript.utilities.bukkit.nbt.QueryNodeBoolean;
 import com.wolfyscript.utilities.bukkit.nbt.QueryNodeByte;
 import com.wolfyscript.utilities.bukkit.nbt.QueryNodeDouble;
 import com.wolfyscript.utilities.bukkit.nbt.QueryNodeFloat;
@@ -301,6 +302,7 @@ public final class WolfyCoreBukkit extends WUPlugin {
         nbtQueryNodes.register(QueryNodeFloat.TYPE, QueryNodeFloat.class);
         nbtQueryNodes.register(QueryNodeString.TYPE, QueryNodeString.class);
         nbtQueryNodes.register(QueryNodeObject.TYPE, QueryNodeObject.class);
+        nbtQueryNodes.register(QueryNodeBoolean.TYPE, QueryNodeBoolean.class);
 
         KeyedTypeIdResolver.registerTypeRegistry(Meta.class, nbtChecks);
         KeyedTypeIdResolver.registerTypeRegistry(Animator.class, particleAnimators);

--- a/core/src/main/java/com/wolfyscript/utilities/bukkit/WolfyCoreBukkit.java
+++ b/core/src/main/java/com/wolfyscript/utilities/bukkit/WolfyCoreBukkit.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.databind.module.SimpleModule;
 import com.wolfyscript.utilities.bukkit.commands.ChatActionCommand;
 import com.wolfyscript.utilities.bukkit.commands.InfoCommand;
 import com.wolfyscript.utilities.bukkit.commands.InputCommand;
+import com.wolfyscript.utilities.bukkit.commands.QueryDebugCommand;
 import com.wolfyscript.utilities.bukkit.commands.SpawnParticleAnimationCommand;
 import com.wolfyscript.utilities.bukkit.commands.SpawnParticleEffectCommand;
 import com.wolfyscript.utilities.bukkit.listeners.BlockListener;
@@ -379,6 +380,8 @@ public final class WolfyCoreBukkit extends WUPlugin {
         Bukkit.getServer().getPluginCommand("wui").setExecutor(new InputCommand(this));
         Bukkit.getServer().getPluginCommand("wui").setTabCompleter(new InputCommand(this));
         Bukkit.getServer().getPluginCommand("wua").setExecutor(new ChatActionCommand());
+
+        Bukkit.getServer().getPluginCommand("query_item").setExecutor(new QueryDebugCommand(this));
     }
 
     @Override

--- a/core/src/main/java/com/wolfyscript/utilities/bukkit/commands/QueryDebugCommand.java
+++ b/core/src/main/java/com/wolfyscript/utilities/bukkit/commands/QueryDebugCommand.java
@@ -1,0 +1,50 @@
+/*
+ *       WolfyUtilities, APIs and Utilities for Minecraft Spigot plugins
+ *                      Copyright (C) 2021  WolfyScript
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package com.wolfyscript.utilities.bukkit.commands;
+
+import com.wolfyscript.utilities.bukkit.WolfyCoreBukkit;
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandSender;
+import org.bukkit.command.TabExecutor;
+import org.bukkit.entity.Player;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.List;
+
+public class QueryDebugCommand implements TabExecutor {
+
+    private final WolfyCoreBukkit plugin;
+
+    public QueryDebugCommand(WolfyCoreBukkit plugin) {
+        this.plugin = plugin;
+    }
+
+    @Override
+    public boolean onCommand(@NotNull CommandSender sender, @NotNull Command command, @NotNull String label, @NotNull String[] args) {
+        if (!(sender instanceof Player)) return true;
+
+        return true;
+    }
+
+    @Override
+    public @Nullable List<String> onTabComplete(@NotNull CommandSender sender, @NotNull Command command, @NotNull String alias, @NotNull String[] args) {
+        return null;
+    }
+}

--- a/core/src/main/java/com/wolfyscript/utilities/bukkit/commands/QueryDebugCommand.java
+++ b/core/src/main/java/com/wolfyscript/utilities/bukkit/commands/QueryDebugCommand.java
@@ -54,7 +54,16 @@ public class QueryDebugCommand implements TabExecutor {
                 NBTQuery.of(file).ifPresent(nbtQuery -> {
                     NBTItem nbtItem = new NBTItem(stack);
                     NBTCompound result = nbtQuery.computeOn(nbtItem);
+
                     System.out.println(result.toString());
+                    if (args.length > 0) {
+                        if (args[0].equalsIgnoreCase("true")) {
+                            ItemStack stackToMergeIn = player.getEquipment().getItem(EquipmentSlot.OFF_HAND);
+                            NBTItem nbtItem1 = new NBTItem(stackToMergeIn);
+                            nbtItem1.mergeCompound(result);
+                            nbtItem1.applyNBT(stackToMergeIn);
+                        }
+                    }
                 });
             }
         }

--- a/core/src/main/java/com/wolfyscript/utilities/bukkit/commands/QueryDebugCommand.java
+++ b/core/src/main/java/com/wolfyscript/utilities/bukkit/commands/QueryDebugCommand.java
@@ -19,13 +19,20 @@
 package com.wolfyscript.utilities.bukkit.commands;
 
 import com.wolfyscript.utilities.bukkit.WolfyCoreBukkit;
+import com.wolfyscript.utilities.bukkit.nbt.NBTQuery;
+import de.tr7zw.changeme.nbtapi.NBTCompound;
+import de.tr7zw.changeme.nbtapi.NBTItem;
+import me.wolfyscript.utilities.util.inventory.ItemUtils;
 import org.bukkit.command.Command;
 import org.bukkit.command.CommandSender;
 import org.bukkit.command.TabExecutor;
 import org.bukkit.entity.Player;
+import org.bukkit.inventory.EquipmentSlot;
+import org.bukkit.inventory.ItemStack;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
+import java.io.File;
 import java.util.List;
 
 public class QueryDebugCommand implements TabExecutor {
@@ -38,8 +45,19 @@ public class QueryDebugCommand implements TabExecutor {
 
     @Override
     public boolean onCommand(@NotNull CommandSender sender, @NotNull Command command, @NotNull String label, @NotNull String[] args) {
-        if (!(sender instanceof Player)) return true;
+        if (!(sender instanceof Player player)) return true;
 
+        ItemStack stack = player.getEquipment().getItem(EquipmentSlot.HAND);
+        if (!ItemUtils.isAirOrNull(stack)) {
+            File file = new File(plugin.getDataFolder(), "query_debug.json");
+            if (file.exists()) {
+                NBTQuery.of(file).ifPresent(nbtQuery -> {
+                    NBTItem nbtItem = new NBTItem(stack);
+                    NBTCompound result = nbtQuery.computeOn(nbtItem);
+                    System.out.println(result.toString());
+                });
+            }
+        }
         return true;
     }
 

--- a/core/src/main/java/com/wolfyscript/utilities/bukkit/commands/QueryDebugCommand.java
+++ b/core/src/main/java/com/wolfyscript/utilities/bukkit/commands/QueryDebugCommand.java
@@ -53,7 +53,7 @@ public class QueryDebugCommand implements TabExecutor {
             if (file.exists()) {
                 NBTQuery.of(file).ifPresent(nbtQuery -> {
                     NBTItem nbtItem = new NBTItem(stack);
-                    NBTCompound result = nbtQuery.computeOn(nbtItem);
+                    NBTCompound result = nbtQuery.run(nbtItem);
 
                     System.out.println(result.toString());
                     if (args.length > 0) {

--- a/core/src/main/java/com/wolfyscript/utilities/bukkit/nbt/NBTQuery.java
+++ b/core/src/main/java/com/wolfyscript/utilities/bukkit/nbt/NBTQuery.java
@@ -74,5 +74,9 @@ public class NBTQuery {
         return container;
     }
 
+    public NBTQuery copy() {
+        return new NBTQuery(this);
+    }
+
 
 }

--- a/core/src/main/java/com/wolfyscript/utilities/bukkit/nbt/NBTQuery.java
+++ b/core/src/main/java/com/wolfyscript/utilities/bukkit/nbt/NBTQuery.java
@@ -22,12 +22,12 @@
 
 package com.wolfyscript.utilities.bukkit.nbt;
 
-import com.wolfyscript.lib.nbt.nbtapi.NBTCompound;
-import com.wolfyscript.lib.nbt.nbtapi.NBTContainer;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.databind.InjectableValues;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
+import de.tr7zw.changeme.nbtapi.NBTCompound;
+import de.tr7zw.changeme.nbtapi.NBTContainer;
 import me.wolfyscript.utilities.util.json.jackson.JacksonUtil;
 
 import java.io.IOException;

--- a/core/src/main/java/com/wolfyscript/utilities/bukkit/nbt/NBTQuery.java
+++ b/core/src/main/java/com/wolfyscript/utilities/bukkit/nbt/NBTQuery.java
@@ -1,0 +1,75 @@
+/*
+ *       ____ _  _ ____ ___ ____ _  _ ____ ____ ____ ____ ___ _ _  _ ____
+ *       |    |  | [__   |  |  | |\/| |    |__/ |__| |___  |  | |\ | | __
+ *       |___ |__| ___]  |  |__| |  | |___ |  \ |  | |     |  | | \| |__]
+ *
+ *       CustomCrafting Recipe creation and management tool for Minecraft
+ *                      Copyright (C) 2021  WolfyScript
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package com.wolfyscript.utilities.bukkit.nbt;
+
+import com.wolfyscript.lib.nbt.nbtapi.NBTCompound;
+import com.wolfyscript.lib.nbt.nbtapi.NBTContainer;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.databind.InjectableValues;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import me.wolfyscript.utilities.util.json.jackson.JacksonUtil;
+
+import java.io.IOException;
+import java.util.Map;
+
+public class NBTQuery {
+
+    private Map<String, QueryNode> nodes;
+
+    @JsonCreator
+    public NBTQuery(ObjectNode node) {
+        ObjectMapper objMapper = JacksonUtil.getObjectMapper();
+        node.fields().forEachRemaining(entry -> {
+            var key = entry.getKey();
+            var injectVars = new InjectableValues.Std();
+            injectVars.addValue("key", key);
+            injectVars.addValue("path", "");
+            var subNode = entry.getValue();
+            try {
+                QueryNode queryNode = objMapper.reader(injectVars).readValue(subNode, QueryNode.class);
+                if (queryNode != null) {
+                    nodes.put(key, queryNode);
+                }
+            } catch (IOException e) {
+
+            }
+        });
+
+    }
+
+
+
+    public NBTCompound find() {
+        NBTContainer container = new NBTContainer();
+
+
+
+
+
+
+        return (NBTCompound) new NBTContainer();
+    }
+
+
+}

--- a/core/src/main/java/com/wolfyscript/utilities/bukkit/nbt/NBTQuery.java
+++ b/core/src/main/java/com/wolfyscript/utilities/bukkit/nbt/NBTQuery.java
@@ -61,7 +61,11 @@ public class NBTQuery {
 
     public NBTCompound computeOn(NBTCompound input) {
         NBTContainer container = new NBTContainer();
-        nodes.forEach((key, queryNode) -> queryNode.visit("", key, input, container));
+        nodes.forEach((key, queryNode) -> {
+            if (input.hasKey(key)) {
+                queryNode.visit("", key, input, container);
+            }
+        });
         return container;
     }
 

--- a/core/src/main/java/com/wolfyscript/utilities/bukkit/nbt/NBTQuery.java
+++ b/core/src/main/java/com/wolfyscript/utilities/bukkit/nbt/NBTQuery.java
@@ -33,13 +33,15 @@ import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 public class NBTQuery {
 
-    private final Map<String, QueryNode<?>> nodes = new HashMap<>();
+    private final Map<String, QueryNode<?>> nodes;
 
     @JsonCreator
     public NBTQuery(ObjectNode node) {
+        nodes = new HashMap<>();
         node.fields().forEachRemaining(entry -> {
             var key = entry.getKey();
             var subNode = entry.getValue();
@@ -47,7 +49,10 @@ public class NBTQuery {
                 nodes.put(key, queryNode);
             });
         });
+    }
 
+    private NBTQuery(NBTQuery other) {
+        this.nodes = other.nodes.entrySet().stream().collect(Collectors.toMap(Map.Entry::getKey, entry -> entry.getValue().copy()));
     }
 
     public static Optional<NBTQuery> of(File file) {

--- a/core/src/main/java/com/wolfyscript/utilities/bukkit/nbt/NBTQuery.java
+++ b/core/src/main/java/com/wolfyscript/utilities/bukkit/nbt/NBTQuery.java
@@ -59,7 +59,7 @@ public class NBTQuery {
         }
     }
 
-    public NBTCompound computeOn(NBTCompound input) {
+    public NBTCompound run(NBTCompound input) {
         NBTContainer container = new NBTContainer();
         nodes.forEach((key, queryNode) -> {
             if (input.hasKey(key)) {

--- a/core/src/main/java/com/wolfyscript/utilities/bukkit/nbt/NBTQuery.java
+++ b/core/src/main/java/com/wolfyscript/utilities/bukkit/nbt/NBTQuery.java
@@ -28,14 +28,16 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import de.tr7zw.changeme.nbtapi.NBTCompound;
 import de.tr7zw.changeme.nbtapi.NBTContainer;
+import de.tr7zw.changeme.nbtapi.NBTType;
 import me.wolfyscript.utilities.util.json.jackson.JacksonUtil;
 
 import java.io.IOException;
 import java.util.Map;
+import java.util.Objects;
 
 public class NBTQuery {
 
-    private Map<String, QueryNode> nodes;
+    private Map<String, QueryNode<?>> nodes;
 
     @JsonCreator
     public NBTQuery(ObjectNode node) {
@@ -47,7 +49,7 @@ public class NBTQuery {
             injectVars.addValue("path", "");
             var subNode = entry.getValue();
             try {
-                QueryNode queryNode = objMapper.reader(injectVars).readValue(subNode, QueryNode.class);
+                QueryNode<?> queryNode = objMapper.reader(injectVars).readValue(subNode, QueryNode.class);
                 if (queryNode != null) {
                     nodes.put(key, queryNode);
                 }
@@ -58,16 +60,18 @@ public class NBTQuery {
 
     }
 
+    NBTCompound visitNode(NBTCompound parent, String path, String key, QueryNode<?> queryNode) {
+        NBTType nbtType = parent.getType(key);
+        if (Objects.equals(nbtType, queryNode.getNbtType())) {
+            queryNode.visit(path, key, parent);
+            return null;
+        }
+        throw new RuntimeException("Mismatched NBT types! Requested type: " + queryNode.getNbtType() + " but found type " + nbtType + " at node " + path + "." + key);
+    }
 
 
     public NBTCompound find() {
         NBTContainer container = new NBTContainer();
-
-
-
-
-
-
         return (NBTCompound) new NBTContainer();
     }
 

--- a/core/src/main/java/com/wolfyscript/utilities/bukkit/nbt/QueryNode.java
+++ b/core/src/main/java/com/wolfyscript/utilities/bukkit/nbt/QueryNode.java
@@ -102,17 +102,11 @@ public abstract class QueryNode implements Keyed {
             if (typeSpecifier.isBlank()) {
                 //Primitive
                 ObjectNode objNode = new ObjectNode(context.getNodeFactory());
+                objNode.put("id", "primitive");
                 objNode.set("value", node);
                 return context.readTreeAsValue(objNode, QueryNodePrimitive.class);
-            } else {
-                //Object, Array, or Object Array
-                return switch (typeSpecifier) {
-                    case "{}" -> context.readTreeAsValue(node, QueryNodeObject.class); //Object
-                    case "[]" -> context.readTreeAsValue(node, QueryNodeArray.class); //Array (Primitive)
-                    case "[{}]" -> null; //Object Array
-                    default -> null;
-                };
             }
+            return null;
         }
     }
 

--- a/core/src/main/java/com/wolfyscript/utilities/bukkit/nbt/QueryNode.java
+++ b/core/src/main/java/com/wolfyscript/utilities/bukkit/nbt/QueryNode.java
@@ -159,6 +159,8 @@ public abstract class QueryNode<VAL> implements Keyed {
         }
     }
 
+    public abstract QueryNode<VAL> copy();
+
     public static class OptionalValueDeserializer extends ValueDeserializer<QueryNode<?>> {
 
         public OptionalValueDeserializer() {

--- a/core/src/main/java/com/wolfyscript/utilities/bukkit/nbt/QueryNode.java
+++ b/core/src/main/java/com/wolfyscript/utilities/bukkit/nbt/QueryNode.java
@@ -1,0 +1,119 @@
+/*
+ *       ____ _  _ ____ ___ ____ _  _ ____ ____ ____ ____ ___ _ _  _ ____
+ *       |    |  | [__   |  |  | |\/| |    |__/ |__| |___  |  | |\ | | __
+ *       |___ |__| ___]  |  |__| |  | |___ |  \ |  | |     |  | | \| |__]
+ *
+ *       CustomCrafting Recipe creation and management tool for Minecraft
+ *                      Copyright (C) 2021  WolfyScript
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package com.wolfyscript.utilities.bukkit.nbt;
+
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import de.tr7zw.changeme.nbtapi.NBTCompound;
+import de.tr7zw.changeme.nbtapi.NBTType;
+import com.fasterxml.jackson.annotation.JacksonInject;
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonGetter;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.annotation.JsonTypeIdResolver;
+import com.fasterxml.jackson.databind.annotation.JsonTypeResolver;
+import me.wolfyscript.utilities.util.Keyed;
+import me.wolfyscript.utilities.util.NamespacedKey;
+import me.wolfyscript.utilities.util.json.jackson.KeyedTypeIdResolver;
+import me.wolfyscript.utilities.util.json.jackson.KeyedTypeResolver;
+import me.wolfyscript.utilities.util.json.jackson.ValueDeserializer;
+import me.wolfyscript.utilities.util.json.jackson.annotations.OptionalValueDeserializer;
+
+import java.io.IOException;
+import java.util.regex.Pattern;
+
+@JsonTypeResolver(KeyedTypeResolver.class)
+@JsonTypeIdResolver(KeyedTypeIdResolver.class)
+@OptionalValueDeserializer(deserializer = QueryNode.OptionalValueDeserializer.class, delegateObjectDeserializer = true)
+@JsonTypeInfo(use = JsonTypeInfo.Id.CUSTOM, property = "id")
+@JsonAutoDetect(fieldVisibility = JsonAutoDetect.Visibility.ANY)
+@JsonPropertyOrder(value = {"id"})
+public abstract class QueryNode implements Keyed {
+
+    private static final Pattern KEY_PATTERN = Pattern.compile("\\{}$|\\[]$|\\[\\{}]$");
+
+    protected final NamespacedKey id;
+    @JsonIgnore
+    protected final String parentPath;
+    @JsonIgnore
+    protected final String key;
+    @JsonIgnore
+    protected NBTType type = NBTType.NBTTagEnd;
+
+    protected QueryNode(NamespacedKey id, @JacksonInject("key") String key, @JacksonInject("path") String parentPath) {
+        this.id = id;
+        this.parentPath = parentPath;
+        this.key = key;
+    }
+
+    public abstract boolean check(String key, NBTType type, NBTCompound parent);
+
+    @JsonGetter("id")
+    public NamespacedKey getId() {
+        return id;
+    }
+
+    @JsonIgnore
+    @Override
+    public NamespacedKey getNamespacedKey() {
+        return id;
+    }
+
+    static class OptionalValueDeserializer extends ValueDeserializer<QueryNode> {
+
+        protected OptionalValueDeserializer() {
+            super(QueryNode.class);
+        }
+
+        @Override
+        public QueryNode deserialize(JsonParser jsonParser, DeserializationContext context) throws IOException, JsonProcessingException {
+            JsonNode node = jsonParser.readValueAsTree();
+            var nodeKey = context.getParser().getCurrentName();
+            var keyMatcher = KEY_PATTERN.matcher(nodeKey);
+            String typeSpecifier = "";
+            if (keyMatcher.matches()) {
+                typeSpecifier = keyMatcher.group();
+            }
+            if (typeSpecifier.isBlank()) {
+                //Primitive
+                ObjectNode objNode = new ObjectNode(context.getNodeFactory());
+                objNode.set("value", node);
+                return context.readTreeAsValue(objNode, QueryNodePrimitive.class);
+            } else {
+                //Object, Array, or Object Array
+                return switch (typeSpecifier) {
+                    case "{}" -> context.readTreeAsValue(node, QueryNodeObject.class); //Object
+                    case "[]" -> context.readTreeAsValue(node, QueryNodeArray.class); //Array (Primitive)
+                    case "[{}]" -> null; //Object Array
+                    default -> null;
+                };
+            }
+        }
+    }
+
+}

--- a/core/src/main/java/com/wolfyscript/utilities/bukkit/nbt/QueryNodeArray.java
+++ b/core/src/main/java/com/wolfyscript/utilities/bukkit/nbt/QueryNodeArray.java
@@ -1,0 +1,48 @@
+/*
+ *       ____ _  _ ____ ___ ____ _  _ ____ ____ ____ ____ ___ _ _  _ ____
+ *       |    |  | [__   |  |  | |\/| |    |__/ |__| |___  |  | |\ | | __
+ *       |___ |__| ___]  |  |__| |  | |___ |  \ |  | |     |  | | \| |__]
+ *
+ *       CustomCrafting Recipe creation and management tool for Minecraft
+ *                      Copyright (C) 2021  WolfyScript
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package com.wolfyscript.utilities.bukkit.nbt;
+
+import com.fasterxml.jackson.annotation.JacksonInject;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import de.tr7zw.changeme.nbtapi.NBTCompound;
+import de.tr7zw.changeme.nbtapi.NBTIntArrayList;
+import de.tr7zw.changeme.nbtapi.NBTType;
+import me.wolfyscript.utilities.util.NamespacedKey;
+
+import java.util.List;
+
+public class QueryNodeArray extends QueryNode {
+
+    public static final NamespacedKey ID = NamespacedKey.wolfyutilties("array");
+
+    @JsonCreator
+    public QueryNodeArray(NBTIntArrayList node, @JacksonInject("key") String key, @JacksonInject("") String path, NBTType type) {
+        super(ID, key, path);
+        this.type = type;
+    }
+
+    @Override
+    public boolean check(String key, NBTType type, NBTCompound parent) {
+        return false;
+    }
+}

--- a/core/src/main/java/com/wolfyscript/utilities/bukkit/nbt/QueryNodeBoolean.java
+++ b/core/src/main/java/com/wolfyscript/utilities/bukkit/nbt/QueryNodeBoolean.java
@@ -24,21 +24,22 @@ package com.wolfyscript.utilities.bukkit.nbt;
 
 import com.fasterxml.jackson.annotation.JacksonInject;
 import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import de.tr7zw.changeme.nbtapi.NBTCompound;
 import de.tr7zw.changeme.nbtapi.NBTType;
 import me.wolfyscript.utilities.util.NamespacedKey;
 
 import java.util.Optional;
 
-public class QueryNodeBoolean extends QueryNode<Boolean> {
+public class QueryNodeBoolean extends QueryNode<Object> {
 
-    public static final NamespacedKey ID = NamespacedKey.wolfyutilties("boolean");
+    public static final NamespacedKey TYPE = NamespacedKey.wolfyutilties("boolean");
 
     private final boolean value;
 
     @JsonCreator
-    public QueryNodeBoolean(boolean value, @JacksonInject("key") String key, @JacksonInject("path") String parentPath) {
-        super(ID, key, parentPath);
+    public QueryNodeBoolean(@JsonProperty("value") boolean value, @JacksonInject("key") String key, @JacksonInject("parent_path") String parentPath) {
+        super(TYPE, key, parentPath);
         this.value = value;
     }
 
@@ -49,12 +50,19 @@ public class QueryNodeBoolean extends QueryNode<Boolean> {
 
     //TODO: Make this work for all types of values and apply the values accordingly
     @Override
-    protected Optional<Boolean> readValue(String path, String key, NBTCompound parent) {
-        return Optional.ofNullable(parent.getBoolean(key));
+    protected Optional<Object> readValue(String path, String key, NBTCompound parent) {
+        var type = parent.getType(key);
+        return Optional.ofNullable(switch (type) {
+            case NBTTagInt -> parent.getInteger(key);
+            default -> parent.getString(key);
+        });
     }
 
     @Override
-    protected void applyValue(String path, String key, Boolean value, NBTCompound resultContainer) {
-
+    protected void applyValue(String path, String key, Object value, NBTCompound resultContainer) {
+        switch (value.getClass().getSimpleName()) {
+            case "Integer" -> resultContainer.setInteger(key, (int) value);
+            default -> resultContainer.setString(key, (String) value);
+        }
     }
 }

--- a/core/src/main/java/com/wolfyscript/utilities/bukkit/nbt/QueryNodeBoolean.java
+++ b/core/src/main/java/com/wolfyscript/utilities/bukkit/nbt/QueryNodeBoolean.java
@@ -44,6 +44,11 @@ public class QueryNodeBoolean extends QueryNode<Object> {
         this.value = value;
     }
 
+    private QueryNodeBoolean(QueryNodeBoolean other) {
+        super(TYPE, other.key, other.parentPath);
+        this.value = other.value;
+    }
+
     @Override
     public boolean check(String key, NBTType nbtType, Object value) {
         return this.key.equals(key) && this.value;
@@ -110,5 +115,10 @@ public class QueryNodeBoolean extends QueryNode<Object> {
                 nbtList.addAll(list);
             }
         }
+    }
+
+    @Override
+    public QueryNodeBoolean copy() {
+        return new QueryNodeBoolean(this);
     }
 }

--- a/core/src/main/java/com/wolfyscript/utilities/bukkit/nbt/QueryNodeBoolean.java
+++ b/core/src/main/java/com/wolfyscript/utilities/bukkit/nbt/QueryNodeBoolean.java
@@ -54,7 +54,14 @@ public class QueryNodeBoolean extends QueryNode<Object> {
         var type = parent.getType(key);
         return Optional.ofNullable(switch (type) {
             case NBTTagInt -> parent.getInteger(key);
-            default -> parent.getString(key);
+            case NBTTagByte -> parent.getByte(key);
+            case NBTTagShort -> parent.getShort(key);
+            case NBTTagLong -> parent.getLong(key);
+            case NBTTagDouble -> parent.getDouble(key);
+            case NBTTagFloat -> parent.getFloat(key);
+            case NBTTagString -> parent.getString(key);
+            case NBTTagCompound -> parent.getCompound(key);
+            default -> null;
         });
     }
 

--- a/core/src/main/java/com/wolfyscript/utilities/bukkit/nbt/QueryNodeBoolean.java
+++ b/core/src/main/java/com/wolfyscript/utilities/bukkit/nbt/QueryNodeBoolean.java
@@ -1,0 +1,47 @@
+/*
+ *       ____ _  _ ____ ___ ____ _  _ ____ ____ ____ ____ ___ _ _  _ ____
+ *       |    |  | [__   |  |  | |\/| |    |__/ |__| |___  |  | |\ | | __
+ *       |___ |__| ___]  |  |__| |  | |___ |  \ |  | |     |  | | \| |__]
+ *
+ *       CustomCrafting Recipe creation and management tool for Minecraft
+ *                      Copyright (C) 2021  WolfyScript
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package com.wolfyscript.utilities.bukkit.nbt;
+
+import com.fasterxml.jackson.annotation.JacksonInject;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import de.tr7zw.changeme.nbtapi.NBTCompound;
+import de.tr7zw.changeme.nbtapi.NBTType;
+import me.wolfyscript.utilities.util.NamespacedKey;
+
+public class QueryNodeBoolean extends QueryNode {
+
+    public static final NamespacedKey ID = NamespacedKey.wolfyutilties("boolean");
+
+    private final boolean value;
+
+    @JsonCreator
+    public QueryNodeBoolean(boolean value, @JacksonInject("key") String key, @JacksonInject("path") String parentPath) {
+        super(ID, key, parentPath);
+        this.value = value;
+    }
+
+    @Override
+    public boolean check(String key, NBTType type, NBTCompound parent) {
+        return this.key.equals(key) && value;
+    }
+}

--- a/core/src/main/java/com/wolfyscript/utilities/bukkit/nbt/QueryNodeBoolean.java
+++ b/core/src/main/java/com/wolfyscript/utilities/bukkit/nbt/QueryNodeBoolean.java
@@ -28,7 +28,9 @@ import de.tr7zw.changeme.nbtapi.NBTCompound;
 import de.tr7zw.changeme.nbtapi.NBTType;
 import me.wolfyscript.utilities.util.NamespacedKey;
 
-public class QueryNodeBoolean extends QueryNode {
+import java.util.Optional;
+
+public class QueryNodeBoolean extends QueryNode<Boolean> {
 
     public static final NamespacedKey ID = NamespacedKey.wolfyutilties("boolean");
 
@@ -43,5 +45,16 @@ public class QueryNodeBoolean extends QueryNode {
     @Override
     public boolean check(String key, NBTType type, NBTCompound parent) {
         return this.key.equals(key) && value;
+    }
+
+    //TODO: Make this work for all types of values and apply the values accordingly
+    @Override
+    protected Optional<Boolean> readValue(String path, String key, NBTCompound parent) {
+        return Optional.ofNullable(parent.getBoolean(key));
+    }
+
+    @Override
+    protected void applyValue(String path, String key, Boolean value, NBTCompound resultContainer) {
+
     }
 }

--- a/core/src/main/java/com/wolfyscript/utilities/bukkit/nbt/QueryNodeBoolean.java
+++ b/core/src/main/java/com/wolfyscript/utilities/bukkit/nbt/QueryNodeBoolean.java
@@ -45,8 +45,8 @@ public class QueryNodeBoolean extends QueryNode<Object> {
     }
 
     @Override
-    public boolean check(String key, NBTType type, NBTCompound parent) {
-        return this.key.equals(key) && value;
+    public boolean check(String key, NBTType nbtType, Object value) {
+        return this.key.equals(key) && this.value;
     }
 
     @Override

--- a/core/src/main/java/com/wolfyscript/utilities/bukkit/nbt/QueryNodeByte.java
+++ b/core/src/main/java/com/wolfyscript/utilities/bukkit/nbt/QueryNodeByte.java
@@ -20,6 +20,10 @@ public class QueryNodeByte extends QueryNodePrimitive<Byte> {
         this.nbtType = NBTType.NBTTagByte;
     }
 
+    private QueryNodeByte(QueryNodeByte other) {
+        super(other);
+    }
+
     @Override
     protected Optional<Byte> readValue(String path, String key, NBTCompound parent) {
         return Optional.ofNullable(parent.getByte(key));
@@ -28,6 +32,11 @@ public class QueryNodeByte extends QueryNodePrimitive<Byte> {
     @Override
     protected void applyValue(String path, String key, Byte value, NBTCompound resultContainer) {
         resultContainer.setByte(key, value);
+    }
+
+    @Override
+    public QueryNodeByte copy() {
+        return new QueryNodeByte(this);
     }
 
 }

--- a/core/src/main/java/com/wolfyscript/utilities/bukkit/nbt/QueryNodeByte.java
+++ b/core/src/main/java/com/wolfyscript/utilities/bukkit/nbt/QueryNodeByte.java
@@ -1,0 +1,30 @@
+package com.wolfyscript.utilities.bukkit.nbt;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.JsonNode;
+import de.tr7zw.changeme.nbtapi.NBTCompound;
+import me.wolfyscript.utilities.util.NamespacedKey;
+
+import java.util.Optional;
+
+public class QueryNodeByte extends QueryNodePrimitive<Byte> {
+
+    public static final NamespacedKey TYPE = NamespacedKey.wolfyutilties("byte");
+
+    @JsonCreator
+    public QueryNodeByte(@JsonProperty("value") JsonNode valueNode, String key, String parentPath) {
+        super(TYPE, valueNode.isTextual() ? Byte.parseByte(valueNode.asText().replaceAll("[bB]", "")) : valueNode.numberValue().byteValue(), key, parentPath);
+    }
+
+    @Override
+    protected Optional<Byte> readValue(String path, String key, NBTCompound parent) {
+        return Optional.ofNullable(parent.getByte(key));
+    }
+
+    @Override
+    protected void applyValue(String path, String key, Byte value, NBTCompound resultContainer) {
+        resultContainer.setByte(key, value);
+    }
+
+}

--- a/core/src/main/java/com/wolfyscript/utilities/bukkit/nbt/QueryNodeByte.java
+++ b/core/src/main/java/com/wolfyscript/utilities/bukkit/nbt/QueryNodeByte.java
@@ -1,9 +1,11 @@
 package com.wolfyscript.utilities.bukkit.nbt;
 
+import com.fasterxml.jackson.annotation.JacksonInject;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.JsonNode;
 import de.tr7zw.changeme.nbtapi.NBTCompound;
+import de.tr7zw.changeme.nbtapi.NBTType;
 import me.wolfyscript.utilities.util.NamespacedKey;
 
 import java.util.Optional;
@@ -13,8 +15,9 @@ public class QueryNodeByte extends QueryNodePrimitive<Byte> {
     public static final NamespacedKey TYPE = NamespacedKey.wolfyutilties("byte");
 
     @JsonCreator
-    public QueryNodeByte(@JsonProperty("value") JsonNode valueNode, String key, String parentPath) {
+    public QueryNodeByte(@JsonProperty("value") JsonNode valueNode, @JacksonInject("key") String key, @JacksonInject("parent_path") String parentPath) {
         super(TYPE, valueNode.isTextual() ? Byte.parseByte(valueNode.asText().replaceAll("[bB]", "")) : valueNode.numberValue().byteValue(), key, parentPath);
+        this.nbtType = NBTType.NBTTagByte;
     }
 
     @Override

--- a/core/src/main/java/com/wolfyscript/utilities/bukkit/nbt/QueryNodeByteArray.java
+++ b/core/src/main/java/com/wolfyscript/utilities/bukkit/nbt/QueryNodeByteArray.java
@@ -3,7 +3,6 @@ package com.wolfyscript.utilities.bukkit.nbt;
 import com.fasterxml.jackson.annotation.JacksonInject;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.databind.JsonNode;
 import de.tr7zw.changeme.nbtapi.NBTCompound;
 import de.tr7zw.changeme.nbtapi.NBTType;
 import me.wolfyscript.utilities.util.NamespacedKey;
@@ -20,6 +19,10 @@ public class QueryNodeByteArray extends QueryNodePrimitive<byte[]> {
         this.nbtType = NBTType.NBTTagByteArray;
     }
 
+    private QueryNodeByteArray(QueryNodeByteArray other) {
+        super(TYPE, other.value.clone(), other.key, other.parentPath);
+    }
+
     @Override
     protected Optional<byte[]> readValue(String path, String key, NBTCompound parent) {
         return Optional.ofNullable(parent.getByteArray(key));
@@ -28,6 +31,11 @@ public class QueryNodeByteArray extends QueryNodePrimitive<byte[]> {
     @Override
     protected void applyValue(String path, String key, byte[] value, NBTCompound resultContainer) {
         resultContainer.setByteArray(key, value);
+    }
+
+    @Override
+    public QueryNodeByteArray copy() {
+        return new QueryNodeByteArray(this);
     }
 
 }

--- a/core/src/main/java/com/wolfyscript/utilities/bukkit/nbt/QueryNodeByteArray.java
+++ b/core/src/main/java/com/wolfyscript/utilities/bukkit/nbt/QueryNodeByteArray.java
@@ -1,0 +1,33 @@
+package com.wolfyscript.utilities.bukkit.nbt;
+
+import com.fasterxml.jackson.annotation.JacksonInject;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.JsonNode;
+import de.tr7zw.changeme.nbtapi.NBTCompound;
+import de.tr7zw.changeme.nbtapi.NBTType;
+import me.wolfyscript.utilities.util.NamespacedKey;
+
+import java.util.Optional;
+
+public class QueryNodeByteArray extends QueryNodePrimitive<byte[]> {
+
+    public static final NamespacedKey TYPE = NamespacedKey.wolfyutilties("byte_array");
+
+    @JsonCreator
+    public QueryNodeByteArray(@JsonProperty("value") byte[] value, @JacksonInject("key") String key, @JacksonInject("parent_path") String parentPath) {
+        super(TYPE, value, key, parentPath);
+        this.nbtType = NBTType.NBTTagByteArray;
+    }
+
+    @Override
+    protected Optional<byte[]> readValue(String path, String key, NBTCompound parent) {
+        return Optional.ofNullable(parent.getByteArray(key));
+    }
+
+    @Override
+    protected void applyValue(String path, String key, byte[] value, NBTCompound resultContainer) {
+        resultContainer.setByteArray(key, value);
+    }
+
+}

--- a/core/src/main/java/com/wolfyscript/utilities/bukkit/nbt/QueryNodeCompound.java
+++ b/core/src/main/java/com/wolfyscript/utilities/bukkit/nbt/QueryNodeCompound.java
@@ -107,8 +107,8 @@ public class QueryNodeCompound extends QueryNode<NBTCompound> {
     }
 
     @Override
-    public boolean check(String key, NBTType type, NBTCompound parent) {
-        return false;
+    public boolean check(String key, NBTType nbtType, NBTCompound value) {
+        return !value.getKeys().isEmpty();
     }
 
     @Override

--- a/core/src/main/java/com/wolfyscript/utilities/bukkit/nbt/QueryNodeCompound.java
+++ b/core/src/main/java/com/wolfyscript/utilities/bukkit/nbt/QueryNodeCompound.java
@@ -61,6 +61,14 @@ public class QueryNodeCompound extends QueryNode<NBTCompound> {
         this.children = new HashMap<>();
     }
 
+    private QueryNodeCompound(QueryNodeCompound other) {
+        super(TYPE, other.key, other.parentPath);
+        this.nbtType = NBTType.NBTTagCompound;
+        this.includes = new HashMap<>(other.includes);
+        this.required = other.required.entrySet().stream().collect(Collectors.toMap(Map.Entry::getKey, entry -> entry.getValue().copy()));
+        this.children = other.children.entrySet().stream().collect(Collectors.toMap(Map.Entry::getKey, entry -> entry.getValue().copy()));
+    }
+
     @JsonAnySetter
     public void loadNonNestedChildren(String key, JsonNode node) {
         //Sets the children that are specified in the root of the object without the "children" node!
@@ -139,6 +147,11 @@ public class QueryNodeCompound extends QueryNode<NBTCompound> {
                 System.out.println("Type: " + childType);
             }
         }
+    }
+
+    @Override
+    public QueryNodeCompound copy() {
+        return new QueryNodeCompound(this);
     }
 
 }

--- a/core/src/main/java/com/wolfyscript/utilities/bukkit/nbt/QueryNodeCompound.java
+++ b/core/src/main/java/com/wolfyscript/utilities/bukkit/nbt/QueryNodeCompound.java
@@ -39,9 +39,9 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 
-public class QueryNodeObject extends QueryNode<NBTCompound> {
+public class QueryNodeCompound extends QueryNode<NBTCompound> {
 
-    public static final NamespacedKey TYPE = NamespacedKey.wolfyutilties("object");
+    public static final NamespacedKey TYPE = NamespacedKey.wolfyutilties("compound");
 
     //If include is true it includes this node with each and every child node.
     private boolean fullyInclude;
@@ -53,7 +53,7 @@ public class QueryNodeObject extends QueryNode<NBTCompound> {
     @JsonIgnore
     private Map<String, QueryNode<?>> children;
 
-    public QueryNodeObject(@JacksonInject("key") String key, @JacksonInject("parent_path") String parentPath) {
+    public QueryNodeCompound(@JacksonInject("key") String key, @JacksonInject("parent_path") String parentPath) {
         super(TYPE, key, parentPath);
         this.nbtType = NBTType.NBTTagCompound;
         this.includes = new HashMap<>();

--- a/core/src/main/java/com/wolfyscript/utilities/bukkit/nbt/QueryNodeDouble.java
+++ b/core/src/main/java/com/wolfyscript/utilities/bukkit/nbt/QueryNodeDouble.java
@@ -1,9 +1,11 @@
 package com.wolfyscript.utilities.bukkit.nbt;
 
+import com.fasterxml.jackson.annotation.JacksonInject;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.JsonNode;
 import de.tr7zw.changeme.nbtapi.NBTCompound;
+import de.tr7zw.changeme.nbtapi.NBTType;
 import me.wolfyscript.utilities.util.NamespacedKey;
 
 import java.util.Optional;
@@ -13,8 +15,9 @@ public class QueryNodeDouble extends QueryNodePrimitive<Double> {
     public static final NamespacedKey TYPE = NamespacedKey.wolfyutilties("double");
 
     @JsonCreator
-    public QueryNodeDouble(@JsonProperty("value") JsonNode valueNode, String key, String parentPath) {
+    public QueryNodeDouble(@JsonProperty("value") JsonNode valueNode, @JacksonInject("key") String key, @JacksonInject("parent_path") String parentPath) {
         super(TYPE, valueNode.isTextual() ? Double.parseDouble(valueNode.asText().replaceAll("[dD]", "")) : valueNode.numberValue().doubleValue(), key, parentPath);
+        this.nbtType = NBTType.NBTTagDouble;
     }
 
     @Override

--- a/core/src/main/java/com/wolfyscript/utilities/bukkit/nbt/QueryNodeDouble.java
+++ b/core/src/main/java/com/wolfyscript/utilities/bukkit/nbt/QueryNodeDouble.java
@@ -1,0 +1,30 @@
+package com.wolfyscript.utilities.bukkit.nbt;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.JsonNode;
+import de.tr7zw.changeme.nbtapi.NBTCompound;
+import me.wolfyscript.utilities.util.NamespacedKey;
+
+import java.util.Optional;
+
+public class QueryNodeDouble extends QueryNodePrimitive<Double> {
+
+    public static final NamespacedKey TYPE = NamespacedKey.wolfyutilties("double");
+
+    @JsonCreator
+    public QueryNodeDouble(@JsonProperty("value") JsonNode valueNode, String key, String parentPath) {
+        super(TYPE, valueNode.isTextual() ? Double.parseDouble(valueNode.asText().replaceAll("[dD]", "")) : valueNode.numberValue().doubleValue(), key, parentPath);
+    }
+
+    @Override
+    protected Optional<Double> readValue(String path, String key, NBTCompound parent) {
+        return Optional.ofNullable(parent.getDouble(key));
+    }
+
+    @Override
+    protected void applyValue(String path, String key, Double value, NBTCompound resultContainer) {
+        resultContainer.setDouble(key, value);
+    }
+
+}

--- a/core/src/main/java/com/wolfyscript/utilities/bukkit/nbt/QueryNodeDouble.java
+++ b/core/src/main/java/com/wolfyscript/utilities/bukkit/nbt/QueryNodeDouble.java
@@ -20,6 +20,10 @@ public class QueryNodeDouble extends QueryNodePrimitive<Double> {
         this.nbtType = NBTType.NBTTagDouble;
     }
 
+    private QueryNodeDouble(QueryNodeDouble other) {
+        super(other);
+    }
+
     @Override
     protected Optional<Double> readValue(String path, String key, NBTCompound parent) {
         return Optional.ofNullable(parent.getDouble(key));
@@ -28,6 +32,11 @@ public class QueryNodeDouble extends QueryNodePrimitive<Double> {
     @Override
     protected void applyValue(String path, String key, Double value, NBTCompound resultContainer) {
         resultContainer.setDouble(key, value);
+    }
+
+    @Override
+    public QueryNodeDouble copy() {
+        return new QueryNodeDouble(this);
     }
 
 }

--- a/core/src/main/java/com/wolfyscript/utilities/bukkit/nbt/QueryNodeFloat.java
+++ b/core/src/main/java/com/wolfyscript/utilities/bukkit/nbt/QueryNodeFloat.java
@@ -20,6 +20,10 @@ public class QueryNodeFloat extends QueryNodePrimitive<Float> {
         this.nbtType = NBTType.NBTTagFloat;
     }
 
+    private QueryNodeFloat(QueryNodeFloat other) {
+        super(other);
+    }
+
     @Override
     protected Optional<Float> readValue(String path, String key, NBTCompound parent) {
         return Optional.ofNullable(parent.getFloat(key));
@@ -28,6 +32,11 @@ public class QueryNodeFloat extends QueryNodePrimitive<Float> {
     @Override
     protected void applyValue(String path, String key, Float value, NBTCompound resultContainer) {
         resultContainer.setFloat(key, value);
+    }
+
+    @Override
+    public QueryNodeFloat copy() {
+        return new QueryNodeFloat(this);
     }
 
 }

--- a/core/src/main/java/com/wolfyscript/utilities/bukkit/nbt/QueryNodeFloat.java
+++ b/core/src/main/java/com/wolfyscript/utilities/bukkit/nbt/QueryNodeFloat.java
@@ -1,0 +1,30 @@
+package com.wolfyscript.utilities.bukkit.nbt;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.JsonNode;
+import de.tr7zw.changeme.nbtapi.NBTCompound;
+import me.wolfyscript.utilities.util.NamespacedKey;
+
+import java.util.Optional;
+
+public class QueryNodeFloat extends QueryNodePrimitive<Float> {
+
+    public static final NamespacedKey TYPE = NamespacedKey.wolfyutilties("float");
+
+    @JsonCreator
+    public QueryNodeFloat(@JsonProperty("value") JsonNode valueNode, String key, String parentPath) {
+        super(TYPE, valueNode.isTextual() ? Float.parseFloat(valueNode.asText().replaceAll("[dD]", "")) : valueNode.numberValue().floatValue(), key, parentPath);
+    }
+
+    @Override
+    protected Optional<Float> readValue(String path, String key, NBTCompound parent) {
+        return Optional.ofNullable(parent.getFloat(key));
+    }
+
+    @Override
+    protected void applyValue(String path, String key, Float value, NBTCompound resultContainer) {
+        resultContainer.setFloat(key, value);
+    }
+
+}

--- a/core/src/main/java/com/wolfyscript/utilities/bukkit/nbt/QueryNodeFloat.java
+++ b/core/src/main/java/com/wolfyscript/utilities/bukkit/nbt/QueryNodeFloat.java
@@ -1,9 +1,11 @@
 package com.wolfyscript.utilities.bukkit.nbt;
 
+import com.fasterxml.jackson.annotation.JacksonInject;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.JsonNode;
 import de.tr7zw.changeme.nbtapi.NBTCompound;
+import de.tr7zw.changeme.nbtapi.NBTType;
 import me.wolfyscript.utilities.util.NamespacedKey;
 
 import java.util.Optional;
@@ -13,8 +15,9 @@ public class QueryNodeFloat extends QueryNodePrimitive<Float> {
     public static final NamespacedKey TYPE = NamespacedKey.wolfyutilties("float");
 
     @JsonCreator
-    public QueryNodeFloat(@JsonProperty("value") JsonNode valueNode, String key, String parentPath) {
+    public QueryNodeFloat(@JsonProperty("value") JsonNode valueNode, @JacksonInject("key") String key, @JacksonInject("parent_path") String parentPath) {
         super(TYPE, valueNode.isTextual() ? Float.parseFloat(valueNode.asText().replaceAll("[dD]", "")) : valueNode.numberValue().floatValue(), key, parentPath);
+        this.nbtType = NBTType.NBTTagFloat;
     }
 
     @Override

--- a/core/src/main/java/com/wolfyscript/utilities/bukkit/nbt/QueryNodeInt.java
+++ b/core/src/main/java/com/wolfyscript/utilities/bukkit/nbt/QueryNodeInt.java
@@ -20,6 +20,10 @@ public class QueryNodeInt extends QueryNodePrimitive<Integer> {
         this.nbtType = NBTType.NBTTagInt;
     }
 
+    public QueryNodeInt(QueryNodePrimitive<Integer> other) {
+        super(other);
+    }
+
     @Override
     protected Optional<Integer> readValue(String path, String key, NBTCompound parent) {
         return Optional.ofNullable(parent.getInteger(key));
@@ -28,6 +32,11 @@ public class QueryNodeInt extends QueryNodePrimitive<Integer> {
     @Override
     protected void applyValue(String path, String key, Integer value, NBTCompound resultContainer) {
         resultContainer.setInteger(key, value);
+    }
+
+    @Override
+    public QueryNode<Integer> copy() {
+        return new QueryNodeInt(this);
     }
 
 }

--- a/core/src/main/java/com/wolfyscript/utilities/bukkit/nbt/QueryNodeInt.java
+++ b/core/src/main/java/com/wolfyscript/utilities/bukkit/nbt/QueryNodeInt.java
@@ -1,0 +1,30 @@
+package com.wolfyscript.utilities.bukkit.nbt;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.JsonNode;
+import de.tr7zw.changeme.nbtapi.NBTCompound;
+import me.wolfyscript.utilities.util.NamespacedKey;
+
+import java.util.Optional;
+
+public class QueryNodeInt extends QueryNodePrimitive<Integer> {
+
+    public static final NamespacedKey TYPE = NamespacedKey.wolfyutilties("int");
+
+    @JsonCreator
+    public QueryNodeInt(@JsonProperty("value") JsonNode valueNode, String key, String parentPath) {
+        super(TYPE, valueNode.isTextual() ? Integer.parseInt(valueNode.asText().replaceAll("[iI]", "")) : valueNode.numberValue().intValue(), key, parentPath);
+    }
+
+    @Override
+    protected Optional<Integer> readValue(String path, String key, NBTCompound parent) {
+        return Optional.ofNullable(parent.getInteger(key));
+    }
+
+    @Override
+    protected void applyValue(String path, String key, Integer value, NBTCompound resultContainer) {
+        resultContainer.setInteger(key, value);
+    }
+
+}

--- a/core/src/main/java/com/wolfyscript/utilities/bukkit/nbt/QueryNodeInt.java
+++ b/core/src/main/java/com/wolfyscript/utilities/bukkit/nbt/QueryNodeInt.java
@@ -1,9 +1,11 @@
 package com.wolfyscript.utilities.bukkit.nbt;
 
+import com.fasterxml.jackson.annotation.JacksonInject;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.JsonNode;
 import de.tr7zw.changeme.nbtapi.NBTCompound;
+import de.tr7zw.changeme.nbtapi.NBTType;
 import me.wolfyscript.utilities.util.NamespacedKey;
 
 import java.util.Optional;
@@ -13,8 +15,9 @@ public class QueryNodeInt extends QueryNodePrimitive<Integer> {
     public static final NamespacedKey TYPE = NamespacedKey.wolfyutilties("int");
 
     @JsonCreator
-    public QueryNodeInt(@JsonProperty("value") JsonNode valueNode, String key, String parentPath) {
+    public QueryNodeInt(@JsonProperty("value") JsonNode valueNode, @JacksonInject("key") String key, @JacksonInject("parent_path") String parentPath) {
         super(TYPE, valueNode.isTextual() ? Integer.parseInt(valueNode.asText().replaceAll("[iI]", "")) : valueNode.numberValue().intValue(), key, parentPath);
+        this.nbtType = NBTType.NBTTagInt;
     }
 
     @Override

--- a/core/src/main/java/com/wolfyscript/utilities/bukkit/nbt/QueryNodeIntArray.java
+++ b/core/src/main/java/com/wolfyscript/utilities/bukkit/nbt/QueryNodeIntArray.java
@@ -1,0 +1,32 @@
+package com.wolfyscript.utilities.bukkit.nbt;
+
+import com.fasterxml.jackson.annotation.JacksonInject;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import de.tr7zw.changeme.nbtapi.NBTCompound;
+import de.tr7zw.changeme.nbtapi.NBTType;
+import me.wolfyscript.utilities.util.NamespacedKey;
+
+import java.util.Optional;
+
+public class QueryNodeIntArray extends QueryNodePrimitive<int[]> {
+
+    public static final NamespacedKey TYPE = NamespacedKey.wolfyutilties("int_array");
+
+    @JsonCreator
+    public QueryNodeIntArray(@JsonProperty("value") int[] value, @JacksonInject("key") String key, @JacksonInject("parent_path") String parentPath) {
+        super(TYPE, value, key, parentPath);
+        this.nbtType = NBTType.NBTTagByteArray;
+    }
+
+    @Override
+    protected Optional<int[]> readValue(String path, String key, NBTCompound parent) {
+        return Optional.ofNullable(parent.getIntArray(key));
+    }
+
+    @Override
+    protected void applyValue(String path, String key, int[] value, NBTCompound resultContainer) {
+        resultContainer.setIntArray(key, value);
+    }
+
+}

--- a/core/src/main/java/com/wolfyscript/utilities/bukkit/nbt/QueryNodeIntArray.java
+++ b/core/src/main/java/com/wolfyscript/utilities/bukkit/nbt/QueryNodeIntArray.java
@@ -19,6 +19,10 @@ public class QueryNodeIntArray extends QueryNodePrimitive<int[]> {
         this.nbtType = NBTType.NBTTagByteArray;
     }
 
+    public QueryNodeIntArray(QueryNodeIntArray other) {
+        super(TYPE, other.value.clone(), other.key, other.parentPath);
+    }
+
     @Override
     protected Optional<int[]> readValue(String path, String key, NBTCompound parent) {
         return Optional.ofNullable(parent.getIntArray(key));
@@ -27,6 +31,11 @@ public class QueryNodeIntArray extends QueryNodePrimitive<int[]> {
     @Override
     protected void applyValue(String path, String key, int[] value, NBTCompound resultContainer) {
         resultContainer.setIntArray(key, value);
+    }
+
+    @Override
+    public QueryNodeIntArray copy() {
+        return new QueryNodeIntArray(this);
     }
 
 }

--- a/core/src/main/java/com/wolfyscript/utilities/bukkit/nbt/QueryNodeList.java
+++ b/core/src/main/java/com/wolfyscript/utilities/bukkit/nbt/QueryNodeList.java
@@ -24,20 +24,23 @@ package com.wolfyscript.utilities.bukkit.nbt;
 
 import com.fasterxml.jackson.annotation.JacksonInject;
 import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.databind.JsonNode;
 import de.tr7zw.changeme.nbtapi.NBTCompound;
-import de.tr7zw.changeme.nbtapi.NBTIntArrayList;
 import de.tr7zw.changeme.nbtapi.NBTType;
 import me.wolfyscript.utilities.util.NamespacedKey;
 
-public class QueryNodeList extends QueryNode {
+import java.util.List;
+import java.util.Optional;
+
+public class QueryNodeList<VAL> extends QueryNode<List<VAL>> {
 
     public static final NamespacedKey ID = NamespacedKey.wolfyutilties("list");
 
     private int index;
-    private QueryNode value;
+    private List<QueryNode<VAL>> values;
 
     @JsonCreator
-    public QueryNodeList(NBTIntArrayList node, @JacksonInject("key") String key, @JacksonInject("path") String path, NBTType type) {
+    public QueryNodeList(JsonNode node, @JacksonInject("key") String key, @JacksonInject("path") String path, NBTType type) {
         super(ID, key, path);
         this.nbtType = type;
     }
@@ -47,11 +50,19 @@ public class QueryNodeList extends QueryNode {
         return false;
     }
 
+    @Override
+    protected Optional<List<VAL>> readValue(String path, String key, NBTCompound parent) {
+        return Optional.empty();
+    }
+
+    @Override
+    protected void applyValue(String path, String key, List<VAL> value, NBTCompound resultContainer) {
+
+    }
+
     public int getIndex() {
         return index;
     }
 
-    public QueryNode getValue() {
-        return value;
-    }
+
 }

--- a/core/src/main/java/com/wolfyscript/utilities/bukkit/nbt/QueryNodeList.java
+++ b/core/src/main/java/com/wolfyscript/utilities/bukkit/nbt/QueryNodeList.java
@@ -29,14 +29,14 @@ import de.tr7zw.changeme.nbtapi.NBTIntArrayList;
 import de.tr7zw.changeme.nbtapi.NBTType;
 import me.wolfyscript.utilities.util.NamespacedKey;
 
-import java.util.List;
-
-public class QueryNodeArray extends QueryNode {
+public class QueryNodeList extends QueryNode {
 
     public static final NamespacedKey ID = NamespacedKey.wolfyutilties("array");
 
+    private int index;
+
     @JsonCreator
-    public QueryNodeArray(NBTIntArrayList node, @JacksonInject("key") String key, @JacksonInject("") String path, NBTType type) {
+    public QueryNodeList(NBTIntArrayList node, @JacksonInject("key") String key, @JacksonInject("") String path, NBTType type) {
         super(ID, key, path);
         this.type = type;
     }

--- a/core/src/main/java/com/wolfyscript/utilities/bukkit/nbt/QueryNodeList.java
+++ b/core/src/main/java/com/wolfyscript/utilities/bukkit/nbt/QueryNodeList.java
@@ -31,18 +31,27 @@ import me.wolfyscript.utilities.util.NamespacedKey;
 
 public class QueryNodeList extends QueryNode {
 
-    public static final NamespacedKey ID = NamespacedKey.wolfyutilties("array");
+    public static final NamespacedKey ID = NamespacedKey.wolfyutilties("list");
 
     private int index;
+    private QueryNode value;
 
     @JsonCreator
-    public QueryNodeList(NBTIntArrayList node, @JacksonInject("key") String key, @JacksonInject("") String path, NBTType type) {
+    public QueryNodeList(NBTIntArrayList node, @JacksonInject("key") String key, @JacksonInject("path") String path, NBTType type) {
         super(ID, key, path);
-        this.type = type;
+        this.nbtType = type;
     }
 
     @Override
     public boolean check(String key, NBTType type, NBTCompound parent) {
         return false;
+    }
+
+    public int getIndex() {
+        return index;
+    }
+
+    public QueryNode getValue() {
+        return value;
     }
 }

--- a/core/src/main/java/com/wolfyscript/utilities/bukkit/nbt/QueryNodeList.java
+++ b/core/src/main/java/com/wolfyscript/utilities/bukkit/nbt/QueryNodeList.java
@@ -55,8 +55,8 @@ public abstract class QueryNodeList<VAL> extends QueryNode<NBTList<VAL>> {
     }
 
     @Override
-    public boolean check(String key, NBTType type, NBTCompound parent) {
-        return false;
+    public boolean check(String key, NBTType nbtType, NBTList<VAL> value) {
+        return !value.isEmpty();
     }
 
     @Override
@@ -76,24 +76,15 @@ public abstract class QueryNodeList<VAL> extends QueryNode<NBTList<VAL>> {
                     index = index % value.size();
                     if (value.size() > index) {
                         int fIndex = index;
-                        element.value().ifPresentOrElse(queryNode -> computeElement(path, fIndex, queryNode, value, list), () -> list.add(value.get(fIndex)));
+                        element.value().ifPresentOrElse(queryNode -> queryNode.visit(path, fIndex, value, list), () -> list.add(value.get(fIndex)));
                     }
                 }, () -> element.value().ifPresent(valQueryNode -> {
-                    for (int i = 0; i < list.size(); i++) {
-                        computeElement(path, i, valQueryNode, value, list);
+                    for (int i = 0; i < value.size(); i++) {
+                        valQueryNode.visit(path, i, value, list);
                     }
                 }));
             }
         }
-    }
-
-    private void computeElement(String path, int index, QueryNode<VAL> queryNode, NBTList<VAL> value, NBTList<VAL> list) {
-        queryNode.readValue(path, index, value).ifPresent(val -> {
-            if (val instanceof NBTCompound nbtCompound && nbtCompound.getKeys().isEmpty()) {
-                return;
-            }
-            list.add(val);
-        });
     }
 
     protected NBTList<VAL> readList(String key, NBTCompound container) {

--- a/core/src/main/java/com/wolfyscript/utilities/bukkit/nbt/QueryNodeList.java
+++ b/core/src/main/java/com/wolfyscript/utilities/bukkit/nbt/QueryNodeList.java
@@ -50,6 +50,13 @@ public abstract class QueryNodeList<VAL> extends QueryNode<NBTList<VAL>> {
         this.elements = elements;
     }
 
+    protected QueryNodeList(QueryNodeList<VAL> other) {
+        super(other.type, other.key, other.parentPath);
+        this.nbtType = other.nbtType;
+        this.elementType = other.elementType;
+        this.elements = other.elements.stream().map(Element::copy).toList();
+    }
+
     public List<Element<VAL>> getElements() {
         return elements;
     }
@@ -73,7 +80,7 @@ public abstract class QueryNodeList<VAL> extends QueryNode<NBTList<VAL>> {
                     if (index < 0) {
                         index = value.size() + (index % value.size()); //Convert the negative index to a positive reverted index, that starts from the end.
                     }
-                    index = index % value.size();
+                    index = index % value.size(); //Prevent out of bounds
                     if (value.size() > index) {
                         int fIndex = index;
                         element.value().ifPresentOrElse(queryNode -> queryNode.visit(path, fIndex, value, list), () -> list.add(value.get(fIndex)));
@@ -114,6 +121,11 @@ public abstract class QueryNodeList<VAL> extends QueryNode<NBTList<VAL>> {
             this.value = null;
         }
 
+        private Element(Element<VAL> other) {
+            this.index = other.index;
+            this.value = other.value.copy();
+        }
+
         private Optional<Integer> index() {
             return Optional.ofNullable(index);
         }
@@ -140,6 +152,10 @@ public abstract class QueryNodeList<VAL> extends QueryNode<NBTList<VAL>> {
         @JsonGetter
         public QueryNode<VAL> getValue() {
             return value;
+        }
+
+        public Element<VAL> copy() {
+            return new Element<>(this);
         }
     }
 }

--- a/core/src/main/java/com/wolfyscript/utilities/bukkit/nbt/QueryNodeList.java
+++ b/core/src/main/java/com/wolfyscript/utilities/bukkit/nbt/QueryNodeList.java
@@ -107,6 +107,8 @@ public abstract class QueryNodeList<VAL> extends QueryNode<NBTList<VAL>> {
             return (NBTList<VAL>) container.getStringList(key);
         } else if (elementType == NBTCompound.class) {
             return (NBTList<VAL>) container.getCompoundList(key);
+        } else if (elementType == int[].class) {
+            return (NBTList<VAL>) container.getIntArrayList(key);
         }
         return null;
     }

--- a/core/src/main/java/com/wolfyscript/utilities/bukkit/nbt/QueryNodeListCompound.java
+++ b/core/src/main/java/com/wolfyscript/utilities/bukkit/nbt/QueryNodeListCompound.java
@@ -16,4 +16,12 @@ public class QueryNodeListCompound extends QueryNodeList<NBTCompound> {
         super(TYPE, elements, key, path, NBTType.NBTTagCompound, NBTCompound.class);
     }
 
+    private QueryNodeListCompound(QueryNodeListCompound other) {
+        super(other);
+    }
+
+    @Override
+    public QueryNodeListCompound copy() {
+        return new QueryNodeListCompound(this);
+    }
 }

--- a/core/src/main/java/com/wolfyscript/utilities/bukkit/nbt/QueryNodeListCompound.java
+++ b/core/src/main/java/com/wolfyscript/utilities/bukkit/nbt/QueryNodeListCompound.java
@@ -1,0 +1,19 @@
+package com.wolfyscript.utilities.bukkit.nbt;
+
+import com.fasterxml.jackson.annotation.JacksonInject;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import de.tr7zw.changeme.nbtapi.NBTCompound;
+import de.tr7zw.changeme.nbtapi.NBTType;
+import me.wolfyscript.utilities.util.NamespacedKey;
+
+import java.util.List;
+
+public class QueryNodeListCompound extends QueryNodeList<NBTCompound> {
+
+    public static final NamespacedKey TYPE = NamespacedKey.wolfyutilties("list/compound");
+
+    public QueryNodeListCompound(@JsonProperty("elements") List<Element<NBTCompound>> elements, @JacksonInject("key") String key, @JacksonInject("parent_path") String path) {
+        super(TYPE, elements, key, path, NBTType.NBTTagCompound, NBTCompound.class);
+    }
+
+}

--- a/core/src/main/java/com/wolfyscript/utilities/bukkit/nbt/QueryNodeListDouble.java
+++ b/core/src/main/java/com/wolfyscript/utilities/bukkit/nbt/QueryNodeListDouble.java
@@ -2,6 +2,7 @@ package com.wolfyscript.utilities.bukkit.nbt;
 
 import com.fasterxml.jackson.annotation.JacksonInject;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import de.tr7zw.changeme.nbtapi.NBTList;
 import de.tr7zw.changeme.nbtapi.NBTType;
 import me.wolfyscript.utilities.util.NamespacedKey;
 
@@ -15,4 +16,12 @@ public class QueryNodeListDouble extends QueryNodeList<Double> {
         super(TYPE, elements, key, path, NBTType.NBTTagByte, Double.class);
     }
 
+    public QueryNodeListDouble(QueryNodeList<Double> other) {
+        super(other);
+    }
+
+    @Override
+    public QueryNodeListDouble copy() {
+        return new QueryNodeListDouble(this);
+    }
 }

--- a/core/src/main/java/com/wolfyscript/utilities/bukkit/nbt/QueryNodeListDouble.java
+++ b/core/src/main/java/com/wolfyscript/utilities/bukkit/nbt/QueryNodeListDouble.java
@@ -1,0 +1,18 @@
+package com.wolfyscript.utilities.bukkit.nbt;
+
+import com.fasterxml.jackson.annotation.JacksonInject;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import de.tr7zw.changeme.nbtapi.NBTType;
+import me.wolfyscript.utilities.util.NamespacedKey;
+
+import java.util.List;
+
+public class QueryNodeListDouble extends QueryNodeList<Double> {
+
+    public static final NamespacedKey TYPE = NamespacedKey.wolfyutilties("list/double");
+
+    public QueryNodeListDouble(@JsonProperty("elements") List<Element<Double>> elements, @JacksonInject("key") String key, @JacksonInject("parent_path") String path) {
+        super(TYPE, elements, key, path, NBTType.NBTTagByte, Double.class);
+    }
+
+}

--- a/core/src/main/java/com/wolfyscript/utilities/bukkit/nbt/QueryNodeListFloat.java
+++ b/core/src/main/java/com/wolfyscript/utilities/bukkit/nbt/QueryNodeListFloat.java
@@ -1,0 +1,18 @@
+package com.wolfyscript.utilities.bukkit.nbt;
+
+import com.fasterxml.jackson.annotation.JacksonInject;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import de.tr7zw.changeme.nbtapi.NBTType;
+import me.wolfyscript.utilities.util.NamespacedKey;
+
+import java.util.List;
+
+public class QueryNodeListFloat extends QueryNodeList<Float> {
+
+    public static final NamespacedKey TYPE = NamespacedKey.wolfyutilties("list/float");
+
+    public QueryNodeListFloat(@JsonProperty("elements") List<Element<Float>> elements, @JacksonInject("key") String key, @JacksonInject("parent_path") String path) {
+        super(TYPE, elements, key, path, NBTType.NBTTagByte, Float.class);
+    }
+
+}

--- a/core/src/main/java/com/wolfyscript/utilities/bukkit/nbt/QueryNodeListFloat.java
+++ b/core/src/main/java/com/wolfyscript/utilities/bukkit/nbt/QueryNodeListFloat.java
@@ -2,6 +2,7 @@ package com.wolfyscript.utilities.bukkit.nbt;
 
 import com.fasterxml.jackson.annotation.JacksonInject;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import de.tr7zw.changeme.nbtapi.NBTList;
 import de.tr7zw.changeme.nbtapi.NBTType;
 import me.wolfyscript.utilities.util.NamespacedKey;
 
@@ -15,4 +16,12 @@ public class QueryNodeListFloat extends QueryNodeList<Float> {
         super(TYPE, elements, key, path, NBTType.NBTTagByte, Float.class);
     }
 
+    public QueryNodeListFloat(QueryNodeList<Float> other) {
+        super(other);
+    }
+
+    @Override
+    public QueryNodeListFloat copy() {
+        return new QueryNodeListFloat(this);
+    }
 }

--- a/core/src/main/java/com/wolfyscript/utilities/bukkit/nbt/QueryNodeListInt.java
+++ b/core/src/main/java/com/wolfyscript/utilities/bukkit/nbt/QueryNodeListInt.java
@@ -1,0 +1,18 @@
+package com.wolfyscript.utilities.bukkit.nbt;
+
+import com.fasterxml.jackson.annotation.JacksonInject;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import de.tr7zw.changeme.nbtapi.NBTType;
+import me.wolfyscript.utilities.util.NamespacedKey;
+
+import java.util.List;
+
+public class QueryNodeListInt extends QueryNodeList<Integer> {
+
+    public static final NamespacedKey TYPE = NamespacedKey.wolfyutilties("list/int");
+
+    public QueryNodeListInt(@JsonProperty("elements") List<Element<Integer>> elements, @JacksonInject("key") String key, @JacksonInject("parent_path") String path) {
+        super(TYPE, elements, key, path, NBTType.NBTTagByte, Integer.class);
+    }
+
+}

--- a/core/src/main/java/com/wolfyscript/utilities/bukkit/nbt/QueryNodeListInt.java
+++ b/core/src/main/java/com/wolfyscript/utilities/bukkit/nbt/QueryNodeListInt.java
@@ -2,6 +2,7 @@ package com.wolfyscript.utilities.bukkit.nbt;
 
 import com.fasterxml.jackson.annotation.JacksonInject;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import de.tr7zw.changeme.nbtapi.NBTList;
 import de.tr7zw.changeme.nbtapi.NBTType;
 import me.wolfyscript.utilities.util.NamespacedKey;
 
@@ -15,4 +16,12 @@ public class QueryNodeListInt extends QueryNodeList<Integer> {
         super(TYPE, elements, key, path, NBTType.NBTTagByte, Integer.class);
     }
 
+    public QueryNodeListInt(QueryNodeList<Integer> other) {
+        super(other);
+    }
+
+    @Override
+    public QueryNodeListInt copy() {
+        return new QueryNodeListInt(this);
+    }
 }

--- a/core/src/main/java/com/wolfyscript/utilities/bukkit/nbt/QueryNodeListLong.java
+++ b/core/src/main/java/com/wolfyscript/utilities/bukkit/nbt/QueryNodeListLong.java
@@ -1,0 +1,18 @@
+package com.wolfyscript.utilities.bukkit.nbt;
+
+import com.fasterxml.jackson.annotation.JacksonInject;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import de.tr7zw.changeme.nbtapi.NBTType;
+import me.wolfyscript.utilities.util.NamespacedKey;
+
+import java.util.List;
+
+public class QueryNodeListLong extends QueryNodeList<Long> {
+
+    public static final NamespacedKey TYPE = NamespacedKey.wolfyutilties("list/long");
+
+    public QueryNodeListLong(@JsonProperty("elements") List<Element<Long>> elements, @JacksonInject("key") String key, @JacksonInject("parent_path") String path) {
+        super(TYPE, elements, key, path, NBTType.NBTTagByte, Long.class);
+    }
+
+}

--- a/core/src/main/java/com/wolfyscript/utilities/bukkit/nbt/QueryNodeListLong.java
+++ b/core/src/main/java/com/wolfyscript/utilities/bukkit/nbt/QueryNodeListLong.java
@@ -2,6 +2,7 @@ package com.wolfyscript.utilities.bukkit.nbt;
 
 import com.fasterxml.jackson.annotation.JacksonInject;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import de.tr7zw.changeme.nbtapi.NBTList;
 import de.tr7zw.changeme.nbtapi.NBTType;
 import me.wolfyscript.utilities.util.NamespacedKey;
 
@@ -15,4 +16,12 @@ public class QueryNodeListLong extends QueryNodeList<Long> {
         super(TYPE, elements, key, path, NBTType.NBTTagByte, Long.class);
     }
 
+    public QueryNodeListLong(QueryNodeList<Long> other) {
+        super(other);
+    }
+
+    @Override
+    public QueryNodeListLong copy() {
+        return new QueryNodeListLong(this);
+    }
 }

--- a/core/src/main/java/com/wolfyscript/utilities/bukkit/nbt/QueryNodeListString.java
+++ b/core/src/main/java/com/wolfyscript/utilities/bukkit/nbt/QueryNodeListString.java
@@ -2,6 +2,7 @@ package com.wolfyscript.utilities.bukkit.nbt;
 
 import com.fasterxml.jackson.annotation.JacksonInject;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import de.tr7zw.changeme.nbtapi.NBTList;
 import de.tr7zw.changeme.nbtapi.NBTType;
 import me.wolfyscript.utilities.util.NamespacedKey;
 
@@ -15,4 +16,12 @@ public class QueryNodeListString extends QueryNodeList<String> {
         super(TYPE, elements, key, path, NBTType.NBTTagByte, String.class);
     }
 
+    public QueryNodeListString(QueryNodeList<String> other) {
+        super(other);
+    }
+
+    @Override
+    public QueryNodeListString copy() {
+        return new QueryNodeListString(this);
+    }
 }

--- a/core/src/main/java/com/wolfyscript/utilities/bukkit/nbt/QueryNodeListString.java
+++ b/core/src/main/java/com/wolfyscript/utilities/bukkit/nbt/QueryNodeListString.java
@@ -1,0 +1,18 @@
+package com.wolfyscript.utilities.bukkit.nbt;
+
+import com.fasterxml.jackson.annotation.JacksonInject;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import de.tr7zw.changeme.nbtapi.NBTType;
+import me.wolfyscript.utilities.util.NamespacedKey;
+
+import java.util.List;
+
+public class QueryNodeListString extends QueryNodeList<String> {
+
+    public static final NamespacedKey TYPE = NamespacedKey.wolfyutilties("list/string");
+
+    public QueryNodeListString(@JsonProperty("elements") List<Element<String>> elements, @JacksonInject("key") String key, @JacksonInject("parent_path") String path) {
+        super(TYPE, elements, key, path, NBTType.NBTTagByte, String.class);
+    }
+
+}

--- a/core/src/main/java/com/wolfyscript/utilities/bukkit/nbt/QueryNodeLong.java
+++ b/core/src/main/java/com/wolfyscript/utilities/bukkit/nbt/QueryNodeLong.java
@@ -1,9 +1,11 @@
 package com.wolfyscript.utilities.bukkit.nbt;
 
+import com.fasterxml.jackson.annotation.JacksonInject;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.JsonNode;
 import de.tr7zw.changeme.nbtapi.NBTCompound;
+import de.tr7zw.changeme.nbtapi.NBTType;
 import me.wolfyscript.utilities.util.NamespacedKey;
 
 import java.util.Optional;
@@ -13,8 +15,9 @@ public class QueryNodeLong extends QueryNodePrimitive<Long> {
     public static final NamespacedKey TYPE = NamespacedKey.wolfyutilties("long");
 
     @JsonCreator
-    public QueryNodeLong(@JsonProperty("value") JsonNode valueNode, String key, String parentPath) {
+    public QueryNodeLong(@JsonProperty("value") JsonNode valueNode, @JacksonInject("key") String key, @JacksonInject("parent_path") String parentPath) {
         super(TYPE, valueNode.isTextual() ? Long.parseLong(valueNode.asText().replaceAll("[lL]", "")) : valueNode.numberValue().longValue(), key, parentPath);
+        this.nbtType = NBTType.NBTTagLong;
     }
 
     @Override

--- a/core/src/main/java/com/wolfyscript/utilities/bukkit/nbt/QueryNodeLong.java
+++ b/core/src/main/java/com/wolfyscript/utilities/bukkit/nbt/QueryNodeLong.java
@@ -1,0 +1,30 @@
+package com.wolfyscript.utilities.bukkit.nbt;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.JsonNode;
+import de.tr7zw.changeme.nbtapi.NBTCompound;
+import me.wolfyscript.utilities.util.NamespacedKey;
+
+import java.util.Optional;
+
+public class QueryNodeLong extends QueryNodePrimitive<Long> {
+
+    public static final NamespacedKey TYPE = NamespacedKey.wolfyutilties("long");
+
+    @JsonCreator
+    public QueryNodeLong(@JsonProperty("value") JsonNode valueNode, String key, String parentPath) {
+        super(TYPE, valueNode.isTextual() ? Long.parseLong(valueNode.asText().replaceAll("[lL]", "")) : valueNode.numberValue().longValue(), key, parentPath);
+    }
+
+    @Override
+    protected Optional<Long> readValue(String path, String key, NBTCompound parent) {
+        return Optional.ofNullable(parent.getLong(key));
+    }
+
+    @Override
+    protected void applyValue(String path, String key, Long value, NBTCompound resultContainer) {
+        resultContainer.setLong(key, value);
+    }
+
+}

--- a/core/src/main/java/com/wolfyscript/utilities/bukkit/nbt/QueryNodeLong.java
+++ b/core/src/main/java/com/wolfyscript/utilities/bukkit/nbt/QueryNodeLong.java
@@ -20,6 +20,10 @@ public class QueryNodeLong extends QueryNodePrimitive<Long> {
         this.nbtType = NBTType.NBTTagLong;
     }
 
+    public QueryNodeLong(QueryNodePrimitive<Long> other) {
+        super(other);
+    }
+
     @Override
     protected Optional<Long> readValue(String path, String key, NBTCompound parent) {
         return Optional.ofNullable(parent.getLong(key));
@@ -28,6 +32,11 @@ public class QueryNodeLong extends QueryNodePrimitive<Long> {
     @Override
     protected void applyValue(String path, String key, Long value, NBTCompound resultContainer) {
         resultContainer.setLong(key, value);
+    }
+
+    @Override
+    public QueryNodeLong copy() {
+        return new QueryNodeLong(this);
     }
 
 }

--- a/core/src/main/java/com/wolfyscript/utilities/bukkit/nbt/QueryNodeObject.java
+++ b/core/src/main/java/com/wolfyscript/utilities/bukkit/nbt/QueryNodeObject.java
@@ -23,31 +23,92 @@
 package com.wolfyscript.utilities.bukkit.nbt;
 
 import com.fasterxml.jackson.annotation.JacksonInject;
+import com.fasterxml.jackson.annotation.JsonAnyGetter;
 import com.fasterxml.jackson.annotation.JsonAnySetter;
 import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonGetter;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonSetter;
+import com.fasterxml.jackson.databind.JsonNode;
 import de.tr7zw.changeme.nbtapi.NBTCompound;
 import de.tr7zw.changeme.nbtapi.NBTType;
 import me.wolfyscript.utilities.util.NamespacedKey;
 
+import java.util.List;
 import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
 
-public class QueryNodeObject extends QueryNode {
+public class QueryNodeObject extends QueryNode<NBTCompound> {
 
     public static final NamespacedKey ID = NamespacedKey.wolfyutilties("object");
 
+    //If include is true it includes this node with each and every child node.
+    private boolean include = false;
+    //If includes has values it includes this node with the specified child nodes.
+    private Map<String, Boolean> includes;
+    //Checks and verifies the child nodes. This node is only included if all the child nodes are valid.
+    private Map<String, QueryNode<?>> requiredChildNodes;
+    //Child nodes to proceed to next. This is useful for further child compound tag settings.
+    @JsonIgnore
+    private Map<String, QueryNode<?>> subNodes;
+
     @JsonCreator
-    public QueryNodeObject(@JacksonInject("key") String key, @JacksonInject("path") String parentPath) {
+    public QueryNodeObject(JsonNode jsonNode, @JacksonInject("key") String key, @JacksonInject("path") String parentPath) {
         super(ID, key, parentPath);
-        this.type = NBTType.NBTTagCompound;
+        this.nbtType = NBTType.NBTTagCompound;
+
     }
 
     @JsonAnySetter
-    public void setSubNodes(Map<String, QueryNode> subNodes) {
+    public void setSubNodes(Map<String, QueryNode<?>> subNodes) {
+        this.subNodes = subNodes;
+    }
 
+    @JsonAnyGetter
+    public Map<String, QueryNode<?>> getSubNodes() {
+        return subNodes;
+    }
+
+    @JsonSetter("required")
+    public void setRequiredChildNodes(Map<String, QueryNode<?>> requiredChildNodes) {
+        this.requiredChildNodes = requiredChildNodes;
+    }
+
+    @JsonGetter("required")
+    public Map<String, QueryNode<?>> getRequiredChildNodes() {
+        return requiredChildNodes;
     }
 
     @Override
     public boolean check(String key, NBTType type, NBTCompound parent) {
         return false;
     }
+
+    @Override
+    protected Optional<NBTCompound> readValue(String key, NBTCompound parent) {
+        return Optional.ofNullable(parent.getCompound(key));
+    }
+
+    @Override
+    public NBTCompound visit(String path, String key, NBTCompound value) {
+        Set<String> keys;
+        if (!include && includes.isEmpty()) {
+            keys = value.getKeys().stream().filter(s -> includes.get(s)).collect(Collectors.toSet());
+            //Nothing to include proceed to children
+
+            return null;
+        } else {
+            keys = value.getKeys();
+        }
+        for (String childKey : keys) {
+            NBTType nbtType = value.getType(childKey);
+
+
+
+        }
+        return null;
+    }
+
 }

--- a/core/src/main/java/com/wolfyscript/utilities/bukkit/nbt/QueryNodeObject.java
+++ b/core/src/main/java/com/wolfyscript/utilities/bukkit/nbt/QueryNodeObject.java
@@ -1,0 +1,53 @@
+/*
+ *       ____ _  _ ____ ___ ____ _  _ ____ ____ ____ ____ ___ _ _  _ ____
+ *       |    |  | [__   |  |  | |\/| |    |__/ |__| |___  |  | |\ | | __
+ *       |___ |__| ___]  |  |__| |  | |___ |  \ |  | |     |  | | \| |__]
+ *
+ *       CustomCrafting Recipe creation and management tool for Minecraft
+ *                      Copyright (C) 2021  WolfyScript
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package com.wolfyscript.utilities.bukkit.nbt;
+
+import com.fasterxml.jackson.annotation.JacksonInject;
+import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import de.tr7zw.changeme.nbtapi.NBTCompound;
+import de.tr7zw.changeme.nbtapi.NBTType;
+import me.wolfyscript.utilities.util.NamespacedKey;
+
+import java.util.Map;
+
+public class QueryNodeObject extends QueryNode {
+
+    public static final NamespacedKey ID = NamespacedKey.wolfyutilties("object");
+
+    @JsonCreator
+    public QueryNodeObject(@JacksonInject("key") String key, @JacksonInject("path") String parentPath) {
+        super(ID, key, parentPath);
+        this.type = NBTType.NBTTagCompound;
+    }
+
+    @JsonAnySetter
+    public void setSubNodes(Map<String, QueryNode> subNodes) {
+
+    }
+
+    @Override
+    public boolean check(String key, NBTType type, NBTCompound parent) {
+        return false;
+    }
+}

--- a/core/src/main/java/com/wolfyscript/utilities/bukkit/nbt/QueryNodeObject.java
+++ b/core/src/main/java/com/wolfyscript/utilities/bukkit/nbt/QueryNodeObject.java
@@ -94,17 +94,19 @@ public class QueryNodeObject extends QueryNode<NBTCompound> {
     @Override
     public NBTCompound visit(String path, String key, NBTCompound value) {
         Set<String> keys;
+        String newPath = path + "." + key;
         if (!include && includes.isEmpty()) {
             keys = value.getKeys().stream().filter(s -> includes.get(s)).collect(Collectors.toSet());
             //Nothing to include proceed to children
-
-            return null;
         } else {
             keys = value.getKeys();
         }
+        //Process child nodes with the specified settings.
         for (String childKey : keys) {
-            NBTType nbtType = value.getType(childKey);
-
+            QueryNode<?> subQueryNode = getSubNodes().get(childKey);
+            if (subQueryNode != null) {
+                subQueryNode.visit(newPath, childKey, value);
+            }
 
 
         }

--- a/core/src/main/java/com/wolfyscript/utilities/bukkit/nbt/QueryNodePrimitive.java
+++ b/core/src/main/java/com/wolfyscript/utilities/bukkit/nbt/QueryNodePrimitive.java
@@ -42,6 +42,12 @@ public abstract class QueryNodePrimitive<VAL> extends QueryNode<VAL> {
         this.value = value;
     }
 
+    protected QueryNodePrimitive(QueryNodePrimitive<VAL> other) {
+        super(other.type, other.key, other.parentPath);
+        this.nbtType = other.nbtType;
+        this.value = other.value;
+    }
+
     @Override
     public boolean check(String key, NBTType nbtType, VAL value) {
         return Objects.equals(this.value, value);

--- a/core/src/main/java/com/wolfyscript/utilities/bukkit/nbt/QueryNodePrimitive.java
+++ b/core/src/main/java/com/wolfyscript/utilities/bukkit/nbt/QueryNodePrimitive.java
@@ -28,7 +28,9 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import de.tr7zw.changeme.nbtapi.NBTCompound;
 import de.tr7zw.changeme.nbtapi.NBTType;
 import me.wolfyscript.utilities.util.NamespacedKey;
+import me.wolfyscript.utilities.util.json.jackson.annotations.KeyedBaseType;
 
+@KeyedBaseType(baseType = QueryNode.class)
 public abstract class QueryNodePrimitive<VAL> extends QueryNode<VAL> {
 
     protected final VAL value;

--- a/core/src/main/java/com/wolfyscript/utilities/bukkit/nbt/QueryNodePrimitive.java
+++ b/core/src/main/java/com/wolfyscript/utilities/bukkit/nbt/QueryNodePrimitive.java
@@ -25,74 +25,22 @@ package com.wolfyscript.utilities.bukkit.nbt;
 
 import com.fasterxml.jackson.annotation.JacksonInject;
 import com.fasterxml.jackson.annotation.JsonCreator;
-import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.databind.JsonNode;
-import com.google.common.base.Preconditions;
 import de.tr7zw.changeme.nbtapi.NBTCompound;
 import de.tr7zw.changeme.nbtapi.NBTType;
 import me.wolfyscript.utilities.util.NamespacedKey;
 
-import java.util.Objects;
+public abstract class QueryNodePrimitive<VAL> extends QueryNode<VAL> {
 
-public abstract class QueryNodePrimitive extends QueryNode {
-
-    public static final NamespacedKey ID = NamespacedKey.wolfyutilties("primitive");
-    private Object value = null;
+    protected final VAL value;
 
     @JsonCreator
-    public QueryNodePrimitive(@JsonProperty("value") JsonNode valueNode, @JacksonInject("key") String key, @JacksonInject("path") String parentPath) {
-        super(ID, key, parentPath);
-        if (valueNode.isTextual()) {
-            var text = valueNode.asText();
-            if (!text.isBlank()) {
-                char identifier = text.charAt(text.length() - 1);
-                String value = text.substring(0, text.length() - 1);
-                switch (identifier) {
-                    case 'b', 'B' -> {
-                        this.value = Byte.parseByte(value);
-                        this.nbtType = NBTType.NBTTagByte;
-                    }
-                    case 's', 'S' -> {
-                        this.value = Short.parseShort(value);
-                        this.nbtType = NBTType.NBTTagShort;
-                    }
-                    case 'i', 'I' -> {
-                        this.value = Integer.parseInt(value);
-                        this.nbtType = NBTType.NBTTagInt;
-                    }
-                    case 'l', 'L' -> {
-                        this.value = Long.parseLong(value);
-                        this.nbtType = NBTType.NBTTagLong;
-                    }
-                    case 'f', 'F' -> {
-                        this.value = Float.parseFloat(value);
-                        this.nbtType = NBTType.NBTTagFloat;
-                    }
-                    case 'd', 'D' -> {
-                        this.value = Double.parseDouble(value);
-                        this.nbtType = NBTType.NBTTagDouble;
-                    }
-                    default -> {
-                        this.value = value;
-                        this.nbtType = NBTType.NBTTagString;
-                    }
-                }
-            }
-        } else if (valueNode.isInt()) {
-            this.value = valueNode.asInt(0);
-            this.nbtType = NBTType.NBTTagInt;
-        } else if (valueNode.isDouble()) {
-            this.value = valueNode.asDouble(0d);
-            this.nbtType = NBTType.NBTTagDouble;
-        }
-        Preconditions.checkArgument(!this.nbtType.equals(NBTType.NBTTagEnd), "Error parsing primitive query node!");
+    protected QueryNodePrimitive(NamespacedKey type, VAL value, @JacksonInject("key") String key, @JacksonInject("path") String parentPath) {
+        super(type, key, parentPath);
+        this.value = value;
     }
 
     @Override
     public boolean check(String key, NBTType type, NBTCompound parent) {
-        if (this.key.equals(key) && this.nbtType.equals(type)) {
-            return Objects.equals(this.value, parent.getObject(key, value.getClass()));
-        }
-        return false;
+        return this.key.equals(key) && this.nbtType.equals(type);
     }
 }

--- a/core/src/main/java/com/wolfyscript/utilities/bukkit/nbt/QueryNodePrimitive.java
+++ b/core/src/main/java/com/wolfyscript/utilities/bukkit/nbt/QueryNodePrimitive.java
@@ -25,10 +25,11 @@ package com.wolfyscript.utilities.bukkit.nbt;
 
 import com.fasterxml.jackson.annotation.JacksonInject;
 import com.fasterxml.jackson.annotation.JsonCreator;
-import de.tr7zw.changeme.nbtapi.NBTCompound;
 import de.tr7zw.changeme.nbtapi.NBTType;
 import me.wolfyscript.utilities.util.NamespacedKey;
 import me.wolfyscript.utilities.util.json.jackson.annotations.KeyedBaseType;
+
+import java.util.Objects;
 
 @KeyedBaseType(baseType = QueryNode.class)
 public abstract class QueryNodePrimitive<VAL> extends QueryNode<VAL> {
@@ -42,7 +43,7 @@ public abstract class QueryNodePrimitive<VAL> extends QueryNode<VAL> {
     }
 
     @Override
-    public boolean check(String key, NBTType type, NBTCompound parent) {
-        return this.key.equals(key) && this.nbtType.equals(type);
+    public boolean check(String key, NBTType nbtType, VAL value) {
+        return Objects.equals(this.value, value);
     }
 }

--- a/core/src/main/java/com/wolfyscript/utilities/bukkit/nbt/QueryNodePrimitive.java
+++ b/core/src/main/java/com/wolfyscript/utilities/bukkit/nbt/QueryNodePrimitive.java
@@ -50,47 +50,47 @@ public abstract class QueryNodePrimitive extends QueryNode {
                 switch (identifier) {
                     case 'b', 'B' -> {
                         this.value = Byte.parseByte(value);
-                        this.type = NBTType.NBTTagByte;
+                        this.nbtType = NBTType.NBTTagByte;
                     }
                     case 's', 'S' -> {
                         this.value = Short.parseShort(value);
-                        this.type = NBTType.NBTTagShort;
+                        this.nbtType = NBTType.NBTTagShort;
                     }
                     case 'i', 'I' -> {
                         this.value = Integer.parseInt(value);
-                        this.type = NBTType.NBTTagInt;
+                        this.nbtType = NBTType.NBTTagInt;
                     }
                     case 'l', 'L' -> {
                         this.value = Long.parseLong(value);
-                        this.type = NBTType.NBTTagLong;
+                        this.nbtType = NBTType.NBTTagLong;
                     }
                     case 'f', 'F' -> {
                         this.value = Float.parseFloat(value);
-                        this.type = NBTType.NBTTagFloat;
+                        this.nbtType = NBTType.NBTTagFloat;
                     }
                     case 'd', 'D' -> {
                         this.value = Double.parseDouble(value);
-                        this.type = NBTType.NBTTagDouble;
+                        this.nbtType = NBTType.NBTTagDouble;
                     }
                     default -> {
                         this.value = value;
-                        this.type = NBTType.NBTTagString;
+                        this.nbtType = NBTType.NBTTagString;
                     }
                 }
             }
         } else if (valueNode.isInt()) {
             this.value = valueNode.asInt(0);
-            this.type = NBTType.NBTTagInt;
+            this.nbtType = NBTType.NBTTagInt;
         } else if (valueNode.isDouble()) {
             this.value = valueNode.asDouble(0d);
-            this.type = NBTType.NBTTagDouble;
+            this.nbtType = NBTType.NBTTagDouble;
         }
-        Preconditions.checkArgument(!this.type.equals(NBTType.NBTTagEnd), "Error parsing primitive query node!");
+        Preconditions.checkArgument(!this.nbtType.equals(NBTType.NBTTagEnd), "Error parsing primitive query node!");
     }
 
     @Override
     public boolean check(String key, NBTType type, NBTCompound parent) {
-        if (this.key.equals(key) && this.type.equals(type)) {
+        if (this.key.equals(key) && this.nbtType.equals(type)) {
             return Objects.equals(this.value, parent.getObject(key, value.getClass()));
         }
         return false;

--- a/core/src/main/java/com/wolfyscript/utilities/bukkit/nbt/QueryNodePrimitive.java
+++ b/core/src/main/java/com/wolfyscript/utilities/bukkit/nbt/QueryNodePrimitive.java
@@ -1,0 +1,98 @@
+/*
+ *       ____ _  _ ____ ___ ____ _  _ ____ ____ ____ ____ ___ _ _  _ ____
+ *       |    |  | [__   |  |  | |\/| |    |__/ |__| |___  |  | |\ | | __
+ *       |___ |__| ___]  |  |__| |  | |___ |  \ |  | |     |  | | \| |__]
+ *
+ *       CustomCrafting Recipe creation and management tool for Minecraft
+ *                      Copyright (C) 2021  WolfyScript
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package com.wolfyscript.utilities.bukkit.nbt;
+
+
+import com.fasterxml.jackson.annotation.JacksonInject;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.google.common.base.Preconditions;
+import de.tr7zw.changeme.nbtapi.NBTCompound;
+import de.tr7zw.changeme.nbtapi.NBTType;
+import me.wolfyscript.utilities.util.NamespacedKey;
+
+import java.util.Objects;
+
+public class QueryNodePrimitive extends QueryNode {
+
+    public static final NamespacedKey ID = NamespacedKey.wolfyutilties("primitive");
+    private Object value = null;
+
+    @JsonCreator
+    public QueryNodePrimitive(@JsonProperty("value") JsonNode valueNode, @JacksonInject("key") String key, @JacksonInject("path") String parentPath) {
+        super(ID, key, parentPath);
+        if (valueNode.isTextual()) {
+            var text = valueNode.asText();
+            if (!text.isBlank()) {
+                char identifier = text.charAt(text.length() - 1);
+                String value = text.substring(0, text.length() - 1);
+                switch (identifier) {
+                    case 'b', 'B' -> {
+                        this.value = Byte.parseByte(value);
+                        this.type = NBTType.NBTTagByte;
+                    }
+                    case 's', 'S' -> {
+                        this.value = Short.parseShort(value);
+                        this.type = NBTType.NBTTagShort;
+                    }
+                    case 'i', 'I' -> {
+                        this.value = Integer.parseInt(value);
+                        this.type = NBTType.NBTTagInt;
+                    }
+                    case 'l', 'L' -> {
+                        this.value = Long.parseLong(value);
+                        this.type = NBTType.NBTTagLong;
+                    }
+                    case 'f', 'F' -> {
+                        this.value = Float.parseFloat(value);
+                        this.type = NBTType.NBTTagFloat;
+                    }
+                    case 'd', 'D' -> {
+                        this.value = Double.parseDouble(value);
+                        this.type = NBTType.NBTTagDouble;
+                    }
+                    default -> {
+                        this.value = value;
+                        this.type = NBTType.NBTTagString;
+                    }
+                }
+            }
+        } else if (valueNode.isInt()) {
+            this.value = valueNode.asInt(0);
+            this.type = NBTType.NBTTagInt;
+        } else if (valueNode.isDouble()) {
+            this.value = valueNode.asDouble(0d);
+            this.type = NBTType.NBTTagDouble;
+        }
+        Preconditions.checkArgument(!this.type.equals(NBTType.NBTTagEnd), "Error parsing primitive query node!");
+    }
+
+    @Override
+    public boolean check(String key, NBTType type, NBTCompound parent) {
+        if (this.key.equals(key) && this.type.equals(type)) {
+            return Objects.equals(this.value, parent.getObject(key, value.getClass()));
+        }
+        return false;
+    }
+}

--- a/core/src/main/java/com/wolfyscript/utilities/bukkit/nbt/QueryNodePrimitive.java
+++ b/core/src/main/java/com/wolfyscript/utilities/bukkit/nbt/QueryNodePrimitive.java
@@ -34,7 +34,7 @@ import me.wolfyscript.utilities.util.NamespacedKey;
 
 import java.util.Objects;
 
-public class QueryNodePrimitive extends QueryNode {
+public abstract class QueryNodePrimitive extends QueryNode {
 
     public static final NamespacedKey ID = NamespacedKey.wolfyutilties("primitive");
     private Object value = null;

--- a/core/src/main/java/com/wolfyscript/utilities/bukkit/nbt/QueryNodeShort.java
+++ b/core/src/main/java/com/wolfyscript/utilities/bukkit/nbt/QueryNodeShort.java
@@ -1,0 +1,30 @@
+package com.wolfyscript.utilities.bukkit.nbt;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.JsonNode;
+import de.tr7zw.changeme.nbtapi.NBTCompound;
+import me.wolfyscript.utilities.util.NamespacedKey;
+
+import java.util.Optional;
+
+public class QueryNodeShort extends QueryNodePrimitive<Short> {
+
+    public static final NamespacedKey TYPE = NamespacedKey.wolfyutilties("short");
+
+    @JsonCreator
+    public QueryNodeShort(@JsonProperty("value") JsonNode valueNode, String key, String parentPath) {
+        super(TYPE, valueNode.isTextual() ? Short.parseShort(valueNode.asText().replaceAll("[sS]", "")) : valueNode.numberValue().shortValue(), key, parentPath);
+    }
+
+    @Override
+    protected Optional<Short> readValue(String path, String key, NBTCompound parent) {
+        return Optional.ofNullable(parent.getShort(key));
+    }
+
+    @Override
+    protected void applyValue(String path, String key, Short value, NBTCompound resultContainer) {
+        resultContainer.setShort(key, value);
+    }
+
+}

--- a/core/src/main/java/com/wolfyscript/utilities/bukkit/nbt/QueryNodeShort.java
+++ b/core/src/main/java/com/wolfyscript/utilities/bukkit/nbt/QueryNodeShort.java
@@ -20,6 +20,10 @@ public class QueryNodeShort extends QueryNodePrimitive<Short> {
         this.nbtType = NBTType.NBTTagShort;
     }
 
+    public QueryNodeShort(QueryNodePrimitive<Short> other) {
+        super(other);
+    }
+
     @Override
     protected Optional<Short> readValue(String path, String key, NBTCompound parent) {
         return Optional.ofNullable(parent.getShort(key));
@@ -28,6 +32,11 @@ public class QueryNodeShort extends QueryNodePrimitive<Short> {
     @Override
     protected void applyValue(String path, String key, Short value, NBTCompound resultContainer) {
         resultContainer.setShort(key, value);
+    }
+
+    @Override
+    public QueryNodeShort copy() {
+        return new QueryNodeShort(this);
     }
 
 }

--- a/core/src/main/java/com/wolfyscript/utilities/bukkit/nbt/QueryNodeShort.java
+++ b/core/src/main/java/com/wolfyscript/utilities/bukkit/nbt/QueryNodeShort.java
@@ -1,9 +1,11 @@
 package com.wolfyscript.utilities.bukkit.nbt;
 
+import com.fasterxml.jackson.annotation.JacksonInject;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.JsonNode;
 import de.tr7zw.changeme.nbtapi.NBTCompound;
+import de.tr7zw.changeme.nbtapi.NBTType;
 import me.wolfyscript.utilities.util.NamespacedKey;
 
 import java.util.Optional;
@@ -13,8 +15,9 @@ public class QueryNodeShort extends QueryNodePrimitive<Short> {
     public static final NamespacedKey TYPE = NamespacedKey.wolfyutilties("short");
 
     @JsonCreator
-    public QueryNodeShort(@JsonProperty("value") JsonNode valueNode, String key, String parentPath) {
+    public QueryNodeShort(@JsonProperty("value") JsonNode valueNode, @JacksonInject("key") String key, @JacksonInject("parent_path") String parentPath) {
         super(TYPE, valueNode.isTextual() ? Short.parseShort(valueNode.asText().replaceAll("[sS]", "")) : valueNode.numberValue().shortValue(), key, parentPath);
+        this.nbtType = NBTType.NBTTagShort;
     }
 
     @Override

--- a/core/src/main/java/com/wolfyscript/utilities/bukkit/nbt/QueryNodeString.java
+++ b/core/src/main/java/com/wolfyscript/utilities/bukkit/nbt/QueryNodeString.java
@@ -20,6 +20,10 @@ public class QueryNodeString extends QueryNodePrimitive<String> {
         this.nbtType = NBTType.NBTTagString;
     }
 
+    public QueryNodeString(QueryNodePrimitive<String> other) {
+        super(other);
+    }
+
     @Override
     protected Optional<String> readValue(String path, String key, NBTCompound parent) {
         return Optional.ofNullable(parent.getString(key));
@@ -28,6 +32,11 @@ public class QueryNodeString extends QueryNodePrimitive<String> {
     @Override
     protected void applyValue(String path, String key, String value, NBTCompound resultContainer) {
         resultContainer.setString(key, value);
+    }
+
+    @Override
+    public QueryNodeString copy() {
+        return new QueryNodeString(this);
     }
 
 }

--- a/core/src/main/java/com/wolfyscript/utilities/bukkit/nbt/QueryNodeString.java
+++ b/core/src/main/java/com/wolfyscript/utilities/bukkit/nbt/QueryNodeString.java
@@ -1,0 +1,30 @@
+package com.wolfyscript.utilities.bukkit.nbt;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.JsonNode;
+import de.tr7zw.changeme.nbtapi.NBTCompound;
+import me.wolfyscript.utilities.util.NamespacedKey;
+
+import java.util.Optional;
+
+public class QueryNodeString extends QueryNodePrimitive<String> {
+
+    public static final NamespacedKey TYPE = NamespacedKey.wolfyutilties("string");
+
+    @JsonCreator
+    public QueryNodeString(@JsonProperty("value") JsonNode valueNode, String key, String parentPath) {
+        super(TYPE, valueNode.asText(), key, parentPath);
+    }
+
+    @Override
+    protected Optional<String> readValue(String path, String key, NBTCompound parent) {
+        return Optional.ofNullable(parent.getString(key));
+    }
+
+    @Override
+    protected void applyValue(String path, String key, String value, NBTCompound resultContainer) {
+        resultContainer.setString(key, value);
+    }
+
+}

--- a/core/src/main/java/com/wolfyscript/utilities/bukkit/nbt/QueryNodeString.java
+++ b/core/src/main/java/com/wolfyscript/utilities/bukkit/nbt/QueryNodeString.java
@@ -1,9 +1,11 @@
 package com.wolfyscript.utilities.bukkit.nbt;
 
+import com.fasterxml.jackson.annotation.JacksonInject;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.JsonNode;
 import de.tr7zw.changeme.nbtapi.NBTCompound;
+import de.tr7zw.changeme.nbtapi.NBTType;
 import me.wolfyscript.utilities.util.NamespacedKey;
 
 import java.util.Optional;
@@ -13,8 +15,9 @@ public class QueryNodeString extends QueryNodePrimitive<String> {
     public static final NamespacedKey TYPE = NamespacedKey.wolfyutilties("string");
 
     @JsonCreator
-    public QueryNodeString(@JsonProperty("value") JsonNode valueNode, String key, String parentPath) {
+    public QueryNodeString(@JsonProperty("value") JsonNode valueNode, @JacksonInject("key") String key, @JacksonInject("parent_path") String parentPath) {
         super(TYPE, valueNode.asText(), key, parentPath);
+        this.nbtType = NBTType.NBTTagString;
     }
 
     @Override

--- a/core/src/main/java/me/wolfyscript/utilities/registry/Registries.java
+++ b/core/src/main/java/me/wolfyscript/utilities/registry/Registries.java
@@ -87,7 +87,7 @@ public class Registries {
     private final TypeRegistry<ValueProvider<?>> valueProviders;
     private final TypeRegistry<Operator> operators;
 
-    private final TypeRegistry<QueryNode> nbtQueryNodes;
+    private final TypeRegistry<QueryNode<?>> nbtQueryNodes;
 
     public Registries(WolfyUtilCore core) {
         this.core = core;
@@ -248,5 +248,9 @@ public class Registries {
 
     public TypeRegistry<Operator> getOperators() {
         return operators;
+    }
+
+    public TypeRegistry<QueryNode<?>> getNbtQueryNodes() {
+        return nbtQueryNodes;
     }
 }

--- a/core/src/main/java/me/wolfyscript/utilities/registry/Registries.java
+++ b/core/src/main/java/me/wolfyscript/utilities/registry/Registries.java
@@ -19,6 +19,7 @@
 package me.wolfyscript.utilities.registry;
 
 import com.google.common.base.Preconditions;
+import com.wolfyscript.utilities.bukkit.nbt.QueryNode;
 import me.wolfyscript.utilities.api.WolfyUtilCore;
 import me.wolfyscript.utilities.api.WolfyUtilities;
 import me.wolfyscript.utilities.api.inventory.custom_items.CustomData;
@@ -86,6 +87,8 @@ public class Registries {
     private final TypeRegistry<ValueProvider<?>> valueProviders;
     private final TypeRegistry<Operator> operators;
 
+    private final TypeRegistry<QueryNode> nbtQueryNodes;
+
     public Registries(WolfyUtilCore core) {
         this.core = core;
 
@@ -106,6 +109,8 @@ public class Registries {
         customItemEvents = new TypeRegistrySimple<>(ITEM_EVENT_TYPES, this);
         valueProviders = new TypeRegistrySimple<>(new NamespacedKey(core, "value_providers"), this);
         operators = new TypeRegistrySimple<>(new NamespacedKey(core, "operators"), this);
+
+        this.nbtQueryNodes = new TypeRegistrySimple<>(new NamespacedKey(core, "nbt/query/nodes"), this);
     }
 
     void indexTypedRegistry(IRegistry<?> registry) {

--- a/wolfyutils-spigot/src/main/resources/plugin.yml
+++ b/wolfyutils-spigot/src/main/resources/plugin.yml
@@ -49,3 +49,5 @@ commands:
   particle_effect:
     usage: "/particle_effect spawn"
     description: "DEBUG! Spawns a test particle effect on the target block."
+  query_item:
+    usage: "/query_item"


### PR DESCRIPTION
The NBTQuery makes it possible to fetch specified values from NBT.  

The way it works is that the NBTQuery constructs a NBTComound, of the values it was specified to fetch, and then returns it.
It is written via simple JSON and provides options to filter elements by value, index in lists, and child NBT nodes.  

To build the query and describe the desired output, you can use the following settings:
```json5
{
  /*
    NBTQuery Settings
  */
  //Primitive Settings
  //Returns the String value if it matches,
  "<key_string>": "<string_value>",
  //Returns the byte value if it matches,
  "<key_byte>": "0b/0B",
  //Returns the short value if it matches,
  "<key_short>": "0s/0S",
  //Returns the long value if it matches,
  "<key_long>": "0l/0L",
  //Returns the int value if it matches,
  "<key_int>": 100,
  "<key_int2>": "100i/100I",
  //Returns the double value if it matches,
  "<key_double>": 1.0,
  "<key_double2>": "1d/1D",
  //Returns the float value if it matches,
  "<key_float>": "1f/1F",
  "<key_primitive>": {
    "type": "string/byte/short/long/int/double/float",
    "value": "<string/byte/short/long/int/double/float>"
  },

  //Hybrid Settings (Applies to primitive, compound, and list nodes)
  //Always returns the value
  "<key>": true,
  //Never returns the value,
  "<key0>": false,

  //Compound Settings
  "<key_compound>": {
    "type": "compound",
    //Do not treat as end-node, proceed to child nodes!
    //The node is not included in the result!
    "<child_key>": "<setting>"
  },
  "<key_compound0>": {
    "type": "compound",
    "preservePath": true, //Optional: keeps the path of the parent and child nodes. Default: true
    "includesAll": false, //Optional: determines the default value for each `includes` child.
    //Optional: Only includes and computes the specified children.
    "includes": {
      "<child_key>": true, //true/false
      //If a key is not specified it will use the value from `includesAll`
    },
    //Proceed to child nodes. If "includes" is used, then it just proceeds to the included nodes!
    "children": {
      "<child_key>": "<setting>"
    },
    //Optional, child keys can be directly put into the root of the compound settings.
    "<child_key>": "<setting>"
  },

  //List Settings
  "<key_array3>": {
    "type": "list/<string/byte/short/long/int/double/float>",
    "values": [
      {
        //Optional: Returns the value at the specified index, if it matches the setting.,
        "index": 0,
        //Optional value (Empty is treated as "true" (Always include))
        "value": {
          "type": "<string/byte/short/long/int/double/float>",
          //Returns the values that match this setting,
          "value": "<setting>"
        }
      },
      //...
    ]
  },

  //Compound List Settings
  //Returns the list with the compounds as defined in the element settings
  "<key_objArray3>": {
    "type": "list/compound",
    "values": [
      {
        "index": 0,
        "value": {
          //See Compound Settings
        }
      }
    ],
  }
}
```  
Once it constructed and returned the NBTCompound it can be used in various ways, like merging it into other NBTCompounds.  