### PR TITLE
No longer shade & relocate Libs

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -36,9 +36,9 @@
         <!-- The dependency versions -->
         <depend_version.spigotapi>1.19-R0.1-SNAPSHOT</depend_version.spigotapi>
         <depend_version.mojang-authlib>1.5.21</depend_version.mojang-authlib>
-        <depend_version.jackson>2.14.0-rc1</depend_version.jackson>
+        <depend_version.jackson>2.14.0</depend_version.jackson>
         <depend_version.jetbrains-annotations>23.0.0</depend_version.jetbrains-annotations>
-        <depend_version.netty>4.1.77.Final</depend_version.netty>
+        <depend_version.netty>4.1.85.Final</depend_version.netty>
         <depend_version.guice>5.1.0</depend_version.guice>
         <depend_version.reflections>0.10.2</depend_version.reflections>
         <depend_version.bstats>3.0.0</depend_version.bstats>
@@ -46,7 +46,7 @@
         <depend_version.adventure-platform>4.1.2</depend_version.adventure-platform>
         <depend_version.adventure-minimessage>4.11.0</depend_version.adventure-minimessage>
         <depend_version.nbt-api>2.10.0</depend_version.nbt-api>
-        <depend_version.javassist>3.29.1-GA</depend_version.javassist>
+        <depend_version.javassist>3.29.2-GA</depend_version.javassist>
     </properties>
 
     <build>
@@ -138,19 +138,16 @@
             <groupId>com.google.inject</groupId>
             <artifactId>guice</artifactId>
             <version>${depend_version.guice}</version>
-            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.reflections</groupId>
             <artifactId>reflections</artifactId>
             <version>${depend_version.reflections}</version>
-            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.javassist</groupId>
             <artifactId>javassist</artifactId>
             <version>${depend_version.javassist}</version>
-            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.jetbrains</groupId>
@@ -181,19 +178,16 @@
             <groupId>net.kyori</groupId>
             <artifactId>adventure-api</artifactId>
             <version>${depend_version.adventure-api}</version>
-            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>net.kyori</groupId>
             <artifactId>adventure-platform-bukkit</artifactId>
             <version>${depend_version.adventure-platform}</version>
-            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>net.kyori</groupId>
             <artifactId>adventure-text-minimessage</artifactId>
             <version>${depend_version.adventure-minimessage}</version>
-            <scope>provided</scope>
         </dependency>
         <!-- NBT -->
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -47,6 +47,9 @@
         <depend_version.adventure-minimessage>4.11.0</depend_version.adventure-minimessage>
         <depend_version.nbt-api>2.10.0</depend_version.nbt-api>
         <depend_version.javassist>3.29.2-GA</depend_version.javassist>
+        <depend_version.test.jupiter>5.9.0</depend_version.test.jupiter>
+        <depend_version.test.mockito>4.8.0</depend_version.test.mockito>
+        <depend_version.test.mockbukkit>2.85.2</depend_version.test.mockbukkit>
     </properties>
 
     <build>

--- a/wolfyutils-spigot/pom.xml
+++ b/wolfyutils-spigot/pom.xml
@@ -167,13 +167,6 @@
                 </exclusion>
             </exclusions>
         </dependency>
-        <!-- Reflections -->
-        <dependency>
-            <groupId>org.reflections</groupId>
-            <artifactId>reflections</artifactId>
-            <version>${depend_version.reflections}</version>
-            <scope>provided</scope>
-        </dependency>
         <!-- NBT -->
         <dependency>
             <groupId>de.tr7zw</groupId>

--- a/wolfyutils-spigot/pom.xml
+++ b/wolfyutils-spigot/pom.xml
@@ -191,19 +191,19 @@
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter</artifactId>
-            <version>5.8.2</version>
+            <version>${depend_version.test.jupiter}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
-            <version>4.4.0</version>
+            <version>${depend_version.test.mockito}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>com.github.seeseemelk</groupId>
             <artifactId>MockBukkit-v1.18</artifactId>
