### PR TITLE
Better Persistent Custom Player Data Storage

### DIFF
--- a/core/src/main/java/com/wolfyscript/utilities/bukkit/WolfyCoreBukkit.java
+++ b/core/src/main/java/com/wolfyscript/utilities/bukkit/WolfyCoreBukkit.java
@@ -38,6 +38,8 @@ import com.wolfyscript.utilities.bukkit.nbt.QueryNodeCompound;
 import com.wolfyscript.utilities.bukkit.nbt.QueryNodeShort;
 import com.wolfyscript.utilities.bukkit.nbt.QueryNodeString;
 import com.wolfyscript.utilities.bukkit.persistent.PersistentStorage;
+import com.wolfyscript.utilities.bukkit.persistent.player.CustomPlayerData;
+import com.wolfyscript.utilities.bukkit.persistent.player.PlayerParticleEffectData;
 import com.wolfyscript.utilities.bukkit.persistent.world.CustomBlockData;
 import java.util.ArrayList;
 import java.util.List;
@@ -366,6 +368,10 @@ public final class WolfyCoreBukkit extends WUPlugin {
         var customBlockData = getRegistries().getCustomBlockData();
         customBlockData.register(CustomItemBlockData.ID, CustomItemBlockData.class);
 
+        getLogger().info("Register Custom Player Data");
+        var customPlayerDataReg = getRegistries().getCustomPlayerData();
+        customPlayerDataReg.register(PlayerParticleEffectData.class);
+
         KeyedTypeIdResolver.registerTypeRegistry(CustomItemData.class, registries.getCustomItemDataTypeRegistry());
         KeyedTypeIdResolver.registerTypeRegistry(Meta.class, nbtChecks);
         KeyedTypeIdResolver.registerTypeRegistry(Animator.class, particleAnimators);
@@ -377,6 +383,7 @@ public final class WolfyCoreBukkit extends WUPlugin {
         KeyedTypeIdResolver.registerTypeRegistry((Class<ValueProvider<?>>) (Object)ValueProvider.class, valueProviders);
         KeyedTypeIdResolver.registerTypeRegistry((Class<QueryNode<?>>) (Object)QueryNode.class, nbtQueryNodes);
         KeyedTypeIdResolver.registerTypeRegistry(CustomBlockData.class, customBlockData);
+        KeyedTypeIdResolver.registerTypeRegistry(CustomPlayerData.class, registries.getCustomPlayerData());
     }
 
     @Override

--- a/core/src/main/java/com/wolfyscript/utilities/bukkit/WolfyCoreBukkit.java
+++ b/core/src/main/java/com/wolfyscript/utilities/bukkit/WolfyCoreBukkit.java
@@ -192,6 +192,17 @@ public final class WolfyCoreBukkit extends WUPlugin {
         this.compatibilityManager = new CompatibilityManagerBukkit(this);
     }
 
+    /**
+     * Gets an instance of the core plugin.
+     * <strong>Only use this if necessary! First try to get the instance via your {@link WolfyUtilities} instance!</strong>
+     *
+     * @return The instance of the core.
+     */
+    @Deprecated
+    public static WolfyCoreBukkit getInstance() {
+        return (WolfyCoreBukkit) WolfyUtilCore.getInstance();
+    }
+
     @Override
     public CompatibilityManager getCompatibilityManager() {
         return compatibilityManager;

--- a/core/src/main/java/com/wolfyscript/utilities/bukkit/WolfyCoreBukkit.java
+++ b/core/src/main/java/com/wolfyscript/utilities/bukkit/WolfyCoreBukkit.java
@@ -227,6 +227,9 @@ public final class WolfyCoreBukkit extends WUPlugin {
 
     @Override
     public void onLoad() {
+        getLogger().info("Generate Functional Recipes");
+        FunctionalRecipeGenerator.generateRecipeClasses();
+
         //Jackson Serializer
         getLogger().info("Register JSON de-/serializers");
         var module = new SimpleModule();
@@ -263,12 +266,29 @@ public final class WolfyCoreBukkit extends WUPlugin {
         JacksonUtil.registerModule(keyReferenceModule);
         JacksonUtil.registerModule(valueReferenceModule);
 
-        FunctionalRecipeGenerator.generateRecipeClasses();
+        getLogger().info("Register JSON Operators");
+        var operators = getRegistries().getOperators();
+        operators.register(ComparisonOperatorEqual.KEY, ComparisonOperatorEqual.class);
+        operators.register(ComparisonOperatorNotEqual.KEY, ComparisonOperatorNotEqual.class);
+        operators.register(ComparisonOperatorGreater.KEY, ComparisonOperatorGreater.class);
+        operators.register(ComparisonOperatorGreaterEqual.KEY, ComparisonOperatorGreaterEqual.class);
+        operators.register(ComparisonOperatorLess.KEY, ComparisonOperatorLess.class);
+        operators.register(ComparisonOperatorLessEqual.KEY, ComparisonOperatorLessEqual.class);
+        operators.register(LogicalOperatorAnd.KEY, LogicalOperatorAnd.class);
+        operators.register(LogicalOperatorOr.KEY, LogicalOperatorOr.class);
+        operators.register(LogicalOperatorNot.KEY, LogicalOperatorNot.class);
 
-        //Register custom item data
+        getLogger().info("Register JSON Value Providers");
+        var valueProviders = getRegistries().getValueProviders();
+        valueProviders.register(ValueProviderConditioned.KEY, (Class<ValueProviderConditioned<?>>)(Object) ValueProviderConditioned.class);
+        valueProviders.register(ValueProviderIntegerConst.KEY, ValueProviderIntegerConst.class);
+        valueProviders.register(ValueProviderIntegerVar.KEY, ValueProviderIntegerVar.class);
+        valueProviders.register(ValueProviderFloatConst.KEY, ValueProviderFloatConst.class);
+        valueProviders.register(ValueProviderFloatVar.KEY, ValueProviderFloatVar.class);
+        valueProviders.register(ValueProviderStringConst.KEY, ValueProviderStringConst.class);
+        valueProviders.register(ValueProviderStringVar.KEY, ValueProviderStringVar.class);
 
-        //Register meta settings providers
-        getLogger().info("Register CustomItem meta checks");
+        getLogger().info("Register CustomItem NBT Checks");
         var nbtChecks = getRegistries().getCustomItemNbtChecks();
         nbtChecks.register(AttributesModifiersMeta.KEY, AttributesModifiersMeta.class);
         nbtChecks.register(CustomDamageMeta.KEY, CustomDamageMeta.class);
@@ -284,6 +304,24 @@ public final class WolfyCoreBukkit extends WUPlugin {
         nbtChecks.register(PotionMeta.KEY, PotionMeta.class);
         nbtChecks.register(RepairCostMeta.KEY, RepairCostMeta.class);
         nbtChecks.register(UnbreakableMeta.KEY, UnbreakableMeta.class);
+
+        getLogger().info("Register CustomItem Actions");
+        var customItemActions = getRegistries().getCustomItemActions();
+        customItemActions.register(ActionCommand.KEY, ActionCommand.class);
+        customItemActions.register(ActionParticleAnimation.KEY, ActionParticleAnimation.class);
+        customItemActions.register(ActionSound.KEY, ActionSound.class);
+
+        getLogger().info("Register CustomItem Events");
+        var customItemEvents = getRegistries().getCustomItemEvents();
+        customItemEvents.register(EventPlayerInteract.KEY, EventPlayerInteract.class);
+        customItemEvents.register(EventPlayerConsumeItem.KEY, EventPlayerConsumeItem.class);
+        customItemEvents.register(EventPlayerInteractEntity.KEY, EventPlayerInteractEntity.class);
+        customItemEvents.register(EventPlayerInteractAtEntity.KEY, EventPlayerInteractAtEntity.class);
+        customItemEvents.register(EventPlayerItemBreak.KEY, EventPlayerItemBreak.class);
+        customItemEvents.register(EventPlayerItemDamage.KEY, EventPlayerItemDamage.class);
+        customItemEvents.register(EventPlayerItemDrop.KEY, EventPlayerItemDrop.class);
+        customItemEvents.register(EventPlayerItemHandSwap.KEY, EventPlayerItemHandSwap.class);
+        customItemEvents.register(EventPlayerItemHeld.KEY, EventPlayerItemHeld.class);
 
         getLogger().info("Register Particle Animators");
         var particleAnimators = getRegistries().getParticleAnimators();
@@ -309,45 +347,13 @@ public final class WolfyCoreBukkit extends WUPlugin {
         particleTimers.register(TimerRandom.KEY, TimerRandom.class);
         particleTimers.register(TimerPi.KEY, TimerPi.class);
 
-        getLogger().info("Register CustomItem Actions");
-        var customItemActions = getRegistries().getCustomItemActions();
-        customItemActions.register(ActionCommand.KEY, ActionCommand.class);
-        customItemActions.register(ActionParticleAnimation.KEY, ActionParticleAnimation.class);
-        customItemActions.register(ActionSound.KEY, ActionSound.class);
+        getLogger().info("Register Custom Block Data");
+        var customBlockData = getRegistries().getCustomBlockData();
+        customBlockData.register(CustomItemBlockData.ID, CustomItemBlockData.class);
 
-        getLogger().info("Register CustomItem Events");
-        var customItemEvents = getRegistries().getCustomItemEvents();
-        customItemEvents.register(EventPlayerInteract.KEY, EventPlayerInteract.class);
-        customItemEvents.register(EventPlayerConsumeItem.KEY, EventPlayerConsumeItem.class);
-        customItemEvents.register(EventPlayerInteractEntity.KEY, EventPlayerInteractEntity.class);
-        customItemEvents.register(EventPlayerInteractAtEntity.KEY, EventPlayerInteractAtEntity.class);
-        customItemEvents.register(EventPlayerItemBreak.KEY, EventPlayerItemBreak.class);
-        customItemEvents.register(EventPlayerItemDamage.KEY, EventPlayerItemDamage.class);
-        customItemEvents.register(EventPlayerItemDrop.KEY, EventPlayerItemDrop.class);
-        customItemEvents.register(EventPlayerItemHandSwap.KEY, EventPlayerItemHandSwap.class);
-        customItemEvents.register(EventPlayerItemHeld.KEY, EventPlayerItemHeld.class);
-
-        getLogger().info("Register JSON Operators");
-        var operators = getRegistries().getOperators();
-        operators.register(ComparisonOperatorEqual.KEY, ComparisonOperatorEqual.class);
-        operators.register(ComparisonOperatorNotEqual.KEY, ComparisonOperatorNotEqual.class);
-        operators.register(ComparisonOperatorGreater.KEY, ComparisonOperatorGreater.class);
-        operators.register(ComparisonOperatorGreaterEqual.KEY, ComparisonOperatorGreaterEqual.class);
-        operators.register(ComparisonOperatorLess.KEY, ComparisonOperatorLess.class);
-        operators.register(ComparisonOperatorLessEqual.KEY, ComparisonOperatorLessEqual.class);
-        operators.register(LogicalOperatorAnd.KEY, LogicalOperatorAnd.class);
-        operators.register(LogicalOperatorOr.KEY, LogicalOperatorOr.class);
-        operators.register(LogicalOperatorNot.KEY, LogicalOperatorNot.class);
-
-        getLogger().info("Register JSON Value Providers");
-        var valueProviders = getRegistries().getValueProviders();
-        valueProviders.register(ValueProviderConditioned.KEY, (Class<ValueProviderConditioned<?>>)(Object) ValueProviderConditioned.class);
-        valueProviders.register(ValueProviderIntegerConst.KEY, ValueProviderIntegerConst.class);
-        valueProviders.register(ValueProviderIntegerVar.KEY, ValueProviderIntegerVar.class);
-        valueProviders.register(ValueProviderFloatConst.KEY, ValueProviderFloatConst.class);
-        valueProviders.register(ValueProviderFloatVar.KEY, ValueProviderFloatVar.class);
-        valueProviders.register(ValueProviderStringConst.KEY, ValueProviderStringConst.class);
-        valueProviders.register(ValueProviderStringVar.KEY, ValueProviderStringVar.class);
+        getLogger().info("Register Custom Player Data");
+        var customPlayerDataReg = getRegistries().getCustomPlayerData();
+        customPlayerDataReg.register(PlayerParticleEffectData.class);
 
         getLogger().info("Register NBT Query Nodes");
         var nbtQueryNodes = getRegistries().getNbtQueryNodes();
@@ -371,14 +377,6 @@ public final class WolfyCoreBukkit extends WUPlugin {
         nbtQueryNodes.register(QueryNodeListFloat.TYPE, QueryNodeListFloat.class);
         nbtQueryNodes.register(QueryNodeListString.TYPE, QueryNodeListString.class);
         nbtQueryNodes.register(QueryNodeListCompound.TYPE, QueryNodeListCompound.class);
-
-        getLogger().info("Register Custom Block Data");
-        var customBlockData = getRegistries().getCustomBlockData();
-        customBlockData.register(CustomItemBlockData.ID, CustomItemBlockData.class);
-
-        getLogger().info("Register Custom Player Data");
-        var customPlayerDataReg = getRegistries().getCustomPlayerData();
-        customPlayerDataReg.register(PlayerParticleEffectData.class);
 
         KeyedTypeIdResolver.registerTypeRegistry(CustomItemData.class, registries.getCustomItemDataTypeRegistry());
         KeyedTypeIdResolver.registerTypeRegistry(Meta.class, nbtChecks);

--- a/core/src/main/java/com/wolfyscript/utilities/bukkit/WolfyCoreBukkit.java
+++ b/core/src/main/java/com/wolfyscript/utilities/bukkit/WolfyCoreBukkit.java
@@ -43,6 +43,7 @@ import com.wolfyscript.utilities.bukkit.persistent.player.PlayerParticleEffectDa
 import com.wolfyscript.utilities.bukkit.persistent.world.CustomBlockData;
 import java.util.ArrayList;
 import java.util.List;
+import me.wolfyscript.utilities.api.WolfyUtilCore;
 import me.wolfyscript.utilities.api.WolfyUtilities;
 import com.wolfyscript.utilities.bukkit.chat.ChatImpl;
 import me.wolfyscript.utilities.api.console.Console;
@@ -87,7 +88,6 @@ import me.wolfyscript.utilities.main.WUPlugin;
 import me.wolfyscript.utilities.main.configs.WUConfig;
 import me.wolfyscript.utilities.messages.MessageFactory;
 import me.wolfyscript.utilities.messages.MessageHandler;
-import me.wolfyscript.utilities.util.entity.PlayerUtils;
 import me.wolfyscript.utilities.util.eval.operators.ComparisonOperatorEqual;
 import me.wolfyscript.utilities.util.eval.operators.ComparisonOperatorGreater;
 import me.wolfyscript.utilities.util.eval.operators.ComparisonOperatorGreaterEqual;
@@ -228,7 +228,7 @@ public final class WolfyCoreBukkit extends WUPlugin {
     @Override
     public void onLoad() {
         //Jackson Serializer
-        getLogger().info("Register json serializer/deserializer");
+        getLogger().info("Register JSON de-/serializers");
         var module = new SimpleModule();
         ItemStackSerialization.create(module);
         ColorSerialization.create(module);
@@ -285,6 +285,7 @@ public final class WolfyCoreBukkit extends WUPlugin {
         nbtChecks.register(RepairCostMeta.KEY, RepairCostMeta.class);
         nbtChecks.register(UnbreakableMeta.KEY, UnbreakableMeta.class);
 
+        getLogger().info("Register Particle Animators");
         var particleAnimators = getRegistries().getParticleAnimators();
         particleAnimators.register(AnimatorBasic.KEY, AnimatorBasic.class);
         particleAnimators.register(AnimatorSphere.KEY, AnimatorSphere.class);
@@ -292,6 +293,7 @@ public final class WolfyCoreBukkit extends WUPlugin {
         particleAnimators.register(AnimatorVectorPath.KEY, AnimatorVectorPath.class);
         particleAnimators.register(AnimatorShape.KEY, AnimatorShape.class);
 
+        getLogger().info("Register Particle Shapes");
         var particleShapes = getRegistries().getParticleShapes();
         particleShapes.register(ShapeSquare.KEY, ShapeSquare.class);
         particleShapes.register(ShapeCircle.KEY, ShapeCircle.class);
@@ -301,16 +303,19 @@ public final class WolfyCoreBukkit extends WUPlugin {
         particleShapes.register(ShapeComplexRotation.KEY, ShapeComplexRotation.class);
         particleShapes.register(ShapeComplexCompound.KEY, ShapeComplexCompound.class);
 
+        getLogger().info("Register Particle Timers");
         var particleTimers = getRegistries().getParticleTimer();
         particleTimers.register(TimerLinear.KEY, TimerLinear.class);
         particleTimers.register(TimerRandom.KEY, TimerRandom.class);
         particleTimers.register(TimerPi.KEY, TimerPi.class);
 
+        getLogger().info("Register CustomItem Actions");
         var customItemActions = getRegistries().getCustomItemActions();
         customItemActions.register(ActionCommand.KEY, ActionCommand.class);
         customItemActions.register(ActionParticleAnimation.KEY, ActionParticleAnimation.class);
         customItemActions.register(ActionSound.KEY, ActionSound.class);
 
+        getLogger().info("Register CustomItem Events");
         var customItemEvents = getRegistries().getCustomItemEvents();
         customItemEvents.register(EventPlayerInteract.KEY, EventPlayerInteract.class);
         customItemEvents.register(EventPlayerConsumeItem.KEY, EventPlayerConsumeItem.class);
@@ -322,6 +327,7 @@ public final class WolfyCoreBukkit extends WUPlugin {
         customItemEvents.register(EventPlayerItemHandSwap.KEY, EventPlayerItemHandSwap.class);
         customItemEvents.register(EventPlayerItemHeld.KEY, EventPlayerItemHeld.class);
 
+        getLogger().info("Register JSON Operators");
         var operators = getRegistries().getOperators();
         operators.register(ComparisonOperatorEqual.KEY, ComparisonOperatorEqual.class);
         operators.register(ComparisonOperatorNotEqual.KEY, ComparisonOperatorNotEqual.class);
@@ -333,6 +339,7 @@ public final class WolfyCoreBukkit extends WUPlugin {
         operators.register(LogicalOperatorOr.KEY, LogicalOperatorOr.class);
         operators.register(LogicalOperatorNot.KEY, LogicalOperatorNot.class);
 
+        getLogger().info("Register JSON Value Providers");
         var valueProviders = getRegistries().getValueProviders();
         valueProviders.register(ValueProviderConditioned.KEY, (Class<ValueProviderConditioned<?>>)(Object) ValueProviderConditioned.class);
         valueProviders.register(ValueProviderIntegerConst.KEY, ValueProviderIntegerConst.class);
@@ -342,6 +349,7 @@ public final class WolfyCoreBukkit extends WUPlugin {
         valueProviders.register(ValueProviderStringConst.KEY, ValueProviderStringConst.class);
         valueProviders.register(ValueProviderStringVar.KEY, ValueProviderStringVar.class);
 
+        getLogger().info("Register NBT Query Nodes");
         var nbtQueryNodes = getRegistries().getNbtQueryNodes();
         nbtQueryNodes.register(QueryNodeCompound.TYPE, QueryNodeCompound.class);
         nbtQueryNodes.register(QueryNodeBoolean.TYPE, QueryNodeBoolean.class);
@@ -356,7 +364,6 @@ public final class WolfyCoreBukkit extends WUPlugin {
         //Arrays
         nbtQueryNodes.register(QueryNodeByteArray.TYPE, QueryNodeByteArray.class);
         nbtQueryNodes.register(QueryNodeIntArray.TYPE, QueryNodeIntArray.class);
-
         //Lists
         nbtQueryNodes.register(QueryNodeListInt.TYPE, QueryNodeListInt.class);
         nbtQueryNodes.register(QueryNodeListLong.TYPE, QueryNodeListLong.class);
@@ -365,6 +372,7 @@ public final class WolfyCoreBukkit extends WUPlugin {
         nbtQueryNodes.register(QueryNodeListString.TYPE, QueryNodeListString.class);
         nbtQueryNodes.register(QueryNodeListCompound.TYPE, QueryNodeListCompound.class);
 
+        getLogger().info("Register Custom Block Data");
         var customBlockData = getRegistries().getCustomBlockData();
         customBlockData.register(CustomItemBlockData.ID, CustomItemBlockData.class);
 
@@ -408,7 +416,6 @@ public final class WolfyCoreBukkit extends WUPlugin {
             this.metrics = new Metrics(this, 5114);
 
             WorldUtils.load();
-            PlayerUtils.loadStores();
             registerListeners();
             registerCommands();
 
@@ -423,7 +430,6 @@ public final class WolfyCoreBukkit extends WUPlugin {
      */
     private void onJUnitTests() {
         WorldUtils.load();
-        PlayerUtils.loadStores();
 
         registerCommands();
     }
@@ -442,7 +448,6 @@ public final class WolfyCoreBukkit extends WUPlugin {
             this.adventure = null;
         }
         api.getConfigAPI().saveConfigs();
-        PlayerUtils.saveStores();
         console.info("Save stored Custom Items");
     }
 

--- a/core/src/main/java/com/wolfyscript/utilities/bukkit/listeners/PersistentStorageListener.java
+++ b/core/src/main/java/com/wolfyscript/utilities/bukkit/listeners/PersistentStorageListener.java
@@ -6,6 +6,7 @@ import com.wolfyscript.utilities.bukkit.events.persistent.BlockStorageDropItemsE
 import com.wolfyscript.utilities.bukkit.events.persistent.BlockStorageMultiPlaceEvent;
 import com.wolfyscript.utilities.bukkit.events.persistent.BlockStoragePlaceEvent;
 import com.wolfyscript.utilities.bukkit.persistent.PersistentStorage;
+import com.wolfyscript.utilities.bukkit.persistent.player.PlayerStorage;
 import com.wolfyscript.utilities.bukkit.persistent.world.BlockStorage;
 import com.wolfyscript.utilities.bukkit.persistent.world.ChunkStorage;
 import com.wolfyscript.utilities.bukkit.persistent.world.WorldStorage;
@@ -42,6 +43,7 @@ import org.bukkit.event.block.BlockPistonRetractEvent;
 import org.bukkit.event.block.BlockPlaceEvent;
 import org.bukkit.event.block.LeavesDecayEvent;
 import org.bukkit.event.entity.EntityExplodeEvent;
+import org.bukkit.event.player.PlayerQuitEvent;
 import org.bukkit.event.server.ServerLoadEvent;
 import org.bukkit.event.world.ChunkLoadEvent;
 import org.bukkit.event.world.ChunkUnloadEvent;
@@ -59,6 +61,12 @@ public class PersistentStorageListener implements Listener {
     public PersistentStorageListener(WolfyCoreBukkit core) {
         this.core = core;
         this.persistentStorage = core.getPersistentStorage();
+    }
+
+    @EventHandler
+    private void onPlayerQuit(PlayerQuitEvent event) {
+        PlayerStorage playerStorage = persistentStorage.getOrCreatePlayerStorage(event.getPlayer());
+        playerStorage.updateAndClearCache(); // Clear cache when player leaves the server, to not waste memory!
     }
 
     @EventHandler

--- a/core/src/main/java/com/wolfyscript/utilities/bukkit/listeners/PlayerListener.java
+++ b/core/src/main/java/com/wolfyscript/utilities/bukkit/listeners/PlayerListener.java
@@ -18,7 +18,6 @@
 
 package com.wolfyscript.utilities.bukkit.listeners;
 
-import me.wolfyscript.utilities.util.entity.PlayerUtils;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
 import org.bukkit.event.player.PlayerJoinEvent;
@@ -27,7 +26,7 @@ public class PlayerListener implements Listener {
 
     @EventHandler
     public void onJoin(PlayerJoinEvent event) {
-        PlayerUtils.getStore(event.getPlayer());
+
     }
 
 }

--- a/core/src/main/java/com/wolfyscript/utilities/bukkit/listeners/custom_item/CustomParticleListener.java
+++ b/core/src/main/java/com/wolfyscript/utilities/bukkit/listeners/custom_item/CustomParticleListener.java
@@ -18,6 +18,9 @@
 
 package com.wolfyscript.utilities.bukkit.listeners.custom_item;
 
+import com.wolfyscript.utilities.bukkit.WolfyCoreBukkit;
+import com.wolfyscript.utilities.bukkit.persistent.player.PlayerParticleEffectData;
+import com.wolfyscript.utilities.bukkit.persistent.player.PlayerStorage;
 import me.wolfyscript.utilities.api.inventory.custom_items.CustomItem;
 import me.wolfyscript.utilities.util.entity.PlayerUtils;
 import org.bukkit.Material;
@@ -26,10 +29,23 @@ import org.bukkit.event.Listener;
 import org.bukkit.event.entity.EntityPickupItemEvent;
 import org.bukkit.event.player.PlayerDropItemEvent;
 import org.bukkit.event.player.PlayerItemHeldEvent;
+import org.bukkit.event.player.PlayerJoinEvent;
 import org.bukkit.event.player.PlayerSwapHandItemsEvent;
 import org.bukkit.inventory.EquipmentSlot;
 
 public class CustomParticleListener implements Listener {
+
+    private final WolfyCoreBukkit core;
+
+    public CustomParticleListener(WolfyCoreBukkit core) {
+        this.core = core;
+    }
+
+    @EventHandler
+    private void onPlayerJoin(PlayerJoinEvent event) {
+        PlayerStorage playerStorage = core.getPersistentStorage().getOrCreatePlayerStorage(event.getPlayer());
+        playerStorage.computeIfAbsent(PlayerParticleEffectData.class, type -> new PlayerParticleEffectData());
+    }
 
     @EventHandler
     public void onItemHeld(PlayerItemHeldEvent event) {

--- a/core/src/main/java/com/wolfyscript/utilities/bukkit/persistent/PersistentStorage.java
+++ b/core/src/main/java/com/wolfyscript/utilities/bukkit/persistent/PersistentStorage.java
@@ -12,6 +12,13 @@ import java.util.UUID;
 import org.bukkit.entity.Player;
 import org.jetbrains.annotations.NotNull;
 
+/**
+ * The PersistentStorage API allows plugins to store custom complex data into block/chunks and players.<br>
+ * It uses the {@link org.bukkit.persistence.PersistentDataHolder} and {@link org.bukkit.persistence.PersistentDataContainer} API to store the data.<br>
+ * <br>
+ * This class keeps track of the cached storage instances of worlds and players, and possibly more.
+ *
+ */
 public class PersistentStorage {
 
     private final Map<UUID, WorldStorage> WORLD_STORAGE = new HashMap<>();
@@ -22,11 +29,23 @@ public class PersistentStorage {
         this.core = core;
     }
 
+    /**
+     * Gets the already existing storage instance of that world or creates a new one.
+     *
+     * @param world The world to get/create the storage for.
+     * @return The world storage instance of the specified world.
+     */
     public WorldStorage getOrCreateWorldStorage(@NotNull World world) {
         Preconditions.checkNotNull(world, "The world cannot be null!");
         return WORLD_STORAGE.computeIfAbsent(world.getUID(), uuid -> new WorldStorage(core, uuid));
     }
 
+    /**
+     * Gets the existing storage instance of the given player, or creates a new one when it doesn't exist.
+     *
+     * @param player The player to get the data for.
+     * @return The player storage instance of the specified player.
+     */
     public PlayerStorage getOrCreatePlayerStorage(@NotNull Player player) {
         Preconditions.checkNotNull(player, "The player cannot be null!");
         return PLAYER_STORAGE.computeIfAbsent(player.getUniqueId(), uuid -> new PlayerStorage(core, uuid));

--- a/core/src/main/java/com/wolfyscript/utilities/bukkit/persistent/PersistentStorage.java
+++ b/core/src/main/java/com/wolfyscript/utilities/bukkit/persistent/PersistentStorage.java
@@ -1,7 +1,7 @@
 package com.wolfyscript.utilities.bukkit.persistent;
 
 import com.google.common.base.Preconditions;
-import com.wolfyscript.utilities.bukkit.WolfyCoreBukkit;
+import com.wolfyscript.utilities.bukkit.persistent.player.PlayerStorage;
 import com.wolfyscript.utilities.bukkit.persistent.world.WorldStorage;
 import me.wolfyscript.utilities.api.WolfyUtilCore;
 import org.bukkit.World;
@@ -9,11 +9,13 @@ import org.bukkit.World;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.UUID;
+import org.bukkit.entity.Player;
 import org.jetbrains.annotations.NotNull;
 
 public class PersistentStorage {
 
     private final Map<UUID, WorldStorage> WORLD_STORAGE = new HashMap<>();
+    private final Map<UUID, PlayerStorage> PLAYER_STORAGE = new HashMap<>();
     private final WolfyUtilCore core;
 
     public PersistentStorage(WolfyUtilCore core) {
@@ -23,6 +25,11 @@ public class PersistentStorage {
     public WorldStorage getOrCreateWorldStorage(@NotNull World world) {
         Preconditions.checkNotNull(world, "The world cannot be null!");
         return WORLD_STORAGE.computeIfAbsent(world.getUID(), uuid -> new WorldStorage(core, uuid));
+    }
+
+    public PlayerStorage getOrCreatePlayerStorage(@NotNull Player player) {
+        Preconditions.checkNotNull(player, "The player cannot be null!");
+        return PLAYER_STORAGE.computeIfAbsent(player.getUniqueId(), uuid -> new PlayerStorage(core, uuid));
     }
 
     public WolfyUtilCore getCore() {

--- a/core/src/main/java/com/wolfyscript/utilities/bukkit/persistent/player/CustomPlayerData.java
+++ b/core/src/main/java/com/wolfyscript/utilities/bukkit/persistent/player/CustomPlayerData.java
@@ -6,11 +6,15 @@ import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.fasterxml.jackson.databind.annotation.JsonTypeIdResolver;
 import com.fasterxml.jackson.databind.annotation.JsonTypeResolver;
+import java.util.Optional;
+import java.util.UUID;
 import me.wolfyscript.utilities.registry.Registries;
 import me.wolfyscript.utilities.util.Keyed;
 import me.wolfyscript.utilities.util.NamespacedKey;
 import me.wolfyscript.utilities.util.json.jackson.KeyedTypeIdResolver;
 import me.wolfyscript.utilities.util.json.jackson.KeyedTypeResolver;
+import org.bukkit.Bukkit;
+import org.bukkit.entity.Player;
 
 /**
  * Custom Data that can be applied to Players and persists across server restarts.<br>
@@ -54,6 +58,16 @@ public abstract class CustomPlayerData implements Keyed {
      * @return A deep-copy of this custom data.
      */
     public abstract CustomPlayerData copy();
+
+    /**
+     * Convenience method to get the player by uuid.
+     *
+     * @param uuid The uuid of the player.
+     * @return The online player with that uuid; or empty optional if not online.
+     */
+    protected Optional<Player> getPlayer(UUID uuid) {
+        return Optional.ofNullable(Bukkit.getPlayer(uuid));
+    }
 
     @JsonIgnore
     @Override

--- a/core/src/main/java/com/wolfyscript/utilities/bukkit/persistent/player/CustomPlayerData.java
+++ b/core/src/main/java/com/wolfyscript/utilities/bukkit/persistent/player/CustomPlayerData.java
@@ -29,6 +29,10 @@ public abstract class CustomPlayerData implements Keyed {
     @JsonProperty("id")
     private final NamespacedKey id;
 
+    /**
+     * The default constructor that must get the id of the custom data type.
+     * @param id The id of the custom data type.
+     */
     protected CustomPlayerData(NamespacedKey id) {
         this.id = id;
     }
@@ -45,6 +49,10 @@ public abstract class CustomPlayerData implements Keyed {
      */
     public abstract void onUnload();
 
+    /**
+     * Copies the custom data.
+     * @return A deep-copy of this custom data.
+     */
     public abstract CustomPlayerData copy();
 
     @JsonIgnore

--- a/core/src/main/java/com/wolfyscript/utilities/bukkit/persistent/player/CustomPlayerData.java
+++ b/core/src/main/java/com/wolfyscript/utilities/bukkit/persistent/player/CustomPlayerData.java
@@ -6,11 +6,20 @@ import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.fasterxml.jackson.databind.annotation.JsonTypeIdResolver;
 import com.fasterxml.jackson.databind.annotation.JsonTypeResolver;
+import me.wolfyscript.utilities.registry.Registries;
 import me.wolfyscript.utilities.util.Keyed;
 import me.wolfyscript.utilities.util.NamespacedKey;
 import me.wolfyscript.utilities.util.json.jackson.KeyedTypeIdResolver;
 import me.wolfyscript.utilities.util.json.jackson.KeyedTypeResolver;
 
+/**
+ * Custom Data that can be applied to Players and persists across server restarts.<br>
+ * <br>
+ * How to create custom data:<br>
+ * - Extend this class<br>
+ * - Register class into Registry {@link Registries#getCustomPlayerData()}
+ *
+ */
 @JsonTypeResolver(KeyedTypeResolver.class)
 @JsonTypeIdResolver(KeyedTypeIdResolver.class)
 @JsonTypeInfo(use = JsonTypeInfo.Id.CUSTOM, include = JsonTypeInfo.As.EXISTING_PROPERTY, property = "id")

--- a/core/src/main/java/com/wolfyscript/utilities/bukkit/persistent/player/CustomPlayerData.java
+++ b/core/src/main/java/com/wolfyscript/utilities/bukkit/persistent/player/CustomPlayerData.java
@@ -1,0 +1,47 @@
+package com.wolfyscript.utilities.bukkit.persistent.player;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import com.fasterxml.jackson.databind.annotation.JsonTypeIdResolver;
+import com.fasterxml.jackson.databind.annotation.JsonTypeResolver;
+import me.wolfyscript.utilities.util.Keyed;
+import me.wolfyscript.utilities.util.NamespacedKey;
+import me.wolfyscript.utilities.util.json.jackson.KeyedTypeIdResolver;
+import me.wolfyscript.utilities.util.json.jackson.KeyedTypeResolver;
+
+@JsonTypeResolver(KeyedTypeResolver.class)
+@JsonTypeIdResolver(KeyedTypeIdResolver.class)
+@JsonTypeInfo(use = JsonTypeInfo.Id.CUSTOM, include = JsonTypeInfo.As.EXISTING_PROPERTY, property = "id")
+@JsonPropertyOrder(value = {"id"})
+public abstract class CustomPlayerData implements Keyed {
+
+    @JsonProperty("id")
+    private final NamespacedKey id;
+
+    protected CustomPlayerData(NamespacedKey id) {
+        this.id = id;
+    }
+
+    /**
+     * Called when the CustomPlayerData is initialising its data.
+     * This happens right before it is added to the player, so the PlayerStorage does not yet contain it!
+     */
+    public abstract void onLoad();
+
+    /**
+     * Called when the CustomPlayerData is removed from the Player.
+     * This happens right before it is removed from the player, so the PlayerStorage still contains it!
+     */
+    public abstract void onUnload();
+
+    public abstract CustomPlayerData copy();
+
+    @JsonIgnore
+    @Override
+    public NamespacedKey getNamespacedKey() {
+        return id;
+    }
+
+}

--- a/core/src/main/java/com/wolfyscript/utilities/bukkit/persistent/player/PlayerParticleEffectData.java
+++ b/core/src/main/java/com/wolfyscript/utilities/bukkit/persistent/player/PlayerParticleEffectData.java
@@ -1,5 +1,6 @@
 package com.wolfyscript.utilities.bukkit.persistent.player;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.wolfyscript.utilities.KeyedStaticId;
 import java.util.EnumMap;
 import java.util.Map;
@@ -38,6 +39,7 @@ public class PlayerParticleEffectData extends CustomPlayerData {
      *
      * @return The active particle effects on the player
      */
+    @JsonIgnore
     public Map<EquipmentSlot, UUID> getActiveItemEffects() {
         return new EnumMap<>(effectsPerSlot);
     }

--- a/core/src/main/java/com/wolfyscript/utilities/bukkit/persistent/player/PlayerParticleEffectData.java
+++ b/core/src/main/java/com/wolfyscript/utilities/bukkit/persistent/player/PlayerParticleEffectData.java
@@ -1,0 +1,63 @@
+package com.wolfyscript.utilities.bukkit.persistent.player;
+
+import com.wolfyscript.utilities.KeyedStaticId;
+import java.util.EnumMap;
+import java.util.Map;
+import java.util.UUID;
+import me.wolfyscript.utilities.util.NamespacedKey;
+import me.wolfyscript.utilities.util.particles.ParticleUtils;
+import org.bukkit.inventory.EquipmentSlot;
+
+@KeyedStaticId(value = "wolfyutilities:particles/effects")
+public class PlayerParticleEffectData extends CustomPlayerData {
+
+    public static final NamespacedKey ID = NamespacedKey.wolfyutilties("particles/effects");
+
+    private final Map<EquipmentSlot, UUID> effectsPerSlot = new EnumMap<>(EquipmentSlot.class);
+
+    public PlayerParticleEffectData() {
+        super(ID);
+    }
+
+    @Override
+    public void onLoad() {
+
+    }
+
+    @Override
+    public void onUnload() {
+
+    }
+
+    public boolean hasActiveItemEffects(EquipmentSlot equipmentSlot) {
+        return effectsPerSlot.containsKey(equipmentSlot);
+    }
+
+    /**
+     * Gets the particle effects that are currently active on the player.
+     *
+     * @return The active particle effects on the player
+     */
+    public Map<EquipmentSlot, UUID> getActiveItemEffects() {
+        return new EnumMap<>(effectsPerSlot);
+    }
+
+    public UUID getActiveItemEffects(EquipmentSlot equipmentSlot) {
+        return effectsPerSlot.get(equipmentSlot);
+    }
+
+    public void setActiveParticleEffect(EquipmentSlot equipmentSlot, UUID effectUUID) {
+        stopActiveParticleEffect(equipmentSlot);
+        effectsPerSlot.put(equipmentSlot, effectUUID);
+    }
+
+    public void stopActiveParticleEffect(EquipmentSlot equipmentSlot) {
+        ParticleUtils.stopAnimation(getActiveItemEffects(equipmentSlot));
+        effectsPerSlot.remove(equipmentSlot);
+    }
+
+    @Override
+    public CustomPlayerData copy() {
+        return null;
+    }
+}

--- a/core/src/main/java/com/wolfyscript/utilities/bukkit/persistent/player/PlayerStorage.java
+++ b/core/src/main/java/com/wolfyscript/utilities/bukkit/persistent/player/PlayerStorage.java
@@ -3,9 +3,13 @@ package com.wolfyscript.utilities.bukkit.persistent.player;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.InjectableValues;
 import com.wolfyscript.utilities.bukkit.persistent.world.CustomBlockData;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
+import java.util.function.Function;
 import me.wolfyscript.utilities.api.WolfyUtilCore;
+import me.wolfyscript.utilities.registry.Registries;
 import me.wolfyscript.utilities.util.NamespacedKey;
 import org.bukkit.Bukkit;
 import org.bukkit.entity.Player;
@@ -20,20 +24,44 @@ public class PlayerStorage {
     private final WolfyUtilCore core;
     private final UUID playerUUID;
 
+    private final Map<NamespacedKey, CustomPlayerData> CACHED_DATA = new HashMap<>();
+
     public PlayerStorage(WolfyUtilCore core, UUID playerUUID) {
         this.core = core;
         this.playerUUID = playerUUID;
     }
 
+    /**
+     * Gets the player to which this storage belongs.
+     *
+     * @return The player linked to this storage; or empty Optional if not available or offline.
+     */
     public Optional<Player> getPlayer () {
         return Optional.ofNullable(Bukkit.getPlayer(playerUUID));
     }
 
+    /**
+     * Gets the {@link PersistentDataContainer} from the owner (Player) that is used to store the data.
+     *
+     * @return The {@link PersistentDataContainer} of the owner; or empty Optional if owner is offline.
+     */
     public Optional<PersistentDataContainer> getPersistentDataContainer() {
         return getPlayer().map(PersistentDataHolder::getPersistentDataContainer);
     }
 
-    public void setData(CustomPlayerData data) {
+    /**
+     * Adds/Updates the specified custom data to this storage.<br>
+     * The data is then cached and added to the persistent storage!<br>
+     * Therefor this method should only be used a limited amount of times!
+     *
+     * @param data
+     * @return The previous cached value, if any; otherwise null
+     */
+    public <T extends CustomPlayerData> T setData(T data) {
+        T prev = (T) CACHED_DATA.put(data.getNamespacedKey(), data);
+        if (prev != null) {
+            prev.onUnload();
+        }
         getPersistentDataContainer().ifPresent(container -> {
             var dataContainer = container.getOrDefault(DATA_KEY, PersistentDataType.TAG_CONTAINER, container.getAdapterContext().newPersistentDataContainer());
             var objectMapper = core.getWolfyUtils().getJacksonMapperUtil().getGlobalMapper();
@@ -45,29 +73,113 @@ public class PlayerStorage {
             }
             container.set(DATA_KEY, PersistentDataType.TAG_CONTAINER, dataContainer);
         });
+        return prev;
     }
 
-    public <T extends CustomPlayerData> Optional<T> getData(Class<T> dataType) {
-        NamespacedKey dataID = core.getRegistries().getCustomPlayerData().getKey(dataType);
-        return getPersistentDataContainer().map(container -> {
-            var dataContainer = container.getOrDefault(DATA_KEY, PersistentDataType.TAG_CONTAINER, container.getAdapterContext().newPersistentDataContainer());
-            var objectMapper = core.getWolfyUtils().getJacksonMapperUtil().getGlobalMapper();
-            org.bukkit.NamespacedKey key = dataID.bukkit();
-            if (dataContainer.has(key, PersistentDataType.STRING)) {
-                try {
-                    return objectMapper.reader(new InjectableValues.Std().addValue(WolfyUtilCore.class, core)).forType(CustomBlockData.class).readValue(dataContainer.get(key, PersistentDataType.STRING));
-                } catch (JsonProcessingException e) {
-                    e.printStackTrace();
-                }
-            }
-            return null;
+    /**
+     * Gets the data that is saved under the specified type, or if not available gets and sets the default data.
+     *
+     * @param dataType The type of the data.
+     * @param defaultValue Function that creates the default value.
+     * @return The existing data; or the newly set default value.
+     * @param <T> The type of the data.
+     */
+    public <T extends CustomPlayerData> Optional<T> computeIfAbsent(Class<T> dataType, Function<Class<T>, T> defaultValue) {
+        return getData(dataType).or(() -> {
+            T data = defaultValue.apply(dataType);
+            setData(data);
+            return Optional.ofNullable(data);
         });
     }
 
-    public void removeData(NamespacedKey dataID) {
+    /**
+     * Gets the data that is saved under the specified type.<br>
+     * In case the value is not yet loaded into the cache it deserializes it from the persistent data container.<br>
+     * If the persistent data container is not available, which is the case when the player is offline, it returns an empty Optional.<br>
+     *
+     * @param dataType The type of the data. Must be registered in {@link Registries#getCustomPlayerData()}!
+     * @return The data of the specified type; or empty Optional when not available.
+     * @param <T> The type of the data.
+     */
+    public <T extends CustomPlayerData> Optional<T> getData(Class<T> dataType) {
+        NamespacedKey dataID = core.getRegistries().getCustomPlayerData().getKey(dataType);
+        T dataResult = dataType.cast(CACHED_DATA.get(dataID));
+        if (dataResult == null) {
+            // If there isn't any cached data yet
+            Optional<T> data = getPersistentDataContainer().map(container -> {
+                var dataContainer = container.getOrDefault(DATA_KEY, PersistentDataType.TAG_CONTAINER, container.getAdapterContext().newPersistentDataContainer());
+                var objectMapper = core.getWolfyUtils().getJacksonMapperUtil().getGlobalMapper();
+                org.bukkit.NamespacedKey key = dataID.bukkit();
+                if (dataContainer.has(key, PersistentDataType.STRING)) {
+                    try {
+                        return objectMapper.reader(new InjectableValues.Std().addValue(WolfyUtilCore.class, core)).forType(CustomBlockData.class).readValue(dataContainer.get(key, PersistentDataType.STRING));
+                    } catch (JsonProcessingException e) {
+                        e.printStackTrace();
+                    }
+                }
+                return null;
+            });
+            dataResult = data.orElse(null);
+            CACHED_DATA.put(dataID, dataResult);
+        }
+        return Optional.ofNullable(dataResult);
+    }
+
+    /**
+     * Removes the data saved under the specified id.
+     *
+     * @param dataType The type of the data. Must be registered in {@link Registries#getCustomPlayerData()}!
+     * @return The removed data value; or null if nothing was removed.
+     * @param <T> The type of the data.
+     */
+    public <T extends CustomPlayerData> T removeData(Class<T> dataType) {
+        NamespacedKey dataID = core.getRegistries().getCustomPlayerData().getKey(dataType);
+        T prev = dataType.cast(CACHED_DATA.remove(dataID));
+        if (prev != null) {
+            prev.onUnload();
+        }
         getPersistentDataContainer().ifPresent(container -> {
             var dataContainer = container.getOrDefault(DATA_KEY, PersistentDataType.TAG_CONTAINER, container.getAdapterContext().newPersistentDataContainer());
             dataContainer.remove(dataID.bukkit());
+            container.set(DATA_KEY, PersistentDataType.TAG_CONTAINER, dataContainer);
+        });
+        return prev;
+    }
+
+    /**
+     * Removes the data saved under the specified id.
+     *
+     * @param dataID The id of the data.
+     * @return The removed data value; or null if nothing was removed.
+     */
+    public CustomPlayerData removeData(NamespacedKey dataID) {
+        return removeData(core.getRegistries().getCustomPlayerData().get(dataID));
+    }
+
+    /**
+     * Updates all the currently cached values in the persistent data container
+     * and clears the cache afterwards.
+     */
+    public void updateAndClearCache() {
+        update();
+        CACHED_DATA.clear();
+    }
+
+    /**
+     * Updates all the currently cached values in the persistent data container.
+     */
+    public void update() {
+        if (CACHED_DATA.isEmpty()) return;
+        getPersistentDataContainer().ifPresent(container -> {
+            var dataContainer = container.getOrDefault(DATA_KEY, PersistentDataType.TAG_CONTAINER, container.getAdapterContext().newPersistentDataContainer());
+            var objectMapper = core.getWolfyUtils().getJacksonMapperUtil().getGlobalMapper();
+            for (Map.Entry<NamespacedKey, CustomPlayerData> dataEntry : CACHED_DATA.entrySet()) {
+                try {
+                    dataContainer.set(dataEntry.getKey().bukkit(), PersistentDataType.STRING, objectMapper.writeValueAsString(dataEntry.getValue()));
+                } catch (JsonProcessingException e) {
+                    throw new RuntimeException(e);
+                }
+            }
             container.set(DATA_KEY, PersistentDataType.TAG_CONTAINER, dataContainer);
         });
     }

--- a/core/src/main/java/com/wolfyscript/utilities/bukkit/persistent/player/PlayerStorage.java
+++ b/core/src/main/java/com/wolfyscript/utilities/bukkit/persistent/player/PlayerStorage.java
@@ -17,13 +17,21 @@ import org.bukkit.persistence.PersistentDataContainer;
 import org.bukkit.persistence.PersistentDataHolder;
 import org.bukkit.persistence.PersistentDataType;
 
+/**
+ * This class stores data for player entities.<br>
+ * If the player is offline, then the stored data is inaccessible.<br>
+ * <br>
+ * {@link CustomPlayerData} stored using {@link #setData(CustomPlayerData)} or {@link #computeIfAbsent(Class, Function)}
+ * is directly cached and stored into the {@link PersistentDataContainer} of the player.<br>
+ * When data is requested via {@link #getData(Class)} it first tries to look for the cached data, and if unavailable
+ * it tries to load it from the {@link PersistentDataContainer}. Only if both fail to find the data it returns an empty value.
+ */
 public class PlayerStorage {
 
     private static final org.bukkit.NamespacedKey DATA_KEY = new org.bukkit.NamespacedKey("wolfyutils", "data");
 
     private final WolfyUtilCore core;
     private final UUID playerUUID;
-
     private final Map<NamespacedKey, CustomPlayerData> CACHED_DATA = new HashMap<>();
 
     public PlayerStorage(WolfyUtilCore core, UUID playerUUID) {
@@ -50,11 +58,11 @@ public class PlayerStorage {
     }
 
     /**
-     * Adds/Updates the specified custom data to this storage.<br>
+     * Adds/Updates the specified custom data to/in this storage.<br>
      * The data is then cached and added to the persistent storage!<br>
      * Therefor this method should only be used a limited amount of times!
      *
-     * @param data
+     * @param data The data value to add/update
      * @return The previous cached value, if any; otherwise null
      */
     public <T extends CustomPlayerData> T setData(T data) {

--- a/core/src/main/java/com/wolfyscript/utilities/bukkit/persistent/player/PlayerStorage.java
+++ b/core/src/main/java/com/wolfyscript/utilities/bukkit/persistent/player/PlayerStorage.java
@@ -1,4 +1,75 @@
 package com.wolfyscript.utilities.bukkit.persistent.player;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.InjectableValues;
+import com.wolfyscript.utilities.bukkit.persistent.world.CustomBlockData;
+import java.util.Optional;
+import java.util.UUID;
+import me.wolfyscript.utilities.api.WolfyUtilCore;
+import me.wolfyscript.utilities.util.NamespacedKey;
+import org.bukkit.Bukkit;
+import org.bukkit.entity.Player;
+import org.bukkit.persistence.PersistentDataContainer;
+import org.bukkit.persistence.PersistentDataHolder;
+import org.bukkit.persistence.PersistentDataType;
+
 public class PlayerStorage {
+
+    private static final org.bukkit.NamespacedKey DATA_KEY = new org.bukkit.NamespacedKey("wolfyutils", "data");
+
+    private final WolfyUtilCore core;
+    private final UUID playerUUID;
+
+    public PlayerStorage(WolfyUtilCore core, UUID playerUUID) {
+        this.core = core;
+        this.playerUUID = playerUUID;
+    }
+
+    public Optional<Player> getPlayer () {
+        return Optional.ofNullable(Bukkit.getPlayer(playerUUID));
+    }
+
+    public Optional<PersistentDataContainer> getPersistentDataContainer() {
+        return getPlayer().map(PersistentDataHolder::getPersistentDataContainer);
+    }
+
+    public void setData(CustomPlayerData data) {
+        getPersistentDataContainer().ifPresent(container -> {
+            var dataContainer = container.getOrDefault(DATA_KEY, PersistentDataType.TAG_CONTAINER, container.getAdapterContext().newPersistentDataContainer());
+            var objectMapper = core.getWolfyUtils().getJacksonMapperUtil().getGlobalMapper();
+            try {
+                data.onLoad();
+                dataContainer.set(data.getNamespacedKey().bukkit(), PersistentDataType.STRING, objectMapper.writeValueAsString(data));
+            } catch (JsonProcessingException e) {
+                throw new RuntimeException(e);
+            }
+            container.set(DATA_KEY, PersistentDataType.TAG_CONTAINER, dataContainer);
+        });
+    }
+
+    public <T extends CustomPlayerData> Optional<T> getData(Class<T> dataType) {
+        NamespacedKey dataID = core.getRegistries().getCustomPlayerData().getKey(dataType);
+        return getPersistentDataContainer().map(container -> {
+            var dataContainer = container.getOrDefault(DATA_KEY, PersistentDataType.TAG_CONTAINER, container.getAdapterContext().newPersistentDataContainer());
+            var objectMapper = core.getWolfyUtils().getJacksonMapperUtil().getGlobalMapper();
+            org.bukkit.NamespacedKey key = dataID.bukkit();
+            if (dataContainer.has(key, PersistentDataType.STRING)) {
+                try {
+                    return objectMapper.reader(new InjectableValues.Std().addValue(WolfyUtilCore.class, core)).forType(CustomBlockData.class).readValue(dataContainer.get(key, PersistentDataType.STRING));
+                } catch (JsonProcessingException e) {
+                    e.printStackTrace();
+                }
+            }
+            return null;
+        });
+    }
+
+    public void removeData(NamespacedKey dataID) {
+        getPersistentDataContainer().ifPresent(container -> {
+            var dataContainer = container.getOrDefault(DATA_KEY, PersistentDataType.TAG_CONTAINER, container.getAdapterContext().newPersistentDataContainer());
+            dataContainer.remove(dataID.bukkit());
+            container.set(DATA_KEY, PersistentDataType.TAG_CONTAINER, dataContainer);
+        });
+    }
+
 }

--- a/core/src/main/java/me/wolfyscript/utilities/registry/Registries.java
+++ b/core/src/main/java/me/wolfyscript/utilities/registry/Registries.java
@@ -21,6 +21,7 @@ package me.wolfyscript.utilities.registry;
 import com.google.common.base.Preconditions;
 import com.wolfyscript.utilities.bukkit.items.CustomItemData;
 import com.wolfyscript.utilities.bukkit.nbt.QueryNode;
+import com.wolfyscript.utilities.bukkit.persistent.player.CustomPlayerData;
 import com.wolfyscript.utilities.bukkit.persistent.world.CustomBlockData;
 import me.wolfyscript.utilities.api.WolfyUtilCore;
 import me.wolfyscript.utilities.api.WolfyUtilities;
@@ -88,7 +89,9 @@ public class Registries {
     private final TypeRegistry<Meta> customItemNbtChecks;
     private final TypeRegistry<Action<?>> customItemActions;
     private final TypeRegistry<Event<?>> customItemEvents;
+
     private final TypeRegistry<CustomBlockData> customBlockData;
+    private final TypeRegistry<CustomPlayerData> customPlayerData;
     private final TypeRegistry<CustomItemData> customItemDataTypeRegistry;
 
     private final TypeRegistry<ValueProvider<?>> valueProviders;
@@ -118,6 +121,7 @@ public class Registries {
         valueProviders = new UniqueTypeRegistrySimple<>(new NamespacedKey(core, "value_providers"), this);
         operators = new UniqueTypeRegistrySimple<>(new NamespacedKey(core, "operators"), this);
 
+        customPlayerData = new UniqueTypeRegistrySimple<>(new NamespacedKey(core, "persistent/player"), this);
         customBlockData = new UniqueTypeRegistrySimple<>(new NamespacedKey(core, "persistent/block"), this);
 
         this.nbtQueryNodes = new UniqueTypeRegistrySimple<>(new NamespacedKey(core, "nbt/query/nodes"), this);
@@ -262,6 +266,10 @@ public class Registries {
 
     public TypeRegistry<Operator> getOperators() {
         return operators;
+    }
+
+    public TypeRegistry<CustomPlayerData> getCustomPlayerData() {
+        return customPlayerData;
     }
 
     public TypeRegistry<CustomBlockData> getCustomBlockData() {

--- a/core/src/main/java/me/wolfyscript/utilities/registry/Registries.java
+++ b/core/src/main/java/me/wolfyscript/utilities/registry/Registries.java
@@ -111,9 +111,9 @@ public class Registries {
 
         itemTags = new Tags<>(this);
 
-        particleAnimators = new UniqueTypeRegistrySimple<>(new NamespacedKey(core, "particle_animators"), this);
+        particleAnimators = new UniqueTypeRegistrySimple<>(new NamespacedKey(core, "particles/animators"), this);
         particleShapes = new UniqueTypeRegistrySimple<>(new NamespacedKey(core, "particles/shapes"), this);
-        particleTimer = new UniqueTypeRegistrySimple<>(new NamespacedKey(core, "particle_timers"), this);
+        particleTimer = new UniqueTypeRegistrySimple<>(new NamespacedKey(core, "particles/timers"), this);
         customItemNbtChecks = new UniqueTypeRegistrySimple<>(ITEM_NBT_CHECKS, this);
         customItemDataTypeRegistry = new UniqueTypeRegistrySimple<>(ITEM_CUSTOM_DATA, this);
         customItemActions = new UniqueTypeRegistrySimple<>(ITEM_ACTION_TYPES, this);

--- a/core/src/main/java/me/wolfyscript/utilities/util/entity/CustomPlayerData.java
+++ b/core/src/main/java/me/wolfyscript/utilities/util/entity/CustomPlayerData.java
@@ -30,6 +30,7 @@ import java.lang.reflect.InvocationTargetException;
 import java.util.HashMap;
 import java.util.Map;
 
+@Deprecated
 public abstract class CustomPlayerData {
 
     static Map<NamespacedKey, Provider<?>> providers = new HashMap<>();

--- a/core/src/main/java/me/wolfyscript/utilities/util/entity/PlayerStore.java
+++ b/core/src/main/java/me/wolfyscript/utilities/util/entity/PlayerStore.java
@@ -18,18 +18,29 @@
 
 package me.wolfyscript.utilities.util.entity;
 
+import java.util.HashMap;
+import java.util.Map;
 import me.wolfyscript.utilities.util.NamespacedKey;
 
 @Deprecated
 public class PlayerStore {
+
+    private final Map<NamespacedKey, CustomPlayerData> cachedData = new HashMap<>();
 
     /**
      * Only used for Json deserialization purposes!
      */
     public PlayerStore() { }
 
+    /**
+     * @deprecated Changes made to the data is no longer persistent across server restarts!
+     */
+    @Deprecated
     public <D extends CustomPlayerData> D getData(NamespacedKey dataKey, Class<D> dataType) {
-        return null;
+        return dataType.cast(cachedData.computeIfAbsent(dataKey, namespacedKey -> {
+            CustomPlayerData.Provider<?> provider = CustomPlayerData.providers.get(namespacedKey);
+            return provider != null ? provider.createData() : null;
+        }));
     }
 
     @Override

--- a/core/src/main/java/me/wolfyscript/utilities/util/entity/PlayerStore.java
+++ b/core/src/main/java/me/wolfyscript/utilities/util/entity/PlayerStore.java
@@ -18,118 +18,24 @@
 
 package me.wolfyscript.utilities.util.entity;
 
-import com.fasterxml.jackson.core.JsonGenerator;
-import com.fasterxml.jackson.core.JsonParser;
-import com.fasterxml.jackson.databind.DeserializationContext;
-import com.fasterxml.jackson.databind.JsonDeserializer;
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.JsonSerializer;
-import com.fasterxml.jackson.databind.SerializerProvider;
-import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
-import com.fasterxml.jackson.databind.annotation.JsonSerialize;
-import me.wolfyscript.utilities.api.WolfyUtilities;
 import me.wolfyscript.utilities.util.NamespacedKey;
-import me.wolfyscript.utilities.util.json.jackson.JacksonUtil;
 
-import java.io.BufferedInputStream;
-import java.io.BufferedOutputStream;
-import java.io.File;
-import java.io.FileInputStream;
-import java.io.FileOutputStream;
-import java.io.IOException;
-import java.util.HashMap;
-import java.util.Map;
-import java.util.UUID;
-import java.util.zip.GZIPInputStream;
-import java.util.zip.GZIPOutputStream;
-
-@JsonSerialize(using = PlayerStore.Serializer.class)
-@JsonDeserialize(using = PlayerStore.Deserializer.class)
+@Deprecated
 public class PlayerStore {
-
-    private final Map<NamespacedKey, CustomPlayerData> data;
 
     /**
      * Only used for Json deserialization purposes!
      */
-    public PlayerStore() {
-        this.data = new HashMap<>();
-        for (Map.Entry<NamespacedKey, CustomPlayerData.Provider<?>> entry : CustomPlayerData.providers.entrySet()) {
-            data.put(entry.getKey(), entry.getValue().createData());
-        }
-    }
-
-    static PlayerStore load(UUID uuid) {
-        var file = new File(PlayerUtils.STORE_FOLDER + File.separator + uuid.toString() + ".store");
-        if (file.exists()) {
-            try (var bufStream = new BufferedInputStream(new GZIPInputStream(new FileInputStream(file)))) {
-                var store = JacksonUtil.getObjectMapper().readValue(bufStream, PlayerStore.class);
-                if (store != null) {
-                    return store;
-                }
-            } catch (IOException ex) {
-                WolfyUtilities.getWUCore().getConsole().warn("Error loading player store for " + uuid+" -> Reset store!");
-            }
-        }
-        return new PlayerStore();
-    }
+    public PlayerStore() { }
 
     public <D extends CustomPlayerData> D getData(NamespacedKey dataKey, Class<D> dataType) {
-        return dataType.cast(data.get(dataKey));
-    }
-
-    void save(UUID uuid) {
-        try (
-                var fileStream = new FileOutputStream(PlayerUtils.STORE_FOLDER + File.separator + uuid.toString() + ".store");
-                var gzip = new GZIPOutputStream(new BufferedOutputStream(fileStream))
-        ) {
-            JacksonUtil.getObjectWriter(false).writeValue(gzip, this);
-            gzip.flush();
-            fileStream.flush();
-        } catch (IOException e) {
-            WolfyUtilities.getWUCore().getConsole().warn("Error saving player store for " + uuid+"!");
-        }
+        return null;
     }
 
     @Override
     public String toString() {
         return "PlayerStore{" +
-                "data=" + data +
+                "data={}" +
                 '}';
-    }
-
-    static class Serializer extends JsonSerializer<PlayerStore> {
-
-        @Override
-        public void serialize(PlayerStore playerStore, JsonGenerator gen, SerializerProvider serializerProvider) throws IOException {
-            gen.writeStartObject();
-            gen.writeObjectFieldStart("data");
-            {
-                for (Map.Entry<NamespacedKey, CustomPlayerData> value : playerStore.data.entrySet()) {
-                    gen.writeObjectFieldStart(value.getKey().toString());
-                    value.getValue().writeToJson(gen, serializerProvider);
-                    gen.writeEndObject();
-                }
-            }
-            gen.writeEndObject();
-            gen.writeEndObject();
-        }
-    }
-
-    static class Deserializer extends JsonDeserializer<PlayerStore> {
-
-        @Override
-        public PlayerStore deserialize(JsonParser jsonParser, DeserializationContext deserializationContext) throws IOException {
-            JsonNode node = jsonParser.readValueAsTree();
-            var store = new PlayerStore();
-            node.path("data").fields().forEachRemaining(entry -> {
-                var key = NamespacedKey.of(entry.getKey());
-                CustomPlayerData.Provider<?> provider = CustomPlayerData.providers.get(key);
-                if (provider != null) {
-                    store.data.put(key, provider.loadData(entry.getValue(), deserializationContext));
-                }
-            });
-            return store;
-        }
     }
 }

--- a/core/src/main/java/me/wolfyscript/utilities/util/entity/PlayerUtils.java
+++ b/core/src/main/java/me/wolfyscript/utilities/util/entity/PlayerUtils.java
@@ -80,7 +80,7 @@ public class PlayerUtils {
 
     @Deprecated
     public static void loadStores() {
-        // The old system is very broken, so do not load old data, to prevent further crashes, etc.!
+        // The old system is very broken, so do not load old data to prevent further crashes, etc.!
     }
 
     /**

--- a/core/src/main/java/me/wolfyscript/utilities/util/entity/PlayerUtils.java
+++ b/core/src/main/java/me/wolfyscript/utilities/util/entity/PlayerUtils.java
@@ -77,43 +77,27 @@ public class PlayerUtils {
 
     @Deprecated
     public static void loadStores() {
-        WolfyUtilities.getWUPlugin().getLogger().info("Loading Player Data");
-        if (STORE_FOLDER.exists() || STORE_FOLDER.mkdirs()) {
-            String[] files = STORE_FOLDER.list();
-            if (files != null) {
-                for (String s : files) {
-                    if (s.endsWith(".store")) {
-                        try {
-                            var uuid = UUID.fromString(s.replace(".store", ""));
-                            indexedStores.put(uuid, PlayerStore.load(uuid));
-                        } catch (IllegalArgumentException e) {
-                            WolfyUtilities.getWUPlugin().getLogger().info("Failed to load file " + s + ": " + e.getMessage());
-                        }
-                    }
-                }
-            }
-        }
+        // The old system is very broken, so do not load old data, to prevent further crashes, etc.!
     }
 
+    /**
+     * @deprecated Does nothing anymore! Kept for backwards compatibility!
+     */
+    @Deprecated
     public static void saveStores() {
-        if (STORE_FOLDER.exists() || STORE_FOLDER.mkdirs()) {
-            indexedStores.forEach((uuid, playerStore) -> playerStore.save(uuid));
-        }
+        // Does nothing anymore. Kept for backwards compatibility!
     }
 
+    @Deprecated
     @NotNull
     public static PlayerStore getStore(@NotNull Player player) {
         return getStore(player.getUniqueId());
     }
 
+    @Deprecated
     @NotNull
     public static PlayerStore getStore(@NotNull UUID uuid) {
-        indexedStores.computeIfAbsent(uuid, key -> {
-            var playerStore = new PlayerStore();
-            playerStore.save(key);
-            return playerStore;
-        });
-        return indexedStores.get(uuid);
+        return new PlayerStore(); // Just return a dummy obj, as the old data is no longer available!
     }
 
 }

--- a/core/src/main/java/me/wolfyscript/utilities/util/entity/PlayerUtils.java
+++ b/core/src/main/java/me/wolfyscript/utilities/util/entity/PlayerUtils.java
@@ -18,35 +18,35 @@
 
 package me.wolfyscript.utilities.util.entity;
 
-import me.wolfyscript.utilities.api.WolfyUtilities;
-import me.wolfyscript.utilities.util.particles.ParticleUtils;
+import com.wolfyscript.utilities.bukkit.WolfyCoreBukkit;
+import com.wolfyscript.utilities.bukkit.persistent.player.PlayerParticleEffectData;
+import java.util.Optional;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.EquipmentSlot;
 import org.jetbrains.annotations.NotNull;
 
-import java.io.File;
 import java.util.EnumMap;
-import java.util.HashMap;
 import java.util.Map;
 import java.util.UUID;
 
+@Deprecated
 public class PlayerUtils {
 
     private PlayerUtils() {
     }
 
-    static final Map<UUID, PlayerStore> indexedStores = new HashMap<>();
-
-    private static final HashMap<UUID, Map<EquipmentSlot, UUID>> playerItemParticles = new HashMap<>();
-    static final File STORE_FOLDER = new File(WolfyUtilities.getWUPlugin().getDataFolder(), "players");
-
-
-    public static boolean hasActiveItemEffects(Player player) {
-        return playerItemParticles.containsKey(player.getUniqueId());
+    private static Optional<PlayerParticleEffectData> getParticleData(Player player) {
+        return WolfyCoreBukkit.getInstance().getPersistentStorage().getOrCreatePlayerStorage(player).getData(PlayerParticleEffectData.class);
     }
 
+    @Deprecated
+    public static boolean hasActiveItemEffects(Player player) {
+        return getParticleData(player).isPresent();
+    }
+
+    @Deprecated
     public static boolean hasActiveItemEffects(Player player, EquipmentSlot equipmentSlot) {
-        return getActiveItemEffects(player).containsKey(equipmentSlot);
+        return getParticleData(player).map(data -> data.hasActiveItemEffects(equipmentSlot)).orElse(false);
     }
 
     /**
@@ -55,24 +55,27 @@ public class PlayerUtils {
      * @param player The player object
      * @return The active particle effects on the player
      */
+    @Deprecated
     public static Map<EquipmentSlot, UUID> getActiveItemEffects(Player player) {
-        return playerItemParticles.computeIfAbsent(player.getUniqueId(), uuid -> new EnumMap<>(EquipmentSlot.class));
+        return getParticleData(player).map(PlayerParticleEffectData::getActiveItemEffects).orElseGet(() -> new EnumMap<>(EquipmentSlot.class));
     }
 
+    @Deprecated
     public static UUID getActiveItemEffects(Player player, EquipmentSlot equipmentSlot) {
         return getActiveItemEffects(player).get(equipmentSlot);
     }
 
+    @Deprecated
     public static void setActiveParticleEffect(Player player, EquipmentSlot equipmentSlot, UUID uuid) {
-        stopActiveParticleEffect(player, equipmentSlot);
-        getActiveItemEffects(player).put(equipmentSlot, uuid);
+        getParticleData(player).ifPresent(data -> data.setActiveParticleEffect(equipmentSlot, uuid));
     }
 
+    @Deprecated
     public static void stopActiveParticleEffect(Player player, EquipmentSlot equipmentSlot) {
-        ParticleUtils.stopAnimation(getActiveItemEffects(player, equipmentSlot));
-        getActiveItemEffects(player).remove(equipmentSlot);
+        getParticleData(player).ifPresent(data -> data.stopActiveParticleEffect(equipmentSlot));
     }
 
+    @Deprecated
     public static void loadStores() {
         WolfyUtilities.getWUPlugin().getLogger().info("Loading Player Data");
         if (STORE_FOLDER.exists() || STORE_FOLDER.mkdirs()) {

--- a/core/src/main/java/me/wolfyscript/utilities/util/entity/PlayerUtils.java
+++ b/core/src/main/java/me/wolfyscript/utilities/util/entity/PlayerUtils.java
@@ -20,6 +20,7 @@ package me.wolfyscript.utilities.util.entity;
 
 import com.wolfyscript.utilities.bukkit.WolfyCoreBukkit;
 import com.wolfyscript.utilities.bukkit.persistent.player.PlayerParticleEffectData;
+import java.util.HashMap;
 import java.util.Optional;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.EquipmentSlot;
@@ -31,6 +32,8 @@ import java.util.UUID;
 
 @Deprecated
 public class PlayerUtils {
+
+    private static final Map<UUID, PlayerStore> cachedStores = new HashMap<>();
 
     private PlayerUtils() {
     }
@@ -97,7 +100,7 @@ public class PlayerUtils {
     @Deprecated
     @NotNull
     public static PlayerStore getStore(@NotNull UUID uuid) {
-        return new PlayerStore(); // Just return a dummy obj, as the old data is no longer available!
+        return cachedStores.computeIfAbsent(uuid, uuid1 -> new PlayerStore()); // Just return a dummy obj, as the old data is no longer available!
     }
 
 }

--- a/core/src/main/java/me/wolfyscript/utilities/util/json/jackson/annotations/OptionalKeyReference.java
+++ b/core/src/main/java/me/wolfyscript/utilities/util/json/jackson/annotations/OptionalKeyReference.java
@@ -58,6 +58,22 @@ import java.lang.annotation.Target;
  *
  * <br>Deserialization:<br>
  * If the {@link JsonNode} is text it will convert it to {@link NamespacedKey} and look for the value in the {@link Registry} of the objects type.
+ * <br>
+ * Looks for the value in the registry:
+ * <pre><code>
+ *     {
+ *         "value": "wolfyutils:registered_value"
+ *     }
+ * </code></pre>
+ * Uses the custom value specified:
+ * <pre><code>
+ *     {
+ *         "value": {
+ *             "custom_object_val": 7,
+ *             ...
+ *         }
+ *     }
+ * </code></pre>
  *
  */
 @Retention(RetentionPolicy.RUNTIME)


### PR DESCRIPTION
The old system that uses the `WolfyUtilities/players` causes a lot of issues and is not very expandable.
So with this update the files in the players folder are no longer used and can be safely deleted.

The new system uses the Bukkit PersistentDataContainer to store custom data directly into the NBT of the Player entity. 
That way loading and saving it to disc is no longer handled by the plugin and is less bound to errors.

Additionally the new can be created more easily. No writeToJson or readFromJson methods anymore. Instead it uses Jackson Annotations to serialize and deserialize to/from json.
