### PR TITLE
Oraxen API Update

### DIFF
--- a/plugin-compatibility/plugin-compatibility-artifact/pom.xml
+++ b/plugin-compatibility/plugin-compatibility-artifact/pom.xml
@@ -92,11 +92,9 @@
         </dependency>
         <!-- Oraxen -->
         <dependency>
-            <groupId>io.th0rgal</groupId>
+            <groupId>com.github.oraxen</groupId>
             <artifactId>oraxen</artifactId>
-            <version>1.66.2</version>
-            <scope>provided</scope>
-            <optional>true</optional>
+            <version>-SNAPSHOT</version>
         </dependency>
         <!-- Mythic Plugins -->
         <dependency>

--- a/plugin-compatibility/plugin-compatibility-artifact/src/main/java/me/wolfyscript/utilities/compatibility/plugins/OraxenImpl.java
+++ b/plugin-compatibility/plugin-compatibility-artifact/src/main/java/me/wolfyscript/utilities/compatibility/plugins/OraxenImpl.java
@@ -18,11 +18,16 @@
 
 package me.wolfyscript.utilities.compatibility.plugins;
 
+import com.wolfyscript.utilities.bukkit.WolfyCoreBukkit;
+import com.wolfyscript.utilities.bukkit.WolfyUtilsBukkit;
+import io.th0rgal.oraxen.OraxenPlugin;
 import me.wolfyscript.utilities.annotations.WUPluginIntegration;
 import me.wolfyscript.utilities.api.WolfyUtilCore;
+import me.wolfyscript.utilities.api.WolfyUtilities;
 import me.wolfyscript.utilities.api.inventory.custom_items.references.APIReference;
 import me.wolfyscript.utilities.compatibility.PluginIntegrationAbstract;
 import me.wolfyscript.utilities.compatibility.plugins.oraxen.OraxenRefImpl;
+import me.wolfyscript.utilities.compatibility.plugins.oraxen.OraxenRefOldImpl;
 import org.bukkit.plugin.Plugin;
 
 @WUPluginIntegration(pluginName = OraxenIntegration.KEY)
@@ -34,7 +39,11 @@ public class OraxenImpl extends PluginIntegrationAbstract implements OraxenInteg
 
     @Override
     public void init(Plugin plugin) {
-        core.registerAPIReference(new OraxenRefImpl.Parser());
+        if (!WolfyUtilities.hasClass("io.th0rgal.oraxen.api.OraxenItems")) {
+            core.registerAPIReference(new OraxenRefOldImpl.Parser());
+        } else {
+            core.registerAPIReference(new OraxenRefImpl.Parser());
+        }
     }
 
     @Override
@@ -44,6 +53,6 @@ public class OraxenImpl extends PluginIntegrationAbstract implements OraxenInteg
 
     @Override
     public boolean isAPIReferenceIncluded(APIReference reference) {
-        return reference instanceof OraxenRefImpl;
+        return reference instanceof OraxenRefOldImpl;
     }
 }

--- a/plugin-compatibility/plugin-compatibility-artifact/src/main/java/me/wolfyscript/utilities/compatibility/plugins/OraxenImpl.java
+++ b/plugin-compatibility/plugin-compatibility-artifact/src/main/java/me/wolfyscript/utilities/compatibility/plugins/OraxenImpl.java
@@ -18,9 +18,6 @@
 
 package me.wolfyscript.utilities.compatibility.plugins;
 
-import com.wolfyscript.utilities.bukkit.WolfyCoreBukkit;
-import com.wolfyscript.utilities.bukkit.WolfyUtilsBukkit;
-import io.th0rgal.oraxen.OraxenPlugin;
 import me.wolfyscript.utilities.annotations.WUPluginIntegration;
 import me.wolfyscript.utilities.api.WolfyUtilCore;
 import me.wolfyscript.utilities.api.WolfyUtilities;

--- a/plugin-compatibility/plugin-compatibility-artifact/src/main/java/me/wolfyscript/utilities/compatibility/plugins/oraxen/OraxenRefImpl.java
+++ b/plugin-compatibility/plugin-compatibility-artifact/src/main/java/me/wolfyscript/utilities/compatibility/plugins/oraxen/OraxenRefImpl.java
@@ -21,7 +21,7 @@ package me.wolfyscript.utilities.compatibility.plugins.oraxen;
 import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.SerializerProvider;
