### PR TITLE
HOCON Format Support

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>wolfyutils-parent</artifactId>
         <groupId>com.wolfyscript.wolfyutils.spigot</groupId>
-        <version>4.16.6-HOCON-SNAPSHOT</version>
+        <version>4.16.6-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>wolfyutils-parent</artifactId>
         <groupId>com.wolfyscript.wolfyutils.spigot</groupId>
-        <version>4.16.5.1</version>
+        <version>4.16.6-HOCON-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/core/src/main/java/com/wolfyscript/utilities/bukkit/WolfyCoreBukkit.java
+++ b/core/src/main/java/com/wolfyscript/utilities/bukkit/WolfyCoreBukkit.java
@@ -206,7 +206,7 @@ public final class WolfyCoreBukkit extends WUPlugin {
     @Deprecated
     @Override
     public WolfyUtilities getWolfyUtilities() {
-        return api;
+        return (WolfyUtilities) getWolfyUtils();
     }
 
     @Override

--- a/core/src/main/java/com/wolfyscript/utilities/bukkit/language/LangAPISpigot.java
+++ b/core/src/main/java/com/wolfyscript/utilities/bukkit/language/LangAPISpigot.java
@@ -51,7 +51,7 @@ public class LangAPISpigot extends LanguageAPI {
         injectableValues.addValue("api", api);
         injectableValues.addValue("lang", lang);
         try {
-            Language language = JacksonUtil.getObjectMapper().reader(injectableValues).readValue(file, Language.class);
+            Language language = api.getJacksonMapperUtil().getGlobalMapper().reader(injectableValues).readValue(file, Language.class);
             registerLanguage(language);
             return language;
         } catch (IOException ex) {
@@ -63,7 +63,7 @@ public class LangAPISpigot extends LanguageAPI {
 
     public void saveLangFile(@NotNull Language language) {
         try {
-            JacksonUtil.getObjectMapper().writeValue(getLangFile(language.getName()), language);
+            api.getJacksonMapperUtil().getGlobalMapper().writeValue(getLangFile(language.getName()), language);
         } catch (IOException ex) {
             getAPI().getConsole().getLogger().severe("Couldn't save language \""+language.getName()+"\"!");
             getAPI().getConsole().getLogger().throwing("LanguageAPI", "saveLangFile", ex);

--- a/core/src/main/java/com/wolfyscript/utilities/bukkit/nbt/NBTQuery.java
+++ b/core/src/main/java/com/wolfyscript/utilities/bukkit/nbt/NBTQuery.java
@@ -24,6 +24,7 @@ package com.wolfyscript.utilities.bukkit.nbt;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.wolfyscript.utilities.common.WolfyUtils;
 import de.tr7zw.changeme.nbtapi.NBTCompound;
 import de.tr7zw.changeme.nbtapi.NBTContainer;
 import me.wolfyscript.utilities.util.json.jackson.JacksonUtil;
@@ -58,6 +59,15 @@ public class NBTQuery {
     public static Optional<NBTQuery> of(File file) {
         try {
             return Optional.ofNullable(JacksonUtil.getObjectMapper().readValue(file, NBTQuery.class));
+        } catch (IOException e) {
+            e.printStackTrace();
+            return Optional.empty();
+        }
+    }
+
+    public static Optional<NBTQuery> of(File file, WolfyUtils wolfyUtils) {
+        try {
+            return Optional.ofNullable(wolfyUtils.getJacksonMapperUtil().getGlobalMapper().readValue(file, NBTQuery.class));
         } catch (IOException e) {
             e.printStackTrace();
             return Optional.empty();

--- a/core/src/main/java/com/wolfyscript/utilities/bukkit/nbt/QueryNode.java
+++ b/core/src/main/java/com/wolfyscript/utilities/bukkit/nbt/QueryNode.java
@@ -24,6 +24,7 @@ package com.wolfyscript.utilities.bukkit.nbt;
 
 import com.fasterxml.jackson.databind.InjectableValues;
 import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.wolfyscript.utilities.bukkit.WolfyCoreBukkit;
 import de.tr7zw.changeme.nbtapi.NBTCompound;
 import de.tr7zw.changeme.nbtapi.NBTList;
 import de.tr7zw.changeme.nbtapi.NBTType;
@@ -41,7 +42,6 @@ import com.fasterxml.jackson.databind.annotation.JsonTypeIdResolver;
 import com.fasterxml.jackson.databind.annotation.JsonTypeResolver;
 import me.wolfyscript.utilities.util.Keyed;
 import me.wolfyscript.utilities.util.NamespacedKey;
-import me.wolfyscript.utilities.util.json.jackson.JacksonUtil;
 import me.wolfyscript.utilities.util.json.jackson.KeyedTypeIdResolver;
 import me.wolfyscript.utilities.util.json.jackson.KeyedTypeResolver;
 import me.wolfyscript.utilities.util.json.jackson.ValueDeserializer;
@@ -151,7 +151,7 @@ public abstract class QueryNode<VAL> implements Keyed {
         injectVars.addValue("key", key);
         injectVars.addValue("parent_path", parentPath);
         try {
-            QueryNode<?> queryNode = JacksonUtil.getObjectMapper().reader(injectVars).readValue(node, QueryNode.class);
+            QueryNode<?> queryNode = WolfyCoreBukkit.getInstance().getWolfyUtils().getJacksonMapperUtil().getGlobalMapper().reader(injectVars).readValue(node, QueryNode.class);
             return Optional.ofNullable(queryNode);
         } catch (IOException e) {
             e.printStackTrace();

--- a/core/src/main/java/com/wolfyscript/utilities/bukkit/persistent/world/BlockStorage.java
+++ b/core/src/main/java/com/wolfyscript/utilities/bukkit/persistent/world/BlockStorage.java
@@ -88,7 +88,7 @@ public class BlockStorage {
     }
 
     private void saveToPersistent() {
-        var objectMapper = JacksonUtil.getObjectMapper();
+        var objectMapper = core.getWolfyUtils().getJacksonMapperUtil().getGlobalMapper();
         var dataPersistent = getPersistentData();
         for (Map.Entry<NamespacedKey, CustomBlockData> entry : data.entrySet()) {
             try {
@@ -102,7 +102,7 @@ public class BlockStorage {
 
     private void loadFromPersistent(ChunkStorage chunkStorage) {
         var dataTypeRegistry = core.getRegistries().getCustomBlockData();
-        var objectMapper = JacksonUtil.getObjectMapper();
+        var objectMapper = core.getWolfyUtils().getJacksonMapperUtil().getGlobalMapper();
         var dataPersistent = getPersistentData();
         for (org.bukkit.NamespacedKey key : dataPersistent.getKeys()) {
             NamespacedKey wuKey = NamespacedKey.fromBukkit(key);

--- a/core/src/main/java/me/wolfyscript/utilities/api/WolfyUtilCore.java
+++ b/core/src/main/java/me/wolfyscript/utilities/api/WolfyUtilCore.java
@@ -1,5 +1,6 @@
 package me.wolfyscript.utilities.api;
 
+import com.wolfyscript.utilities.bukkit.WolfyUtilsBukkit;
 import com.wolfyscript.utilities.common.WolfyCore;
 import com.wolfyscript.utilities.bukkit.WolfyCoreBukkit;
 import me.wolfyscript.utilities.api.inventory.custom_items.references.APIReference;
@@ -86,6 +87,11 @@ public abstract class WolfyUtilCore extends JavaPlugin implements WolfyCore {
     @Deprecated
     public static WolfyUtilCore getInstance() {
         return instance;
+    }
+
+    @Override
+    public WolfyUtilsBukkit getWolfyUtils() {
+        return api;
     }
 
     /**

--- a/core/src/main/java/me/wolfyscript/utilities/main/WUPlugin.java
+++ b/core/src/main/java/me/wolfyscript/utilities/main/WUPlugin.java
@@ -28,6 +28,7 @@ public abstract class WUPlugin extends WolfyUtilCore {
         instance = this;
     }
 
+    @Deprecated
     public abstract WolfyUtilities getWolfyUtilities();
 
     @Deprecated

--- a/core/src/main/java/me/wolfyscript/utilities/util/json/jackson/serialization/APIReferenceSerialization.java
+++ b/core/src/main/java/me/wolfyscript/utilities/util/json/jackson/serialization/APIReferenceSerialization.java
@@ -55,7 +55,7 @@ public class APIReferenceSerialization {
                     if (parser != null) {
                         JsonNode element = node.path(key);
                         if (element != null) {
-                            APIReference reference = parser.parse(element);
+                            APIReference reference = parser.parse(element); //TODO: Provide parser to the parse method
                             if (reference != null) {
                                 reference.setAmount(node.path(CUSTOM_AMOUNT).asInt(0));
                                 reference.setWeight(node.path(WEIGHT).asDouble(0));
@@ -66,7 +66,7 @@ public class APIReferenceSerialization {
                 }
             } else if (node.isTextual()) {
                 //Legacy items saved as string!
-                APIReference apiReference = JacksonUtil.getObjectMapper().treeToValue(node, VanillaRef.class);
+                APIReference apiReference = p.getCodec().treeToValue(node, VanillaRef.class);
                 if (apiReference != null) {
                     return apiReference;
                 }

--- a/core/src/main/java/me/wolfyscript/utilities/util/json/jackson/serialization/DustOptionsSerialization.java
+++ b/core/src/main/java/me/wolfyscript/utilities/util/json/jackson/serialization/DustOptionsSerialization.java
@@ -34,11 +34,10 @@ public class DustOptionsSerialization {
             gen.writeObjectField("color", dustOptions.getColor());
             gen.writeEndObject();
         }, (p, ctxt) -> {
-            p.setCodec(JacksonUtil.getObjectMapper());
             JsonNode node = p.readValueAsTree();
             if (node.isObject()) {
                 float size = node.get("size").floatValue();
-                Color color = ctxt.readValue(node.get("color").traverse(JacksonUtil.getObjectMapper()), Color.class);
+                Color color = p.getCodec().treeToValue(node.get("color"), Color.class);
                 return new Particle.DustOptions(color, size);
             }
             WolfyUtilities.getWUCore().getConsole().warn("Error Deserializing DustOptions! Invalid DustOptions object!");

--- a/core/src/main/java/me/wolfyscript/utilities/util/json/jackson/serialization/ItemStackSerialization.java
+++ b/core/src/main/java/me/wolfyscript/utilities/util/json/jackson/serialization/ItemStackSerialization.java
@@ -53,7 +53,7 @@ public class ItemStackSerialization {
             }
             var config = new YamlConfiguration();
             //Loads the Map from the JsonNode && Sets the Map to YamlConfig
-            config.set("i", JacksonUtil.getObjectMapper().convertValue(node, new TypeReference<Map<String, Object>>() {
+            config.set("i", p.getCodec().readValue(node.traverse(p.getCodec()), new TypeReference<Map<String, Object>>() {
             }));
             try {
                     /*

--- a/core/src/main/java/me/wolfyscript/utilities/util/json/jackson/serialization/PotionEffectSerialization.java
+++ b/core/src/main/java/me/wolfyscript/utilities/util/json/jackson/serialization/PotionEffectSerialization.java
@@ -46,7 +46,7 @@ public class PotionEffectSerialization {
         }, (p, deserializationContext) -> {
             JsonNode node = p.readValueAsTree();
             if (!node.has(TYPE)) return null;
-            PotionEffectType type = JacksonUtil.getObjectMapper().convertValue(node.path(TYPE), PotionEffectType.class);
+            PotionEffectType type = p.getCodec().treeToValue(node.path(TYPE), PotionEffectType.class);
             boolean particles = node.path(PARTICLES).asBoolean(true);
             boolean icon = node.path(ICON).asBoolean(particles);
             return type == null ? null : new PotionEffect(type, node.path(DURATION).asInt(), node.path(AMPLIFIER).asInt(), node.path(AMBIENT).asBoolean(false), particles, icon);

--- a/nmsutil/nmsutil-artifact/pom.xml
+++ b/nmsutil/nmsutil-artifact/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <artifactId>nmsutil</artifactId>
         <groupId>com.wolfyscript.wolfyutils.spigot</groupId>
-        <version>4.16.5.1</version>
+        <version>4.16.6-HOCON-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/nmsutil/nmsutil-artifact/pom.xml
+++ b/nmsutil/nmsutil-artifact/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <artifactId>nmsutil</artifactId>
         <groupId>com.wolfyscript.wolfyutils.spigot</groupId>
-        <version>4.16.6-HOCON-SNAPSHOT</version>
+        <version>4.16.6-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/nmsutil/nmsutil-v1_16_R1/pom.xml
+++ b/nmsutil/nmsutil-v1_16_R1/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <artifactId>nmsutil</artifactId>
         <groupId>com.wolfyscript.wolfyutils.spigot</groupId>
-        <version>4.16.5.1</version>
+        <version>4.16.6-HOCON-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/nmsutil/nmsutil-v1_16_R1/pom.xml
+++ b/nmsutil/nmsutil-v1_16_R1/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <artifactId>nmsutil</artifactId>
         <groupId>com.wolfyscript.wolfyutils.spigot</groupId>
-        <version>4.16.6-HOCON-SNAPSHOT</version>
+        <version>4.16.6-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/nmsutil/nmsutil-v1_16_R2/pom.xml
+++ b/nmsutil/nmsutil-v1_16_R2/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <artifactId>nmsutil</artifactId>
         <groupId>com.wolfyscript.wolfyutils.spigot</groupId>
-        <version>4.16.5.1</version>
+        <version>4.16.6-HOCON-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/nmsutil/nmsutil-v1_16_R2/pom.xml
+++ b/nmsutil/nmsutil-v1_16_R2/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <artifactId>nmsutil</artifactId>
         <groupId>com.wolfyscript.wolfyutils.spigot</groupId>
-        <version>4.16.6-HOCON-SNAPSHOT</version>
+        <version>4.16.6-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/nmsutil/nmsutil-v1_16_R3/pom.xml
+++ b/nmsutil/nmsutil-v1_16_R3/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <artifactId>nmsutil</artifactId>
         <groupId>com.wolfyscript.wolfyutils.spigot</groupId>
-        <version>4.16.5.1</version>
+        <version>4.16.6-HOCON-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/nmsutil/nmsutil-v1_16_R3/pom.xml
+++ b/nmsutil/nmsutil-v1_16_R3/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <artifactId>nmsutil</artifactId>
         <groupId>com.wolfyscript.wolfyutils.spigot</groupId>
-        <version>4.16.6-HOCON-SNAPSHOT</version>
+        <version>4.16.6-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/nmsutil/nmsutil-v1_17_R1/pom.xml
+++ b/nmsutil/nmsutil-v1_17_R1/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <artifactId>nmsutil</artifactId>
         <groupId>com.wolfyscript.wolfyutils.spigot</groupId>
-        <version>4.16.5.1</version>
+        <version>4.16.6-HOCON-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/nmsutil/nmsutil-v1_17_R1/pom.xml
+++ b/nmsutil/nmsutil-v1_17_R1/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <artifactId>nmsutil</artifactId>
         <groupId>com.wolfyscript.wolfyutils.spigot</groupId>
-        <version>4.16.6-HOCON-SNAPSHOT</version>
+        <version>4.16.6-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/nmsutil/nmsutil-v1_17_R1_P1/pom.xml
+++ b/nmsutil/nmsutil-v1_17_R1_P1/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <artifactId>nmsutil</artifactId>
         <groupId>com.wolfyscript.wolfyutils.spigot</groupId>
-        <version>4.16.5.1</version>
+        <version>4.16.6-HOCON-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/nmsutil/nmsutil-v1_17_R1_P1/pom.xml
+++ b/nmsutil/nmsutil-v1_17_R1_P1/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <artifactId>nmsutil</artifactId>
         <groupId>com.wolfyscript.wolfyutils.spigot</groupId>
-        <version>4.16.6-HOCON-SNAPSHOT</version>
+        <version>4.16.6-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/nmsutil/nmsutil-v1_18_R1/pom.xml
+++ b/nmsutil/nmsutil-v1_18_R1/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <artifactId>nmsutil</artifactId>
         <groupId>com.wolfyscript.wolfyutils.spigot</groupId>
-        <version>4.16.5.1</version>
+        <version>4.16.6-HOCON-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/nmsutil/nmsutil-v1_18_R1/pom.xml
+++ b/nmsutil/nmsutil-v1_18_R1/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <artifactId>nmsutil</artifactId>
         <groupId>com.wolfyscript.wolfyutils.spigot</groupId>
-        <version>4.16.6-HOCON-SNAPSHOT</version>
+        <version>4.16.6-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/nmsutil/nmsutil-v1_18_R1_P1/pom.xml
+++ b/nmsutil/nmsutil-v1_18_R1_P1/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <artifactId>nmsutil</artifactId>
         <groupId>com.wolfyscript.wolfyutils.spigot</groupId>
-        <version>4.16.5.1</version>
+        <version>4.16.6-HOCON-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/nmsutil/nmsutil-v1_18_R1_P1/pom.xml
+++ b/nmsutil/nmsutil-v1_18_R1_P1/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <artifactId>nmsutil</artifactId>
         <groupId>com.wolfyscript.wolfyutils.spigot</groupId>
-        <version>4.16.6-HOCON-SNAPSHOT</version>
+        <version>4.16.6-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/nmsutil/nmsutil-v1_18_R2/pom.xml
+++ b/nmsutil/nmsutil-v1_18_R2/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <artifactId>nmsutil</artifactId>
         <groupId>com.wolfyscript.wolfyutils.spigot</groupId>
-        <version>4.16.5.1</version>
+        <version>4.16.6-HOCON-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/nmsutil/nmsutil-v1_18_R2/pom.xml
+++ b/nmsutil/nmsutil-v1_18_R2/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <artifactId>nmsutil</artifactId>
         <groupId>com.wolfyscript.wolfyutils.spigot</groupId>
-        <version>4.16.6-HOCON-SNAPSHOT</version>
+        <version>4.16.6-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/nmsutil/nmsutil-v1_19_R1/pom.xml
+++ b/nmsutil/nmsutil-v1_19_R1/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>nmsutil</artifactId>
         <groupId>com.wolfyscript.wolfyutils.spigot</groupId>
-        <version>4.16.6-HOCON-SNAPSHOT</version>
+        <version>4.16.6-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/nmsutil/nmsutil-v1_19_R1/pom.xml
+++ b/nmsutil/nmsutil-v1_19_R1/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>nmsutil</artifactId>
         <groupId>com.wolfyscript.wolfyutils.spigot</groupId>
-        <version>4.16.5.1</version>
+        <version>4.16.6-HOCON-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/nmsutil/pom.xml
+++ b/nmsutil/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <artifactId>wolfyutils-parent</artifactId>
         <groupId>com.wolfyscript.wolfyutils.spigot</groupId>
-        <version>4.16.6-HOCON-SNAPSHOT</version>
+        <version>4.16.6-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <packaging>pom</packaging>

--- a/nmsutil/pom.xml
+++ b/nmsutil/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <artifactId>wolfyutils-parent</artifactId>
         <groupId>com.wolfyscript.wolfyutils.spigot</groupId>
-        <version>4.16.5.1</version>
+        <version>4.16.6-HOCON-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <packaging>pom</packaging>

--- a/plugin-compatibility/plugin-compatibility-artifact/pom.xml
+++ b/plugin-compatibility/plugin-compatibility-artifact/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <artifactId>plugin-compatibility</artifactId>
         <groupId>com.wolfyscript.wolfyutils.spigot</groupId>
-        <version>4.16.6-HOCON-SNAPSHOT</version>
+        <version>4.16.6-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/plugin-compatibility/plugin-compatibility-artifact/pom.xml
+++ b/plugin-compatibility/plugin-compatibility-artifact/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <artifactId>plugin-compatibility</artifactId>
         <groupId>com.wolfyscript.wolfyutils.spigot</groupId>
-        <version>4.16.5.1</version>
+        <version>4.16.6-HOCON-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/plugin-compatibility/plugin-compatibility-artifact/src/main/java/me/wolfyscript/utilities/compatibility/plugins/denizen/DenizenRefImpl.java
+++ b/plugin-compatibility/plugin-compatibility-artifact/src/main/java/me/wolfyscript/utilities/compatibility/plugins/denizen/DenizenRefImpl.java
@@ -6,10 +6,10 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.SerializerProvider;
 import java.io.IOException;
 import java.util.Objects;
+import me.wolfyscript.utilities.api.WolfyUtilCore;
 import me.wolfyscript.utilities.api.inventory.custom_items.references.APIReference;
 import me.wolfyscript.utilities.compatibility.plugins.DenizenIntegrationImpl;
 import me.wolfyscript.utilities.util.inventory.ItemUtils;
-import me.wolfyscript.utilities.util.json.jackson.JacksonUtil;
 import org.bukkit.inventory.ItemStack;
 import org.jetbrains.annotations.Nullable;
 
@@ -69,7 +69,7 @@ public class DenizenRefImpl extends APIReference {
         @Override
         public @Nullable DenizenRefImpl parse(JsonNode element) {
             if (element.isObject()) {
-                ItemStack item = JacksonUtil.getObjectMapper().convertValue(element.path("display_item"), ItemStack.class);
+                ItemStack item = WolfyUtilCore.getInstance().getWolfyUtils().getJacksonMapperUtil().getGlobalMapper().convertValue(element.path("display_item"), ItemStack.class);
                 if(!ItemUtils.isAirOrNull(item)) {
                     String script = element.path("script").asText("");
                     if (!script.isBlank()) {

--- a/plugin-compatibility/pom.xml
+++ b/plugin-compatibility/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>wolfyutils-parent</artifactId>
         <groupId>com.wolfyscript.wolfyutils.spigot</groupId>
-        <version>4.16.6-HOCON-SNAPSHOT</version>
+        <version>4.16.6-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <packaging>pom</packaging>

--- a/plugin-compatibility/pom.xml
+++ b/plugin-compatibility/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>wolfyutils-parent</artifactId>
         <groupId>com.wolfyscript.wolfyutils.spigot</groupId>
-        <version>4.16.5.1</version>
+        <version>4.16.6-HOCON-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <packaging>pom</packaging>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.wolfyscript.wolfyutils.spigot</groupId>
     <artifactId>wolfyutils-parent</artifactId>
-    <version>4.16.5.1</version>
+    <version>4.16.6-HOCON-SNAPSHOT</version>
     <packaging>pom</packaging>
     <name>WolfyUtils-Spigot</name>
 
@@ -27,7 +27,7 @@
         <java.version>16</java.version>
         <java.mc18.version>17</java.mc18.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <wolfyutils.api>4.16-SNAPSHOT</wolfyutils.api>
+        <wolfyutils.api>4.16.1-HOCON-SNAPSHOT</wolfyutils.api>
         <!-- Plugin versions -->
         <plugin_version.compile>3.10.1</plugin_version.compile>
         <plugin_version.shade>3.3.0</plugin_version.shade>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.wolfyscript.wolfyutils.spigot</groupId>
     <artifactId>wolfyutils-parent</artifactId>
-    <version>4.16.6-HOCON-SNAPSHOT</version>
+    <version>4.16.6-SNAPSHOT</version>
     <packaging>pom</packaging>
     <name>WolfyUtils-Spigot</name>
 

--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
         <java.version>16</java.version>
         <java.mc18.version>17</java.mc18.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <wolfyutils.api>4.16.1-HOCON-SNAPSHOT</wolfyutils.api>
+        <wolfyutils.api>4.16.1-SNAPSHOT</wolfyutils.api>
         <!-- Plugin versions -->
         <plugin_version.compile>3.10.1</plugin_version.compile>
         <plugin_version.shade>3.3.0</plugin_version.shade>

--- a/wolfyutils-spigot/pom.xml
+++ b/wolfyutils-spigot/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <artifactId>wolfyutils-parent</artifactId>
         <groupId>com.wolfyscript.wolfyutils.spigot</groupId>
-        <version>4.16.6-HOCON-SNAPSHOT</version>
+        <version>4.16.6-SNAPSHOT</version>
     </parent>
 
     <build>

--- a/wolfyutils-spigot/pom.xml
+++ b/wolfyutils-spigot/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <artifactId>wolfyutils-parent</artifactId>
         <groupId>com.wolfyscript.wolfyutils.spigot</groupId>
-        <version>4.16.5.1</version>
+        <version>4.16.6-HOCON-SNAPSHOT</version>
     </parent>
 
     <build>
@@ -71,6 +71,8 @@
                                     <include>org.javassist</include>
                                     <include>net.kyori</include>
                                     <include>de.tr7zw</include>
+                                    <include>com.wolfyscript</include>
+                                    <include>com.typesafe</include>
                                 </includes>
                             </artifactSet>
                             <relocations>
@@ -89,6 +91,10 @@
                                 <relocation>
                                     <pattern>org.bstats</pattern>
                                     <shadedPattern>com.wolfyscript.utilities.main.metrics</shadedPattern>
+                                </relocation>
+                                <relocation>
+                                    <pattern>com.typesafe</pattern>
+                                    <shadedPattern>com.wolfyscript.lib.com.typesafe</shadedPattern>
                                 </relocation>
                                 <relocation>
                                     <pattern>org.reflections</pattern>


### PR DESCRIPTION
Implemented WolfyUtilities API v4.16.1 to support the HOCON format.

HOCON stands for Human-Optimized Config Object Notation and is made by Typesafe.

HOCON is the official configuration method for Sponge servers and plugins and provides an easier to use configuration format.
Files using HOCON are saved as .conf files.

A good introduction to hocon can be found in the Sponge docs.
https://docs.spongepowered.org/stable/en/server/getting-started/configuration/hocon.html

More detailed info about the format can be found here: 
https://github.com/lightbend/config

Using [WolfyScript/jackson-dataformat-hocon](https://github.com/WolfyScript/jackson-dataformat-hocon) Jackson is able to parse and generate .conf files.