-            <version>1.24.1</version>
+            <version>${depend_version.test.mockbukkit}</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/wolfyutils-spigot/pom.xml
+++ b/wolfyutils-spigot/pom.xml
@@ -26,7 +26,7 @@
                     <include>**/*</include>
                 </includes>
                 <filtering>true
-                </filtering> <!-- this replaces, filters, all placeholders in the resources folder (such as ${project.version} in plugin.yml) -->
+                </filtering> <!-- this replaces, filters, all placeholders in the resources' folder (such as ${project.version} in plugin.yml) -->
             </resource>
         </resources>
         <plugins>
@@ -66,10 +66,6 @@
                                     <include>com.wolfyscript.wolfyutils</include>
                                     <include>com.wolfyscript.wolfyutils.spigot</include>
                                     <include>org.bstats</include>
-                                    <include>com.fasterxml.jackson.core</include>
-                                    <include>org.reflections</include>
-                                    <include>org.javassist</include>
-                                    <include>net.kyori</include>
                                     <include>de.tr7zw</include>
                                     <include>com.wolfyscript</include>
                                     <include>com.typesafe</include>
@@ -95,22 +91,6 @@
                                 <relocation>
                                     <pattern>com.typesafe</pattern>
                                     <shadedPattern>com.wolfyscript.lib.com.typesafe</shadedPattern>
-                                </relocation>
-                                <relocation>
-                                    <pattern>org.reflections</pattern>
-                                    <shadedPattern>me.wolfyscript.lib.org.reflections</shadedPattern>
-                                </relocation>
-                                <relocation>
-                                    <pattern>javassist</pattern>
-                                    <shadedPattern>me.wolfyscript.lib.javassist</shadedPattern>
-                                </relocation>
-                                <relocation>
-                                    <pattern>com.fasterxml.jackson</pattern>
-                                    <shadedPattern>me.wolfyscript.lib.com.fasterxml.jackson</shadedPattern>
-                                </relocation>
-                                <relocation>
-                                    <pattern>net.kyori</pattern>
-                                    <shadedPattern>me.wolfyscript.lib.net.kyori</shadedPattern>
                                 </relocation>
                             </relocations>
                             <filters>
@@ -192,39 +172,7 @@
             <groupId>org.reflections</groupId>
             <artifactId>reflections</artifactId>
             <version>${depend_version.reflections}</version>
-            <scope>compile</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.javassist</groupId>
-            <artifactId>javassist</artifactId>
-            <version>${depend_version.javassist}</version>
-            <scope>compile</scope>
-        </dependency>
-        <!-- Jackson -->
-        <dependency>
-            <groupId>com.fasterxml.jackson.core</groupId>
-            <artifactId>jackson-databind</artifactId>
-            <version>${depend_version.jackson}</version>
-            <scope>compile</scope>
-        </dependency>
-        <!-- Adventure API -->
-        <dependency>
-            <groupId>net.kyori</groupId>
-            <artifactId>adventure-api</artifactId>
-            <version>${depend_version.adventure-api}</version>
-            <scope>compile</scope>
-        </dependency>
-        <dependency>
-            <groupId>net.kyori</groupId>
-            <artifactId>adventure-platform-bukkit</artifactId>
-            <version>${depend_version.adventure-platform}</version>
-            <scope>compile</scope>
-        </dependency>
-        <dependency>
-            <groupId>net.kyori</groupId>
-            <artifactId>adventure-text-minimessage</artifactId>
-            <version>${depend_version.adventure-minimessage}</version>
-            <scope>compile</scope>
+            <scope>provided</scope>
         </dependency>
         <!-- NBT -->
         <dependency>
@@ -244,13 +192,6 @@
             <groupId>org.bstats</groupId>
             <artifactId>bstats-bukkit</artifactId>
             <version>${depend_version.bstats}</version>
-            <scope>compile</scope>
-        </dependency>
-        <!---->
-        <dependency>
-            <groupId>com.google.inject</groupId>
-            <artifactId>guice</artifactId>
-            <version>${depend_version.guice}</version>
             <scope>compile</scope>
         </dependency>
         <!-- Testing -->

--- a/wolfyutils-spigot/src/main/resources/plugin.yml
+++ b/wolfyutils-spigot/src/main/resources/plugin.yml
@@ -6,8 +6,14 @@ authors: [ WolfyScript ]
 load: STARTUP
 
 libraries:
-  - "com.google.inject:guice:5.1.0"
+  - "com.google.inject:guice:${depend_version.guice}"
   - "org.apache.commons:commons-lang3:3.12.0"
+  - "org.javassist:javassist:${depend_version.javassist}"
+  - "org.reflections:reflections:${depend_version.reflections}"
+  - "com.fasterxml.jackson.core:jackson-databind:${depend_version.jackson}"
+  - "net.kyori:adventure-api:${depend_version.adventure-api}"
+  - "net.kyori:adventure-text-minimessage:${depend_version.adventure-api}"
+  - "net.kyori:adventure-platform-bukkit:${depend_version.adventure-platform}"
 
 loadbefore:
   - ChatColor


### PR DESCRIPTION
This update removes most libraries that are available in maven-central from the shading and relocation list.
Instead it uses the `libraries` feature available in the `plugin.yml`.
This reduces the size of the jar massively and also reduces build time by a bit.
Additionally, it makes libs like Adventure to be compatible with the one included in Paper, and provides a more direct access to docs and source code of the dependencies.