### PR TITLE
Set Current Recipe of Inventories

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>wolfyutils-parent</artifactId>
         <groupId>com.wolfyscript.wolfyutils.spigot</groupId>
-        <version>4.16.8.0</version>
+        <version>4.16.9-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/core/src/main/java/com/wolfyscript/utilities/bukkit/nms/inventory/NMSInventoryUtils.java
+++ b/core/src/main/java/com/wolfyscript/utilities/bukkit/nms/inventory/NMSInventoryUtils.java
@@ -10,6 +10,7 @@ import org.bukkit.inventory.Inventory;
 
 public class NMSInventoryUtils {
 
+    // TODO: Combine these and FunctionalRecipeGenerator constants!
     private static final Class<?> CONTAINER_CLASS = Reflection.getNMS("world", "IInventory");
     private static final Class<?> RECIPE_CLASS = Reflection.getNMS("world.item.crafting", "IRecipe");
     private static final Class<?> RESOURCE_KEY_CLASS = Reflection.getNMS("resources", "MinecraftKey");

--- a/core/src/main/java/com/wolfyscript/utilities/bukkit/nms/inventory/NMSInventoryUtils.java
+++ b/core/src/main/java/com/wolfyscript/utilities/bukkit/nms/inventory/NMSInventoryUtils.java
@@ -1,0 +1,64 @@
+package com.wolfyscript.utilities.bukkit.nms.inventory;
+
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.util.Arrays;
+import java.util.Optional;
+import me.wolfyscript.utilities.util.NamespacedKey;
+import me.wolfyscript.utilities.util.Reflection;
+import org.bukkit.inventory.Inventory;
+
+public class NMSInventoryUtils {
+
+    private static final Class<?> CONTAINER_CLASS = Reflection.getNMS("world", "IInventory");
+    private static final Class<?> RECIPE_CLASS = Reflection.getNMS("world.item.crafting", "IRecipe");
+    private static final Class<?> RESOURCE_KEY_CLASS = Reflection.getNMS("resources", "MinecraftKey");
+    private static final Class<?> MINECRAFT_SERVER_CLASS = Reflection.getNMS("server", "MinecraftServer");
+    private static final Class<?> RECIPE_MANAGER_CLASS = Reflection.getNMS("world.item.crafting", "CraftingManager");
+
+    private static final Method MINECRAFT_SERVER_GET_RECIPE_MANAGER_METHOD;
+    private static final Method MINECRAFT_SERVER_STATIC_GETTER_METHOD;
+    private static final Method RECIPE_MANAGER_GET_RECIPE_METHOD;
+    private static final Method CONTAINER_SET_CURRENT_RECIPE;
+
+    private static final Class<?> CRAFT_INVENTORY_CLASS = Reflection.getOBC("inventory.CraftInventory");
+
+    private static final Method CRAFT_INV_GET_CONTAINER;
+
+    static {
+        try {
+            CONTAINER_SET_CURRENT_RECIPE = CONTAINER_CLASS.getMethod("setCurrentRecipe", RECIPE_CLASS);
+            MINECRAFT_SERVER_STATIC_GETTER_METHOD = Reflection.getMethod(MINECRAFT_SERVER_CLASS, "getServer");
+            MINECRAFT_SERVER_GET_RECIPE_MANAGER_METHOD = Arrays.stream(MINECRAFT_SERVER_CLASS.getMethods()).filter(method -> method.getReturnType().equals(RECIPE_MANAGER_CLASS)).findFirst().orElseGet(() -> Reflection.getMethod(MINECRAFT_SERVER_CLASS, "getCraftingManager"));
+            RECIPE_MANAGER_GET_RECIPE_METHOD = Reflection.getMethod(RECIPE_MANAGER_CLASS, "a", RESOURCE_KEY_CLASS);
+
+            CRAFT_INV_GET_CONTAINER = CRAFT_INVENTORY_CLASS.getMethod("getInventory");
+        } catch (NoSuchMethodException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    public static void setCurrentRecipe(Inventory inventory, NamespacedKey recipeId) {
+        if (inventory == null) return;
+        if (CRAFT_INVENTORY_CLASS.isInstance(inventory)) {
+            try {
+                Object container = CRAFT_INV_GET_CONTAINER.invoke(CRAFT_INVENTORY_CLASS.cast(inventory));
+                if (CONTAINER_CLASS.isInstance(container)) {
+                    Object recipeMCKey = RESOURCE_KEY_CLASS.getConstructor(String.class, String.class).newInstance(recipeId.getNamespace(), recipeId.getKey());
+                    Object minecraftServer = MINECRAFT_SERVER_STATIC_GETTER_METHOD.invoke(null);
+                    Object recipeManager = MINECRAFT_SERVER_GET_RECIPE_MANAGER_METHOD.invoke(minecraftServer);
+                    Object recipeOptional = RECIPE_MANAGER_GET_RECIPE_METHOD.invoke(recipeManager, recipeMCKey);
+                    if (recipeOptional instanceof Optional<?> optional && optional.isPresent()) {
+                        Object recipe = optional.get();
+                        CONTAINER_SET_CURRENT_RECIPE.invoke(container, recipe);
+                    }
+                }
+            } catch (IllegalAccessException | InvocationTargetException | InstantiationException |
+                     NoSuchMethodException e) {
+                throw new RuntimeException(e);
+            }
+        }
+    }
+
+
+}

--- a/nmsutil/nmsutil-artifact/pom.xml
+++ b/nmsutil/nmsutil-artifact/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <artifactId>nmsutil</artifactId>
         <groupId>com.wolfyscript.wolfyutils.spigot</groupId>
-        <version>4.16.8.0</version>
+        <version>4.16.9-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/nmsutil/nmsutil-v1_16_R1/pom.xml
+++ b/nmsutil/nmsutil-v1_16_R1/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <artifactId>nmsutil</artifactId>
         <groupId>com.wolfyscript.wolfyutils.spigot</groupId>
-        <version>4.16.8.0</version>
+        <version>4.16.9-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/nmsutil/nmsutil-v1_16_R2/pom.xml
+++ b/nmsutil/nmsutil-v1_16_R2/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <artifactId>nmsutil</artifactId>
         <groupId>com.wolfyscript.wolfyutils.spigot</groupId>
-        <version>4.16.8.0</version>
+        <version>4.16.9-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/nmsutil/nmsutil-v1_16_R3/pom.xml
+++ b/nmsutil/nmsutil-v1_16_R3/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <artifactId>nmsutil</artifactId>
         <groupId>com.wolfyscript.wolfyutils.spigot</groupId>
-        <version>4.16.8.0</version>
+        <version>4.16.9-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/nmsutil/nmsutil-v1_17_R1/pom.xml
+++ b/nmsutil/nmsutil-v1_17_R1/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <artifactId>nmsutil</artifactId>
         <groupId>com.wolfyscript.wolfyutils.spigot</groupId>
-        <version>4.16.8.0</version>
+        <version>4.16.9-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/nmsutil/nmsutil-v1_17_R1_P1/pom.xml
+++ b/nmsutil/nmsutil-v1_17_R1_P1/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <artifactId>nmsutil</artifactId>
         <groupId>com.wolfyscript.wolfyutils.spigot</groupId>
-        <version>4.16.8.0</version>
+        <version>4.16.9-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/nmsutil/nmsutil-v1_18_R1/pom.xml
+++ b/nmsutil/nmsutil-v1_18_R1/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <artifactId>nmsutil</artifactId>
         <groupId>com.wolfyscript.wolfyutils.spigot</groupId>
-        <version>4.16.8.0</version>
+        <version>4.16.9-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/nmsutil/nmsutil-v1_18_R1_P1/pom.xml
+++ b/nmsutil/nmsutil-v1_18_R1_P1/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <artifactId>nmsutil</artifactId>
         <groupId>com.wolfyscript.wolfyutils.spigot</groupId>
-        <version>4.16.8.0</version>
+        <version>4.16.9-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/nmsutil/nmsutil-v1_18_R2/pom.xml
+++ b/nmsutil/nmsutil-v1_18_R2/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <artifactId>nmsutil</artifactId>
         <groupId>com.wolfyscript.wolfyutils.spigot</groupId>
-        <version>4.16.8.0</version>
+        <version>4.16.9-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/nmsutil/nmsutil-v1_19_R1/pom.xml
+++ b/nmsutil/nmsutil-v1_19_R1/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>nmsutil</artifactId>
         <groupId>com.wolfyscript.wolfyutils.spigot</groupId>
-        <version>4.16.8.0</version>
+        <version>4.16.9-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/nmsutil/pom.xml
+++ b/nmsutil/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <artifactId>wolfyutils-parent</artifactId>
         <groupId>com.wolfyscript.wolfyutils.spigot</groupId>
-        <version>4.16.8.0</version>
+        <version>4.16.9-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <packaging>pom</packaging>

--- a/plugin-compatibility/plugin-compatibility-artifact/pom.xml
+++ b/plugin-compatibility/plugin-compatibility-artifact/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <artifactId>plugin-compatibility</artifactId>
         <groupId>com.wolfyscript.wolfyutils.spigot</groupId>
-        <version>4.16.8.0</version>
+        <version>4.16.9-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/plugin-compatibility/pom.xml
+++ b/plugin-compatibility/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>wolfyutils-parent</artifactId>
         <groupId>com.wolfyscript.wolfyutils.spigot</groupId>
-        <version>4.16.8.0</version>
+        <version>4.16.9-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <packaging>pom</packaging>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.wolfyscript.wolfyutils.spigot</groupId>
     <artifactId>wolfyutils-parent</artifactId>
-    <version>4.16.8.0</version>
+    <version>4.16.9-SNAPSHOT</version>
     <packaging>pom</packaging>
     <name>WolfyUtils-Spigot</name>
 

--- a/wolfyutils-spigot/pom.xml
+++ b/wolfyutils-spigot/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <artifactId>wolfyutils-parent</artifactId>
         <groupId>com.wolfyscript.wolfyutils.spigot</groupId>
-        <version>4.16.8.0</version>
+        <version>4.16.9-SNAPSHOT</version>
     </parent>
 
     <build>


### PR DESCRIPTION
Added NMS InventoryUtils with a function to set the current recipe of an inventory, as a counter part to CraftingInventory#getCurrentRecipe!
It takes in a NamespacedKey and applies the associated recipe to the inventory. If the recipe doesn't exist, then it ignores it.