-import io.th0rgal.oraxen.items.OraxenItems;
+import io.th0rgal.oraxen.api.OraxenItems;
 import java.io.IOException;
 import java.util.Objects;
 import me.wolfyscript.utilities.api.inventory.custom_items.references.APIReference;
@@ -41,9 +41,9 @@ public class OraxenRefImpl extends APIReference implements OraxenRef {
         this.itemID = itemID;
     }
 
-    public OraxenRefImpl(OraxenRefImpl oraxenRefImpl) {
-        super(oraxenRefImpl);
-        this.itemID = oraxenRefImpl.itemID;
+    public OraxenRefImpl(OraxenRefImpl oraxenRefOldImpl) {
+        super(oraxenRefOldImpl);
+        this.itemID = oraxenRefOldImpl.itemID;
     }
 
     @Override

--- a/plugin-compatibility/plugin-compatibility-artifact/src/main/java/me/wolfyscript/utilities/compatibility/plugins/oraxen/OraxenRefOldImpl.java
+++ b/plugin-compatibility/plugin-compatibility-artifact/src/main/java/me/wolfyscript/utilities/compatibility/plugins/oraxen/OraxenRefOldImpl.java
@@ -1,0 +1,119 @@
+/*
+ *       WolfyUtilities, APIs and Utilities for Minecraft Spigot plugins
+ *                      Copyright (C) 2021  WolfyScript
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package me.wolfyscript.utilities.compatibility.plugins.oraxen;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import io.th0rgal.oraxen.items.OraxenItems;
+import java.io.IOException;
+import java.util.Objects;
+import me.wolfyscript.utilities.api.inventory.custom_items.references.APIReference;
+import me.wolfyscript.utilities.util.inventory.ItemUtils;
+import org.bukkit.inventory.ItemStack;
+import org.jetbrains.annotations.Nullable;
+
+/**
+ * Links to Oraxen and saves the specified id of the item.
+ */
+public class OraxenRefOldImpl extends APIReference implements OraxenRef {
+
+    private final String itemID;
+
+    public OraxenRefOldImpl(String itemID) {
+        super();
+        this.itemID = itemID;
+    }
+
+    public OraxenRefOldImpl(OraxenRefOldImpl oraxenRefOldImpl) {
+        super(oraxenRefOldImpl);
+        this.itemID = oraxenRefOldImpl.itemID;
+    }
+
+    @Override
+    public ItemStack getLinkedItem() {
+        if (OraxenItems.exists(itemID)) {
+            return OraxenItems.getItemById(itemID).build();
+        }
+        return ItemUtils.AIR;
+    }
+
+    @Override
+    public ItemStack getIdItem() {
+        return getLinkedItem();
+    }
+
+    @Override
+    public boolean isValidItem(ItemStack itemStack) {
+        String itemId = OraxenItems.getIdByItem(itemStack);
+        if (itemId != null && !itemId.isEmpty()) {
+            return Objects.equals(this.itemID, itemId);
+        }
+        return false;
+    }
+
+    @Override
+    public void serialize(JsonGenerator gen, SerializerProvider provider) throws IOException {
+        gen.writeStringField("oraxen", itemID);
+    }
+
+    @Override
+    public String getItemID() {
+        return itemID;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof OraxenRefOldImpl oraxenRefOldImpl)) return false;
+        if (!super.equals(o)) return false;
+        return Objects.equals(itemID, oraxenRefOldImpl.itemID);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(super.hashCode(), itemID);
+    }
+
+    @Override
+    public OraxenRefOldImpl clone() {
+        return new OraxenRefOldImpl(this);
+    }
+
+    public static class Parser extends PluginParser<OraxenRefOldImpl> {
+
+        public Parser() {
+            super("Oraxen", "oraxen");
+        }
+
+        @Override
+        public @Nullable OraxenRefOldImpl construct(ItemStack itemStack) {
+            String itemId = OraxenItems.getIdByItem(itemStack);
+            if (itemId != null && !itemId.isEmpty()) {
+                return new OraxenRefOldImpl(itemId);
+            }
+            return null;
+        }
+
+        @Override
+        public @Nullable OraxenRefOldImpl parse(JsonNode element) {
+            return new OraxenRefOldImpl(element.asText());
+        }
+    }
+}


### PR DESCRIPTION
Updated Item APIReference Parser to the new Oraxen API.
Kept the old one which is used when the new API is not available.