### PR TITLE
Fixed Recursive Calls of BlockStorageEvents

### DIFF
--- a/core/src/main/java/com/wolfyscript/utilities/bukkit/events/persistent/BlockStorageBreakEvent.java
+++ b/core/src/main/java/com/wolfyscript/utilities/bukkit/events/persistent/BlockStorageBreakEvent.java
@@ -3,23 +3,30 @@ package com.wolfyscript.utilities.bukkit.events.persistent;
 import com.wolfyscript.utilities.bukkit.persistent.world.BlockStorage;
 import org.bukkit.block.Block;
 import org.bukkit.entity.Player;
+import org.bukkit.event.Cancellable;
+import org.bukkit.event.Event;
 import org.bukkit.event.HandlerList;
 import org.bukkit.event.block.BlockBreakEvent;
 import org.jetbrains.annotations.NotNull;
 
-public class BlockStorageBreakEvent extends BlockBreakEvent implements BlockStorageEvent {
+public class BlockStorageBreakEvent extends Event implements BlockStorageEvent, Cancellable {
 
     private static final HandlerList handlers = new HandlerList();
 
+    private final Player player;
+
+    protected Block block;
     protected BlockStorage blockStorage;
+    private boolean cancel;
 
     public BlockStorageBreakEvent(@NotNull Block theBlock, BlockStorage blockStorage, @NotNull Player player) {
-        super(theBlock, player);
+        super();
+        this.block = theBlock;
+        this.player = player;
         this.blockStorage = blockStorage;
     }
 
     @NotNull
-    @Override
     public HandlerList getHandlers() {
         return handlers;
     }
@@ -28,8 +35,32 @@ public class BlockStorageBreakEvent extends BlockBreakEvent implements BlockStor
         return handlers;
     }
 
+    /**
+     * Gets the block involved in this event.
+     *
+     * @return The Block which block is involved in this event
+     */
+    @NotNull
+    public Block getBlock() {
+        return block;
+    }
+
+    public Player getPlayer() {
+        return player;
+    }
+
     @Override
     public BlockStorage getStorage() {
         return blockStorage;
+    }
+
+    @Override
+    public boolean isCancelled() {
+        return cancel;
+    }
+
+    @Override
+    public void setCancelled(boolean cancel) {
+        this.cancel = cancel;
     }
 }

--- a/core/src/main/java/com/wolfyscript/utilities/bukkit/events/persistent/BlockStorageMultiPlaceEvent.java
+++ b/core/src/main/java/com/wolfyscript/utilities/bukkit/events/persistent/BlockStorageMultiPlaceEvent.java
@@ -1,27 +1,43 @@
 package com.wolfyscript.utilities.bukkit.events.persistent;
 
+import com.google.common.collect.ImmutableList;
 import com.wolfyscript.utilities.bukkit.persistent.world.BlockStorage;
 import java.util.List;
 import org.bukkit.block.Block;
 import org.bukkit.block.BlockState;
 import org.bukkit.entity.Player;
 import org.bukkit.event.block.BlockMultiPlaceEvent;
+import org.bukkit.inventory.EquipmentSlot;
 import org.bukkit.inventory.ItemStack;
 import org.jetbrains.annotations.NotNull;
 
