### PR TITLE
CustomItem Block Settings

### DIFF
--- a/core/src/main/java/com/wolfyscript/utilities/Copyable.java
+++ b/core/src/main/java/com/wolfyscript/utilities/Copyable.java
@@ -1,0 +1,7 @@
+package com.wolfyscript.utilities;
+
+public interface Copyable<T> {
+
+    T copy();
+
+}

--- a/core/src/main/java/com/wolfyscript/utilities/bukkit/items/CustomBlockSettings.java
+++ b/core/src/main/java/com/wolfyscript/utilities/bukkit/items/CustomBlockSettings.java
@@ -1,6 +1,7 @@
 package com.wolfyscript.utilities.bukkit.items;
 
 import com.wolfyscript.utilities.Copyable;
+import java.util.Objects;
 
 public class CustomBlockSettings implements Copyable<CustomBlockSettings> {
 
@@ -25,5 +26,18 @@ public class CustomBlockSettings implements Copyable<CustomBlockSettings> {
     @Override
     public CustomBlockSettings copy() {
         return new CustomBlockSettings(this);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        CustomBlockSettings that = (CustomBlockSettings) o;
+        return useCustomDrops == that.useCustomDrops;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(useCustomDrops);
     }
 }

--- a/core/src/main/java/com/wolfyscript/utilities/bukkit/items/CustomBlockSettings.java
+++ b/core/src/main/java/com/wolfyscript/utilities/bukkit/items/CustomBlockSettings.java
@@ -1,0 +1,29 @@
+package com.wolfyscript.utilities.bukkit.items;
+
+import com.wolfyscript.utilities.Copyable;
+
+public class CustomBlockSettings implements Copyable<CustomBlockSettings> {
+
+    private boolean useCustomDrops;
+
+    public CustomBlockSettings() {
+        this.useCustomDrops = true;
+    }
+
+    private CustomBlockSettings(CustomBlockSettings settings) {
+        this.useCustomDrops = settings.useCustomDrops;
+    }
+
+    public boolean isUseCustomDrops() {
+        return useCustomDrops;
+    }
+
+    public void setUseCustomDrops(boolean useCustomDrops) {
+        this.useCustomDrops = useCustomDrops;
+    }
+
+    @Override
+    public CustomBlockSettings copy() {
+        return new CustomBlockSettings(this);
+    }
+}

--- a/core/src/main/java/com/wolfyscript/utilities/bukkit/listeners/custom_item/CustomItemDataListener.java
+++ b/core/src/main/java/com/wolfyscript/utilities/bukkit/listeners/custom_item/CustomItemDataListener.java
@@ -32,23 +32,25 @@ public class CustomItemDataListener implements Listener {
         event.getStorage().getData(CustomItemBlockData.ID, CustomItemBlockData.class).ifPresent(data -> {
             var blockState = event.getBlockState();
             data.getCustomItem().ifPresent(customItem -> {
-                //TODO for future: Let people customize this!
-                event.getItems().clear();
-                ItemStack result = customItem.create();
-                if (blockState instanceof Container container) {
-                    var blockStateMeta = (BlockStateMeta) result.getItemMeta();
-                    if (container instanceof ShulkerBox) {
-                        var shulkerBox = (ShulkerBox) blockStateMeta.getBlockState();
-                        shulkerBox.getInventory().setContents(container.getInventory().getContents());
-                        blockStateMeta.setBlockState(shulkerBox);
-                    } else {
-                        var itemContainer = (Container) blockStateMeta.getBlockState();
-                        itemContainer.getInventory().clear();
-                        blockStateMeta.setBlockState(itemContainer);
+                if (customItem.getBlockSettings().isUseCustomDrops()) {
+                    event.setCancelled(true);
+                    //TODO for future: Let people customize this!
+                    ItemStack result = customItem.create();
+                    if (blockState instanceof Container container) {
+                        var blockStateMeta = (BlockStateMeta) result.getItemMeta();
+                        if (container instanceof ShulkerBox) {
+                            var shulkerBox = (ShulkerBox) blockStateMeta.getBlockState();
+                            shulkerBox.getInventory().setContents(container.getInventory().getContents());
+                            blockStateMeta.setBlockState(shulkerBox);
+                        } else {
+                            var itemContainer = (Container) blockStateMeta.getBlockState();
+                            itemContainer.getInventory().clear();
+                            blockStateMeta.setBlockState(itemContainer);
+                        }
+                        result.setItemMeta(blockStateMeta);
                     }
-                    result.setItemMeta(blockStateMeta);
+                    blockState.getWorld().dropItemNaturally(blockState.getLocation(), result);
                 }
-                blockState.getWorld().dropItemNaturally(blockState.getLocation(), result);
             });
         });
     }

--- a/core/src/main/java/me/wolfyscript/utilities/api/inventory/custom_items/CustomItem.java
+++ b/core/src/main/java/me/wolfyscript/utilities/api/inventory/custom_items/CustomItem.java
@@ -651,7 +651,7 @@ public class CustomItem extends AbstractItemBuilder<CustomItem> implements Keyed
 
     @Override
     public int hashCode() {
-        return Objects.hash(getCustomDataMap(), getNamespacedKey(), getReplacement(), getPermission(), getRarityPercentage(), getFuelSettings(), getDurabilityCost(), isConsumed(), blockPlacement, isBlockVanillaEquip(), isBlockVanillaRecipes(), getEquipmentSlots(), getApiReference(), getParticleContent(), getMetaSettings());
+        return Objects.hash(getCustomDataMap(), getNamespacedKey(), getReplacement(), getPermission(), getRarityPercentage(), getFuelSettings(), getBlockSettings(), getDurabilityCost(), isConsumed(), blockPlacement, isBlockVanillaEquip(), isBlockVanillaRecipes(), getEquipmentSlots(), getApiReference(), getParticleContent(), getMetaSettings());
     }
 
     /**

--- a/core/src/main/java/me/wolfyscript/utilities/api/inventory/custom_items/CustomItem.java
+++ b/core/src/main/java/me/wolfyscript/utilities/api/inventory/custom_items/CustomItem.java
@@ -33,6 +33,7 @@ import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.google.common.collect.Streams;
+import com.wolfyscript.utilities.bukkit.items.CustomBlockSettings;
 import me.wolfyscript.utilities.api.WolfyUtilCore;
 import me.wolfyscript.utilities.api.WolfyUtilities;
 import me.wolfyscript.utilities.api.inventory.custom_items.meta.CustomItemTagMeta;
@@ -155,6 +156,7 @@ public class CustomItem extends AbstractItemBuilder<CustomItem> implements Keyed
     @JsonAlias("particles")
     private ParticleContent particleContent;
     private ActionSettings actionSettings = new ActionSettings();
+    private final CustomBlockSettings blockSettings;
 
     @JsonIgnore
     private boolean checkOldMetaSettings = true;
@@ -174,6 +176,7 @@ public class CustomItem extends AbstractItemBuilder<CustomItem> implements Keyed
         }
         this.equipmentSlots = new ArrayList<>();
         this.particleContent = new ParticleContent();
+        this.blockSettings = new CustomBlockSettings();
         this.blockPlacement = false;
         this.blockVanillaEquip = false;
         this.blockVanillaRecipes = false;
@@ -248,6 +251,7 @@ public class CustomItem extends AbstractItemBuilder<CustomItem> implements Keyed
 
         this.namespacedKey = customItem.getNamespacedKey();
         this.fuelSettings = customItem.fuelSettings.clone();
+        this.blockSettings = customItem.blockSettings.copy();
         this.nbtChecks = customItem.nbtChecks;
         this.permission = customItem.permission;
         this.rarityPercentage = customItem.rarityPercentage;
@@ -647,7 +651,7 @@ public class CustomItem extends AbstractItemBuilder<CustomItem> implements Keyed
 
     @Override
     public int hashCode() {
-        return Objects.hash(getCustomDataMap(), getNamespacedKey(), getReplacement(), getAllowedBlocks(), getPermission(), getRarityPercentage(), getBurnTime(), getDurabilityCost(), isConsumed(), blockPlacement, isBlockVanillaEquip(), isBlockVanillaRecipes(), getEquipmentSlots(), getApiReference(), getParticleContent(), getMetaSettings());
+        return Objects.hash(getCustomDataMap(), getNamespacedKey(), getReplacement(), getPermission(), getRarityPercentage(), getFuelSettings(), getDurabilityCost(), isConsumed(), blockPlacement, isBlockVanillaEquip(), isBlockVanillaRecipes(), getEquipmentSlots(), getApiReference(), getParticleContent(), getMetaSettings());
     }
 
     /**
@@ -1183,6 +1187,10 @@ public class CustomItem extends AbstractItemBuilder<CustomItem> implements Keyed
     @JsonSetter
     public void setActionSettings(ActionSettings actionSettings) {
         this.actionSettings = actionSettings == null ? new ActionSettings() : actionSettings;
+    }
+
+    public CustomBlockSettings getBlockSettings() {
+        return blockSettings;
     }
 
     /**

--- a/core/src/main/java/me/wolfyscript/utilities/api/inventory/custom_items/FuelSettings.java
+++ b/core/src/main/java/me/wolfyscript/utilities/api/inventory/custom_items/FuelSettings.java
@@ -20,6 +20,7 @@ package me.wolfyscript.utilities.api.inventory.custom_items;
 
 import com.fasterxml.jackson.annotation.JsonAlias;
 import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import java.util.Objects;
 import org.bukkit.Material;
 
 import java.util.ArrayList;
@@ -63,4 +64,16 @@ public class FuelSettings {
         return new FuelSettings(this);
     }
 
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        FuelSettings that = (FuelSettings) o;
+        return burnTime == that.burnTime && Objects.equals(allowedBlocks, that.allowedBlocks);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(allowedBlocks, burnTime);
+    }
 }


### PR DESCRIPTION
Adds settings to CustomItems to edit their behaviour when placed down as blocks. In the future there are going to be more options. 
For now it provides one option `useCustomDrops`, that allows you to disable the CustomItem from dropping and instead use the vanilla and/or other plugins behaviour.