### PR TITLE
Fixed Player Head textures not applying to items

### DIFF
--- a/core/src/main/java/me/wolfyscript/utilities/util/inventory/PlayerHeadUtils.java
+++ b/core/src/main/java/me/wolfyscript/utilities/util/inventory/PlayerHeadUtils.java
@@ -46,6 +46,20 @@ public class PlayerHeadUtils {
     }
 
     /**
+     * Gets the Player Head ItemStack via a URL or Base64 encoded string.
+     * <p>This method uses the {@link ItemBuilder}!
+     *
+     * @see ItemBuilder#setPlayerHeadValue(String)
+     * @param value Skin URL or Base64 encoded value of textures object
+     * @param name The name of the skull owner
+     * @param uuid The uuid of the skull owner
+     * @return the Player Head ItemStack with the corresponding Texture
+     */
+    public static ItemStack getViaValue(String value, String name, UUID uuid) {
+        return new ItemBuilder(Material.PLAYER_HEAD).setPlayerHeadValue(value, name, uuid).create();
+    }
+
+    /**
      * Get the Player Head via URL value
      * <p>This method uses the {@link ItemBuilder}!
      *
@@ -56,6 +70,22 @@ public class PlayerHeadUtils {
      */
     public static ItemStack getViaURL(String value) {
         return new ItemBuilder(Material.PLAYER_HEAD).setPlayerHeadURL(value).create();
+    }
+
+    /**
+     * Get the Player Head via URL value
+     * <p>This method uses the {@link ItemBuilder}!
+     *
+     * @see ItemBuilder#setPlayerHeadURL(String)
+     * @param value the Base64 value at the end of the textures url.
+     *              <p>e.g. http://textures.minecraft.net/texture/{value}
+     * @param name The name of the skull owner
+     * @param uuid The uuid of the skull owner
+     *
+     * @return the Player Head ItemStack with the corresponding Texture
+     */
+    public static ItemStack getViaURL(String value, String name, UUID uuid) {
+        return new ItemBuilder(Material.PLAYER_HEAD).setPlayerHeadURL(value, name, uuid).create();
     }
 
     /**

--- a/core/src/main/java/me/wolfyscript/utilities/util/inventory/item_builder/AbstractItemBuilder.java
+++ b/core/src/main/java/me/wolfyscript/utilities/util/inventory/item_builder/AbstractItemBuilder.java
@@ -340,6 +340,13 @@ public abstract class AbstractItemBuilder<T extends AbstractItemBuilder<?>> {
         return setPlayerHeadValue("http://textures.minecraft.net/texture/" + value);
     }
 
+    public T setPlayerHeadURL(String value, String name, UUID uuid) {
+        if (value.startsWith("http://textures.minecraft.net/texture/")) {
+            return setPlayerHeadValue(value, name, uuid);
+        }
+        return setPlayerHeadValue("http://textures.minecraft.net/texture/" + value, name, uuid);
+    }
+
     public String getPlayerHeadValue() {
         if (getItemMeta() instanceof SkullMeta) {
             NBTItem nbtItem = new NBTItem(getItemStack());

--- a/core/src/main/java/me/wolfyscript/utilities/util/inventory/item_builder/AbstractItemBuilder.java
+++ b/core/src/main/java/me/wolfyscript/utilities/util/inventory/item_builder/AbstractItemBuilder.java
@@ -20,6 +20,7 @@ package me.wolfyscript.utilities.util.inventory.item_builder;
 
 import com.fasterxml.jackson.annotation.JsonAutoDetect;
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.google.common.base.Preconditions;
 import de.tr7zw.changeme.nbtapi.NBTCompound;
 import de.tr7zw.changeme.nbtapi.NBTCompoundList;
 import de.tr7zw.changeme.nbtapi.NBTItem;
@@ -360,20 +361,25 @@ public abstract class AbstractItemBuilder<T extends AbstractItemBuilder<?>> {
         return "";
     }
 
-    public T setPlayerHeadValue(String value) {
+    public T setPlayerHeadValue(String value, String name, UUID uuid) {
+        Preconditions.checkArgument(name.isEmpty(), "Name of Skull cannot be empty!");
         String textureValue = value;
         if (value.startsWith("https://") || value.startsWith("http://")) {
             textureValue = EncryptionUtils.getBase64EncodedString(String.format("{textures:{SKIN:{url:\"%s\"}}}", value));
         }
         NBTItem nbtItem = new NBTItem(getItemStack(), true);
         NBTCompound skull = nbtItem.addCompound("SkullOwner");
-        skull.setString("Name", "");
-        skull.setString("Id", UUID.randomUUID().toString());
+        skull.setString("Name", name);
+        skull.setString("Id", uuid.toString());
         // The UUID, note that skulls with the same UUID but different textures will misbehave and only one texture will load
         // (They'll share it), if skulls have different UUIDs and same textures they won't stack. See UUID.randomUUID();
         NBTListCompound texture = skull.addCompound("Properties").getCompoundList("textures").addCompound();
         texture.setString("Value",  textureValue);
         return get();
+    }
+
+    public T setPlayerHeadValue(String value) {
+        return setPlayerHeadValue(value, "none", UUID.randomUUID());
     }
 
 


### PR DESCRIPTION
This fixes the issue where the texture isn't applied to items when using the AbstractItemBuilder#setPlayerHeadValue or other related methods, caused by missing skull owner name.
Adds new methods and functions that provide an option to specify the name and uuid of the skull owner when creating the player head item stack.