-public class BlockStorageMultiPlaceEvent extends BlockMultiPlaceEvent implements BlockStorageEvent {
+public class BlockStorageMultiPlaceEvent extends BlockStoragePlaceEvent implements BlockStorageEvent {
 
+    private final List<BlockState> states;
     private final BlockStorage blockStorage;
     private final List<BlockStorage> blockStorages;
 
-    public BlockStorageMultiPlaceEvent(@NotNull List<BlockState> states, List<BlockStorage> blockStorages, @NotNull Block clicked, @NotNull ItemStack itemInHand, @NotNull Player thePlayer, boolean canBuild) {
-        super(states, clicked, itemInHand, thePlayer, canBuild);
+    public BlockStorageMultiPlaceEvent(@NotNull List<BlockState> states, List<BlockStorage> blockStorages, @NotNull Block clicked, @NotNull ItemStack itemInHand, @NotNull Player thePlayer, boolean canBuild, EquipmentSlot hand) {
+        super(states.get(0).getBlock(), blockStorages.get(0), states.get(0), clicked, itemInHand, thePlayer, canBuild, hand);
+        this.states = ImmutableList.copyOf(states);
         this.blockStorage = blockStorages.get(0);
         this.blockStorages = blockStorages;
     }
 
     public List<BlockStorage> getBlockStorages() {
         return blockStorages;
+    }
+
+    /**
+     * Gets a list of blockstates for all blocks which were replaced by the
+     * placement of the new blocks. Most of these blocks will just have a
+     * Material type of AIR.
+     *
+     * @return immutable list of replaced BlockStates
+     */
+    @NotNull
+    public List<BlockState> getReplacedBlockStates() {
+        return states;
     }
 
     @Override

--- a/core/src/main/java/com/wolfyscript/utilities/bukkit/events/persistent/BlockStoragePlaceEvent.java
+++ b/core/src/main/java/com/wolfyscript/utilities/bukkit/events/persistent/BlockStoragePlaceEvent.java
@@ -5,35 +5,151 @@ import org.bukkit.block.Block;
 import org.bukkit.block.BlockState;
 import org.bukkit.entity.Player;
 import org.bukkit.event.Cancellable;
+import org.bukkit.event.Event;
 import org.bukkit.event.HandlerList;
 import org.bukkit.event.block.BlockPlaceEvent;
 import org.bukkit.inventory.EquipmentSlot;
 import org.bukkit.inventory.ItemStack;
 import org.jetbrains.annotations.NotNull;
 
-public class BlockStoragePlaceEvent extends BlockPlaceEvent implements BlockStorageEvent, Cancellable {
+public class BlockStoragePlaceEvent extends Event implements BlockStorageEvent, Cancellable {
 
     private static final HandlerList handlers = new HandlerList();
+    protected boolean cancel;
+    protected boolean canBuild;
+    protected Block placedAgainst;
+    protected BlockState replacedBlockState;
+    protected ItemStack itemInHand;
+    protected Player player;
+    protected EquipmentSlot hand;
 
+    protected Block block;
     private final BlockStorage blockStorage;
 
     public BlockStoragePlaceEvent(@NotNull Block placedBlock, BlockStorage placedBlockStorage, @NotNull BlockState replacedBlockState, @NotNull Block placedAgainst, @NotNull ItemStack itemInHand, @NotNull Player thePlayer, boolean canBuild, @NotNull EquipmentSlot hand) {
-        super(placedBlock, replacedBlockState, placedAgainst, itemInHand, thePlayer, canBuild, hand);
+        super();
+        this.block = placedBlock;
         this.blockStorage = placedBlockStorage;
+        this.placedAgainst = placedAgainst;
+        this.itemInHand = itemInHand;
+        this.player = thePlayer;
+        this.replacedBlockState = replacedBlockState;
+        this.canBuild = canBuild;
+        this.hand = hand;
+        cancel = false;
+    }
+
+    @Override
+    public boolean isCancelled() {
+        return cancel;
+    }
+
+    @Override
+    public void setCancelled(boolean cancel) {
+        this.cancel = cancel;
+    }
+
+    /**
+     * Gets the player who placed the block involved in this event.
+     *
+     * @return The Player who placed the block involved in this event
+     */
+    @NotNull
+    public Player getPlayer() {
+        return player;
+    }
+
+    /**
+     * Clarity method for getting the placed block. Not really needed except
+     * for reasons of clarity.
+     *
+     * @return The Block that was placed
+     */
+    @NotNull
+    public Block getBlockPlaced() {
+        return getBlock();
+    }
+
+    @Override
+    public BlockStorage getStorage() {
+        return blockStorage;
     }
 
     @NotNull
-    @Override
+    public Block getBlock() {
+        return block;
+    }
+
+    /**
+     * Gets the BlockState for the block which was replaced. Material type air
+     * mostly.
+     *
+     * @return The BlockState for the block which was replaced.
+     */
+    @NotNull
+    public BlockState getBlockReplacedState() {
+        return this.replacedBlockState;
+    }
+
+    /**
+     * Gets the block that this block was placed against
+     *
+     * @return Block the block that the new block was placed against
+     */
+    @NotNull
+    public Block getBlockAgainst() {
+        return placedAgainst;
+    }
+
+    /**
+     * Gets the item in the player's hand when they placed the block.
+     *
+     * @return The ItemStack for the item in the player's hand when they
+     *     placed the block
+     */
+    @NotNull
+    public ItemStack getItemInHand() {
+        return itemInHand;
+    }
+
+    /**
+     * Gets the hand which placed the block
+     * @return Main or off-hand, depending on which hand was used to place the block
+     */
+    @NotNull
+    public EquipmentSlot getHand() {
+        return this.hand;
+    }
+
+    /**
+     * Gets the value whether the player would be allowed to build here.
+     * Defaults to spawn if the server was going to stop them (such as, the
+     * player is in Spawn). Note that this is an entirely different check
+     * than BLOCK_CANBUILD, as this refers to a player, not universe-physics
+     * rule like cactus on dirt.
+     *
+     * @return boolean whether the server would allow a player to build here
+     */
+    public boolean canBuild() {
+        return this.canBuild;
+    }
+
+    /**
+     * Sets the canBuild state of this event. Set to true if you want the
+     * player to be able to build.
+     *
+     * @param canBuild true if you want the player to be able to build
+     */
+    public void setBuild(boolean canBuild) {
+        this.canBuild = canBuild;
+    }
+
+    @NotNull
     public HandlerList getHandlers() {
         return handlers;
     }
 
     public static HandlerList getHandlerList() {
         return handlers;
-    }
-
-    @Override
-    public BlockStorage getStorage() {
-        return blockStorage;
     }
 }

--- a/core/src/main/java/com/wolfyscript/utilities/bukkit/items/CustomItemBlockData.java
+++ b/core/src/main/java/com/wolfyscript/utilities/bukkit/items/CustomItemBlockData.java
@@ -4,6 +4,8 @@ import com.fasterxml.jackson.annotation.JacksonInject;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.wolfyscript.utilities.bukkit.events.persistent.BlockStorageBreakEvent;
+import com.wolfyscript.utilities.bukkit.events.persistent.BlockStoragePlaceEvent;
 import com.wolfyscript.utilities.bukkit.persistent.world.BlockStorage;
 import com.wolfyscript.utilities.bukkit.persistent.world.ChunkStorage;
 import com.wolfyscript.utilities.bukkit.persistent.world.CustomBlockData;
@@ -73,7 +75,7 @@ public class CustomItemBlockData extends CustomBlockData {
         this.particleAnimationID = particleAnimationID;
     }
 
-    public void onPlace(BlockPlaceEvent event) {
+    public void onPlace(BlockStoragePlaceEvent event) {
         getCustomItem().ifPresent(customItem -> {
             var animation = customItem.getParticleContent().getAnimation(ParticleLocation.BLOCK);
             if (animation != null) {
@@ -82,7 +84,7 @@ public class CustomItemBlockData extends CustomBlockData {
         });
     }
 
-    public void onBreak(BlockBreakEvent event) {
+    public void onBreak(BlockStorageBreakEvent event) {
         getCustomItem().ifPresent(customItem -> {
             var event1 = new CustomItemBreakEvent(customItem, event);
             Bukkit.getPluginManager().callEvent(event1);

--- a/core/src/main/java/com/wolfyscript/utilities/bukkit/listeners/PersistentStorageListener.java
+++ b/core/src/main/java/com/wolfyscript/utilities/bukkit/listeners/PersistentStorageListener.java
@@ -138,7 +138,7 @@ public class PersistentStorageListener implements Listener {
     public void onBlockPlaceMulti(BlockMultiPlaceEvent event) {
         WorldStorage worldStorage = persistentStorage.getOrCreateWorldStorage(event.getBlock().getWorld());
         List<BlockStorage> storages = event.getReplacedBlockStates().stream().map(state -> worldStorage.createBlockStorage(state.getLocation())).toList();
-        var blockStorageMultiPlaceEvent = new BlockStorageMultiPlaceEvent(event.getReplacedBlockStates(), storages, event.getBlockAgainst(), event.getItemInHand(), event.getPlayer(), event.canBuild());
+        var blockStorageMultiPlaceEvent = new BlockStorageMultiPlaceEvent(event.getReplacedBlockStates(), storages, event.getBlockAgainst(), event.getItemInHand(), event.getPlayer(), event.canBuild(), event.getHand());
         blockStorageMultiPlaceEvent.setCancelled(event.isCancelled());
         Bukkit.getPluginManager().callEvent(blockStorageMultiPlaceEvent);
         event.setCancelled(blockStorageMultiPlaceEvent.isCancelled());

--- a/core/src/main/java/me/wolfyscript/utilities/util/events/CustomItemBreakEvent.java
+++ b/core/src/main/java/me/wolfyscript/utilities/util/events/CustomItemBreakEvent.java
@@ -18,6 +18,7 @@
 
 package me.wolfyscript.utilities.util.events;
 
+import com.wolfyscript.utilities.bukkit.events.persistent.BlockStorageBreakEvent;
 import me.wolfyscript.utilities.api.inventory.custom_items.CustomItem;
 import org.bukkit.block.Block;
 import org.bukkit.entity.Player;
@@ -35,10 +36,10 @@ public class CustomItemBreakEvent extends Event {
     private boolean cancel;
     private CustomItem customItem;
 
-    public CustomItemBreakEvent(CustomItem customItem, BlockBreakEvent event){
+    public CustomItemBreakEvent(CustomItem customItem, BlockStorageBreakEvent event){
         this.player = event.getPlayer();
         this.dropItems = true;
-        this.exp = event.getExpToDrop();
+        this.exp = 0;
         this.block = event.getBlock();
         this.customItem = customItem;
     }


### PR DESCRIPTION
Due to BlockStorageEvents extending the Bukkit BlockEvents, but also them being called inside Bukkit BlockEvents, they cause recursive calls.