### PR TITLE
Minecraft 1.19.3 Update

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>wolfyutils-parent</artifactId>
         <groupId>com.wolfyscript.wolfyutils.spigot</groupId>
-        <version>4.16.9.3</version>
+        <version>4.16.9.4-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/core/src/main/java/com/wolfyscript/utilities/bukkit/nms/fallback/FallbackInventoryUtilImpl.java
+++ b/core/src/main/java/com/wolfyscript/utilities/bukkit/nms/fallback/FallbackInventoryUtilImpl.java
@@ -2,17 +2,23 @@ package com.wolfyscript.utilities.bukkit.nms.fallback;
 
 import me.wolfyscript.utilities.api.nms.InventoryUtil;
 import me.wolfyscript.utilities.api.nms.NMSUtil;
+import me.wolfyscript.utilities.util.inventory.CreativeModeTab;
 import me.wolfyscript.utilities.util.version.ServerVersion;
 import org.apache.commons.lang3.NotImplementedException;
+import org.bukkit.Material;
 
 public class FallbackInventoryUtilImpl extends InventoryUtil {
 
-    protected FallbackInventoryUtilImpl(NMSUtil nmsUtil) {
+    public FallbackInventoryUtilImpl(NMSUtil nmsUtil) {
         super(nmsUtil);
     }
 
     @Override
     public void initItemCategories() {
-        throw new NotImplementedException("Item categories are not yet implement for " + ServerVersion.getVersion());
+        // Since 1.19.3 the server has no info about the Creative menu categories anymore!
+        // Future versions might sort the items manually, but maybe not...
+        for (Material material : Material.values()) {
+            CreativeModeTab.of("building_blocks").ifPresent(creativeModeTab -> creativeModeTab.registerMaterial(material));
+        }
     }
 }

--- a/core/src/main/java/com/wolfyscript/utilities/bukkit/nms/fallback/FallbackNMSEntry.java
+++ b/core/src/main/java/com/wolfyscript/utilities/bukkit/nms/fallback/FallbackNMSEntry.java
@@ -38,7 +38,7 @@ public class FallbackNMSEntry extends NMSUtil {
 
     @Override
     public InventoryUtil getInventoryUtil() {
-        throw new NotImplementedException("InventoryUtil is not yet implement for " + ServerVersion.getVersion());
+        return inventoryUtil;
     }
 
     @Override

--- a/core/src/main/java/com/wolfyscript/utilities/bukkit/nms/item/crafting/FunctionalRecipeBuilderCooking.java
+++ b/core/src/main/java/com/wolfyscript/utilities/bukkit/nms/item/crafting/FunctionalRecipeBuilderCooking.java
@@ -63,7 +63,7 @@ public abstract class FunctionalRecipeBuilderCooking extends FunctionalRecipeBui
                 constructor = recipeClass.getConstructor(
                         NamespacedKey.class, RecipeMatcher.class, RecipeAssembler.class, RecipeRemainingItemsFunction.class, String.class, String.class, RecipeChoice.class, ItemStack.class, Float.TYPE, Integer.TYPE
                 );
-                recipe = (FunctionalRecipe<Inventory>) constructor.newInstance(key, recipeMatcher, recipeAssembler, remainingItemsFunction, "misc", group, ingredient, result, experience, cookingTime);
+                recipe = (FunctionalRecipe<Inventory>) constructor.newInstance(key, recipeMatcher, recipeAssembler, remainingItemsFunction, group, "misc", ingredient, result, experience, cookingTime);
             } else {
                 constructor = recipeClass.getConstructor(
                         NamespacedKey.class, RecipeMatcher.class, RecipeAssembler.class, RecipeRemainingItemsFunction.class, String.class, RecipeChoice.class, ItemStack.class, Float.TYPE, Integer.TYPE

--- a/core/src/main/java/com/wolfyscript/utilities/bukkit/nms/item/crafting/FunctionalRecipeBuilderCooking.java
+++ b/core/src/main/java/com/wolfyscript/utilities/bukkit/nms/item/crafting/FunctionalRecipeBuilderCooking.java
@@ -5,6 +5,8 @@ import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
 import java.util.Optional;
 import me.wolfyscript.utilities.util.NamespacedKey;
+import me.wolfyscript.utilities.util.version.MinecraftVersion;
+import me.wolfyscript.utilities.util.version.ServerVersion;
 import org.bukkit.inventory.Inventory;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.RecipeChoice;
@@ -54,10 +56,20 @@ public abstract class FunctionalRecipeBuilderCooking extends FunctionalRecipeBui
 
     public void createAndRegister() {
         try {
-            Constructor<?> constructor = FunctionalRecipeGenerator.getFunctionalRecipeClass(getType()).getConstructor(
-                    NamespacedKey.class, RecipeMatcher.class, RecipeAssembler.class, RecipeRemainingItemsFunction.class, String.class, RecipeChoice.class, ItemStack.class, Float.TYPE, Integer.TYPE
-            );
-            FunctionalRecipe<Inventory> recipe = (FunctionalRecipe<Inventory>) constructor.newInstance(key, recipeMatcher, recipeAssembler, remainingItemsFunction, group, ingredient, result, experience, cookingTime);
+            Class<?> recipeClass = FunctionalRecipeGenerator.getFunctionalRecipeClass(getType());
+            Constructor<?> constructor;
+            FunctionalRecipe<Inventory> recipe;
+            if (ServerVersion.isAfterOrEq(MinecraftVersion.of(1, 19, 3))) {
+                constructor = recipeClass.getConstructor(
+                        NamespacedKey.class, RecipeMatcher.class, RecipeAssembler.class, RecipeRemainingItemsFunction.class, String.class, String.class, RecipeChoice.class, ItemStack.class, Float.TYPE, Integer.TYPE
+                );
+                recipe = (FunctionalRecipe<Inventory>) constructor.newInstance(key, recipeMatcher, recipeAssembler, remainingItemsFunction, "misc", group, ingredient, result, experience, cookingTime);
+            } else {
+                constructor = recipeClass.getConstructor(
+                        NamespacedKey.class, RecipeMatcher.class, RecipeAssembler.class, RecipeRemainingItemsFunction.class, String.class, RecipeChoice.class, ItemStack.class, Float.TYPE, Integer.TYPE
+                );
+                recipe = (FunctionalRecipe<Inventory>) constructor.newInstance(key, recipeMatcher, recipeAssembler, remainingItemsFunction, group, ingredient, result, experience, cookingTime);
+            }
             FunctionalRecipeGenerator.addRecipeToRecipeManager(recipe);
         } catch (NoSuchMethodException | InvocationTargetException | InstantiationException | IllegalAccessException e) {
             e.printStackTrace();

--- a/core/src/main/java/com/wolfyscript/utilities/bukkit/nms/item/crafting/FunctionalRecipeBuilderShaped.java
+++ b/core/src/main/java/com/wolfyscript/utilities/bukkit/nms/item/crafting/FunctionalRecipeBuilderShaped.java
@@ -53,7 +53,7 @@ public class FunctionalRecipeBuilderShaped extends FunctionalRecipeBuilderCrafti
                 constructor =  FunctionalRecipeGenerator.getFunctionalRecipeClass(getType()).getConstructor(
                         NamespacedKey.class, RecipeMatcher.class, RecipeAssembler.class, RecipeRemainingItemsFunction.class, String.class, String.class, Integer.TYPE, Integer.TYPE, List.class, ItemStack.class
                 );
-                recipe = (FunctionalRecipe<CraftingInventory>) constructor.newInstance(key, recipeMatcher, recipeAssembler, remainingItemsFunction, "misc", group, width, height, choices, result);
+                recipe = (FunctionalRecipe<CraftingInventory>) constructor.newInstance(key, recipeMatcher, recipeAssembler, remainingItemsFunction, group, "misc", width, height, choices, result);
             } else {
                 constructor = FunctionalRecipeGenerator.getFunctionalRecipeClass(getType()).getConstructor(
                         NamespacedKey.class, RecipeMatcher.class, RecipeAssembler.class, RecipeRemainingItemsFunction.class, String.class, Integer.TYPE, Integer.TYPE, List.class, ItemStack.class

--- a/core/src/main/java/com/wolfyscript/utilities/bukkit/nms/item/crafting/FunctionalRecipeBuilderShaped.java
+++ b/core/src/main/java/com/wolfyscript/utilities/bukkit/nms/item/crafting/FunctionalRecipeBuilderShaped.java
@@ -5,6 +5,8 @@ import java.lang.reflect.InvocationTargetException;
 import java.util.ArrayList;
 import java.util.List;
 import me.wolfyscript.utilities.util.NamespacedKey;
+import me.wolfyscript.utilities.util.version.MinecraftVersion;
+import me.wolfyscript.utilities.util.version.ServerVersion;
 import org.bukkit.inventory.CraftingInventory;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.RecipeChoice;
@@ -45,10 +47,19 @@ public class FunctionalRecipeBuilderShaped extends FunctionalRecipeBuilderCrafti
     @Override
     public void createAndRegister() {
         try {
-            Constructor<?> constructor = FunctionalRecipeGenerator.getFunctionalRecipeClass(getType()).getConstructor(
-                    NamespacedKey.class, RecipeMatcher.class, RecipeAssembler.class, RecipeRemainingItemsFunction.class, String.class, Integer.TYPE, Integer.TYPE, List.class, ItemStack.class
-            );
-            FunctionalRecipe<CraftingInventory> recipe = (FunctionalRecipe<CraftingInventory>) constructor.newInstance(key, recipeMatcher, recipeAssembler, remainingItemsFunction, group, width, height, choices, result);
+            Constructor<?> constructor;
+            FunctionalRecipe<CraftingInventory> recipe;
+            if (ServerVersion.isAfterOrEq(MinecraftVersion.of(1, 19, 3))) {
+                constructor =  FunctionalRecipeGenerator.getFunctionalRecipeClass(getType()).getConstructor(
+                        NamespacedKey.class, RecipeMatcher.class, RecipeAssembler.class, RecipeRemainingItemsFunction.class, String.class, String.class, Integer.TYPE, Integer.TYPE, List.class, ItemStack.class
+                );
+                recipe = (FunctionalRecipe<CraftingInventory>) constructor.newInstance(key, recipeMatcher, recipeAssembler, remainingItemsFunction, "misc", group, width, height, choices, result);
+            } else {
+                constructor = FunctionalRecipeGenerator.getFunctionalRecipeClass(getType()).getConstructor(
+                        NamespacedKey.class, RecipeMatcher.class, RecipeAssembler.class, RecipeRemainingItemsFunction.class, String.class, Integer.TYPE, Integer.TYPE, List.class, ItemStack.class
+                );
+                recipe = (FunctionalRecipe<CraftingInventory>) constructor.newInstance(key, recipeMatcher, recipeAssembler, remainingItemsFunction, group, width, height, choices, result);
+            }
             FunctionalRecipeGenerator.addRecipeToRecipeManager(recipe);
         } catch (NoSuchMethodException | InvocationTargetException | InstantiationException | IllegalAccessException e) {
             e.printStackTrace();

--- a/core/src/main/java/com/wolfyscript/utilities/bukkit/nms/item/crafting/FunctionalRecipeGenerator.java
+++ b/core/src/main/java/com/wolfyscript/utilities/bukkit/nms/item/crafting/FunctionalRecipeGenerator.java
@@ -27,7 +27,8 @@ import javassist.bytecode.SignatureAttribute;
 import me.wolfyscript.utilities.api.nms.inventory.InjectGUIInventory;
 import me.wolfyscript.utilities.util.NamespacedKey;
 import me.wolfyscript.utilities.util.Reflection;
-import me.wolfyscript.utilities.util.version.MinecraftVersions;
+import me.wolfyscript.utilities.util.version.MinecraftVersion;
+import me.wolfyscript.utilities.util.version.ServerVersion;
 import org.apache.commons.lang3.text.StrSubstitutor;
 import org.bukkit.Material;
 import org.bukkit.inventory.ItemStack;
@@ -50,6 +51,8 @@ public class FunctionalRecipeGenerator {
     private static final Class<?> NON_NULL_LIST_CLASS;
     private static final Class<?> RECIPE_MANAGER_CLASS;
     private static final Class<?> MINECRAFT_SERVER_CLASS;
+    private static final Class<?> COOKING_BOOK_CATEGORY;
+    private static final Class<?> CRAFTING_BOOK_CATEGORY;
 
     // Recipe classes
     private static final Class<?> RECIPE_CAMPFIRE_CLASS;
@@ -62,6 +65,8 @@ public class FunctionalRecipeGenerator {
     // Fields
     private static final Field ITEMSTACK_EMPTY_CONST;
     private static final Field RECIPE_ITEMSTACK_EMPTY_CONST;
+    private static final Field COOKING_BOOK_CATEGORY_CODEC;
+    private static final Field CRAFTING_BOOK_CATEGORY_CODEC;
 
     // Methods
     private static final Method MINECRAFT_SERVER_GET_RECIPE_MANAGER_METHOD;
@@ -106,6 +111,14 @@ public class FunctionalRecipeGenerator {
         RECIPE_MANAGER_CLASS = Reflection.getNMS("world.item.crafting", "CraftingManager");
         MINECRAFT_SERVER_CLASS = Reflection.getNMS("server", "MinecraftServer");
 
+        if (ServerVersion.isAfterOrEq(MinecraftVersion.of(1, 19, 3))) {
+            COOKING_BOOK_CATEGORY = Reflection.getNMS("world.item.crafting", "CookingBookCategory");
+            CRAFTING_BOOK_CATEGORY = Reflection.getNMS("world.item.crafting", "CraftingBookCategory");
+        } else {
+            COOKING_BOOK_CATEGORY = null;
+            CRAFTING_BOOK_CATEGORY = null;
+        }
+
         RECIPE_CAMPFIRE_CLASS = Reflection.getNMS("world.item.crafting", "RecipeCampfire");
         RECIPE_FURNACE_CLASS = Reflection.getNMS("world.item.crafting", "FurnaceRecipe");
         RECIPE_SMOKING_CLASS = Reflection.getNMS("world.item.crafting", "RecipeSmoking");
@@ -116,6 +129,14 @@ public class FunctionalRecipeGenerator {
         try {
             ITEMSTACK_EMPTY_CONST = ITEMSTACK_CLASS.getDeclaredField("b");
             RECIPE_ITEMSTACK_EMPTY_CONST = RECIPE_ITEMSTACK_CLASS.getDeclaredField("a");
+
+            if (ServerVersion.isAfterOrEq(MinecraftVersion.of(1, 19, 3))) {
+                COOKING_BOOK_CATEGORY_CODEC = COOKING_BOOK_CATEGORY.getDeclaredField("d");
+                CRAFTING_BOOK_CATEGORY_CODEC = CRAFTING_BOOK_CATEGORY.getDeclaredField("e");
+            } else {
+                COOKING_BOOK_CATEGORY_CODEC = null;
+                CRAFTING_BOOK_CATEGORY_CODEC = null;
+            }
         } catch (NoSuchFieldException e) {
             throw new RuntimeException(e);
         }
@@ -307,9 +328,9 @@ public class FunctionalRecipeGenerator {
             signatureBuilder.append(NamespacedKey.class.getName()).append(" var0").append(", ");
             // RecipeMatcher var1
             signatureBuilder.append(RecipeMatcher.class.getName()).append(" var1").append(", ");
-            // RecipeAssembler var1
+            // RecipeAssembler var2
             signatureBuilder.append(RecipeAssembler.class.getName()).append(" var2").append(", ");
-            // RecipeRemainingItemsFunction var1
+            // RecipeRemainingItemsFunction var3
             signatureBuilder.append(RecipeRemainingItemsFunction.class.getName()).append(" var3");
 
             for (int i = 0; i < parameters.length; i++) {
@@ -342,6 +363,18 @@ public class FunctionalRecipeGenerator {
                     // List var<i>
                     signatureBuilder.append(", ");
                     signatureBuilder.append(List.class.getName()).append(' ').append(name);
+                } else if (ServerVersion.isAfterOrEq(MinecraftVersion.of(1, 19, 3)) && parameters[i].equals(COOKING_BOOK_CATEGORY)) {
+                    // Use String in the constructor and find the category for it.
+                    bodyBuilder.append("(").append(COOKING_BOOK_CATEGORY.getName()).append(")").append(COOKING_BOOK_CATEGORY.getName()).append(".").append(COOKING_BOOK_CATEGORY_CODEC.getName()).append(".a(").append(name).append(")");
+                    // String var<i>
+                    signatureBuilder.append(", ");
+                    signatureBuilder.append("String ").append(name);
+                } else if (ServerVersion.isAfterOrEq(MinecraftVersion.of(1, 19, 3)) && parameters[i].equals(CRAFTING_BOOK_CATEGORY)) {
+                    // Use String in the constructor and find the category for it.
+                    bodyBuilder.append("(").append(CRAFTING_BOOK_CATEGORY.getName()).append(")").append(CRAFTING_BOOK_CATEGORY.getName()).append(".").append(CRAFTING_BOOK_CATEGORY_CODEC.getName()).append(".a(").append(name).append(")");
+                    // String var<i>
+                    signatureBuilder.append(", ");
+                    signatureBuilder.append("String ").append(name);
                 } else {
                     bodyBuilder.append(name);
                     // <Class Name> var<i>
@@ -469,8 +502,7 @@ public class FunctionalRecipeGenerator {
                         stack.exact = true;
                     }
                             
-                    stack.${ingredient_dissolve}();
-                    if (requireNotEmpty && stack.${ingredient_choices}.length == 0) {
+                    if (requireNotEmpty && stack.${ingredient_choices}().length == 0) {
                         throw new java.lang.IllegalArgumentException("Recipe requires at least one non-air choice!");
                     } else {
                         return stack;
@@ -485,8 +517,7 @@ public class FunctionalRecipeGenerator {
                 "itemstack", ItemStack.class.getName(),
                 "empty_ingredient", emptyIngredientField.getName(),
                 "craftitemstack", CRAFT_ITEMSTACK_CLASS.getName(),
-                "ingredient_dissolve", Reflection.NMSMapping.of(MinecraftVersions.v1_18, "f").orElse("buildChoices"),
-                "ingredient_choices", Arrays.stream(RECIPE_ITEMSTACK_CLASS.getFields()).filter(field -> field.getType().equals(ITEMSTACK_CLASS.arrayType())).findFirst().map(Field::getName).orElse("choices")
+                "ingredient_choices", Arrays.stream(RECIPE_ITEMSTACK_CLASS.getMethods()).filter(field -> field.getReturnType().equals(ITEMSTACK_CLASS.arrayType())).findFirst().map(Method::getName).orElse("choices")
         ));
         conversionUtils.addMethod(CtNewMethod.make(recipeChoiceConverterMethod, conversionUtils));
 

--- a/core/src/main/java/me/wolfyscript/utilities/api/nms/NMSUtil.java
+++ b/core/src/main/java/me/wolfyscript/utilities/api/nms/NMSUtil.java
@@ -19,6 +19,8 @@
 package me.wolfyscript.utilities.api.nms;
 
 import com.wolfyscript.utilities.bukkit.nms.fallback.FallbackNMSEntry;
+import java.util.ArrayList;
+import java.util.List;
 import me.wolfyscript.utilities.api.WolfyUtilities;
 import me.wolfyscript.utilities.util.Reflection;
 import me.wolfyscript.utilities.util.version.ServerVersion;
@@ -29,7 +31,8 @@ import java.util.HashMap;
 
 public abstract class NMSUtil {
 
-    private static final HashMap<String, VersionAdapter> versionAdapters = new HashMap<>();
+    private static final List<VersionHandler> versionHandlers = new ArrayList<>();
+    private static final HashMap<String, VersionHandler> versionAdapters = new HashMap<>();
 
     static {
         registerAdapter(new VersionAdapter("v1_17_R1"));
@@ -128,7 +131,7 @@ public abstract class NMSUtil {
     /**
      * Used to handle new types of NMS versions introduced with spigot 1.17 thanks to the use of Mojang mappings.
      */
-    private static class VersionAdapter {
+    private static class VersionAdapter implements VersionHandler {
 
         protected final String version;
 
@@ -136,6 +139,7 @@ public abstract class NMSUtil {
             this.version = entryVersion;
         }
 
+        @Override
         public String getPackageName() {
             if (ServerVersion.getVersion().getPatch() > 0) {
                 return version + "_P" + ServerVersion.getVersion().getPatch();
@@ -143,4 +147,11 @@ public abstract class NMSUtil {
             return version;
         }
     }
+
+    private interface VersionHandler {
+
+        String getPackageName();
+
+    }
+
 }

--- a/nmsutil/nmsutil-artifact/pom.xml
+++ b/nmsutil/nmsutil-artifact/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <artifactId>nmsutil</artifactId>
         <groupId>com.wolfyscript.wolfyutils.spigot</groupId>
-        <version>4.16.9.3</version>
+        <version>4.16.9.4-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
@@ -73,6 +73,11 @@
         <dependency>
             <groupId>${project.groupId}</groupId>
             <artifactId>nmsutil-v1_19_R1</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>nmsutil-v1_19_R2</artifactId>
             <version>${project.version}</version>
         </dependency>
     </dependencies>

--- a/nmsutil/nmsutil-v1_16_R1/pom.xml
+++ b/nmsutil/nmsutil-v1_16_R1/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <artifactId>nmsutil</artifactId>
         <groupId>com.wolfyscript.wolfyutils.spigot</groupId>
-        <version>4.16.9.3</version>
+        <version>4.16.9.4-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/nmsutil/nmsutil-v1_16_R2/pom.xml
+++ b/nmsutil/nmsutil-v1_16_R2/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <artifactId>nmsutil</artifactId>
         <groupId>com.wolfyscript.wolfyutils.spigot</groupId>
-        <version>4.16.9.3</version>
+        <version>4.16.9.4-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/nmsutil/nmsutil-v1_16_R3/pom.xml
+++ b/nmsutil/nmsutil-v1_16_R3/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <artifactId>nmsutil</artifactId>
         <groupId>com.wolfyscript.wolfyutils.spigot</groupId>
-        <version>4.16.9.3</version>
+        <version>4.16.9.4-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/nmsutil/nmsutil-v1_17_R1/pom.xml
+++ b/nmsutil/nmsutil-v1_17_R1/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <artifactId>nmsutil</artifactId>
         <groupId>com.wolfyscript.wolfyutils.spigot</groupId>
-        <version>4.16.9.3</version>
+        <version>4.16.9.4-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/nmsutil/nmsutil-v1_18_R1/pom.xml
+++ b/nmsutil/nmsutil-v1_18_R1/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <artifactId>nmsutil</artifactId>
         <groupId>com.wolfyscript.wolfyutils.spigot</groupId>
-        <version>4.16.9.3</version>
+        <version>4.16.9.4-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/nmsutil/nmsutil-v1_18_R1_P1/pom.xml
+++ b/nmsutil/nmsutil-v1_18_R1_P1/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <artifactId>nmsutil</artifactId>
         <groupId>com.wolfyscript.wolfyutils.spigot</groupId>
-        <version>4.16.9.3</version>
+        <version>4.16.9.4-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/nmsutil/nmsutil-v1_18_R2/pom.xml
+++ b/nmsutil/nmsutil-v1_18_R2/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <artifactId>nmsutil</artifactId>
         <groupId>com.wolfyscript.wolfyutils.spigot</groupId>
-        <version>4.16.9.3</version>
+        <version>4.16.9.4-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/nmsutil/nmsutil-v1_19_R1/pom.xml
+++ b/nmsutil/nmsutil-v1_19_R1/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>nmsutil</artifactId>
         <groupId>com.wolfyscript.wolfyutils.spigot</groupId>
-        <version>4.16.9.3</version>
+        <version>4.16.9.4-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/nmsutil/nmsutil-v1_19_R2/pom.xml
+++ b/nmsutil/nmsutil-v1_19_R2/pom.xml
@@ -1,24 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!--
-  ~       WolfyUtilities, APIs and Utilities for Minecraft Spigot plugins
-  ~                      Copyright (C) 2021  WolfyScript
-  ~
-  ~     This program is free software: you can redistribute it and/or modify
-  ~     it under the terms of the GNU General Public License as published by
-  ~     the Free Software Foundation, either version 3 of the License, or
-  ~     (at your option) any later version.
-  ~
-  ~     This program is distributed in the hope that it will be useful,
-  ~     but WITHOUT ANY WARRANTY; without even the implied warranty of
-  ~     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-  ~     GNU General Public License for more details.
-  ~
-  ~     You should have received a copy of the GNU General Public License
-  ~     along with this program.  If not, see <https://www.gnu.org/licenses/>.
-  -->
-
-<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xmlns="http://maven.apache.org/POM/4.0.0"
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
         <artifactId>nmsutil</artifactId>
@@ -27,13 +9,13 @@
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
-    <artifactId>nmsutil-v1_17_R1_P1</artifactId>
+    <artifactId>nmsutil-v1_19_R2</artifactId>
 
     <dependencies>
         <dependency>
             <groupId>org.spigotmc</groupId>
             <artifactId>spigot</artifactId>
-            <version>1.17.1-R0.1-SNAPSHOT</version>
+            <version>1.19.3-R0.1-SNAPSHOT</version>
             <type>jar</type>
             <classifier>remapped-mojang</classifier>
             <scope>provided</scope>
@@ -47,7 +29,7 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>${plugin_version.compile}</version>
                 <configuration>
-                    <release>${java.version}</release>
+                    <release>${java.mc18.version}</release>
                 </configuration>
             </plugin>
             <plugin>
@@ -62,9 +44,9 @@
                         </goals>
                         <id>remap-obf</id>
                         <configuration>
-                            <srgIn>org.spigotmc:minecraft-server:1.17.1-R0.1-SNAPSHOT:txt:maps-mojang</srgIn>
+                            <srgIn>org.spigotmc:minecraft-server:1.19.3-R0.1-SNAPSHOT:txt:maps-mojang</srgIn>
                             <reverse>true</reverse>
-                            <remappedDependencies>org.spigotmc:spigot:1.17.1-R0.1-SNAPSHOT:jar:remapped-mojang</remappedDependencies>
+                            <remappedDependencies>org.spigotmc:spigot:1.19.3-R0.1-SNAPSHOT:jar:remapped-mojang</remappedDependencies>
                             <remappedArtifactAttached>true</remappedArtifactAttached>
                             <remappedClassifierName>remapped-obf</remappedClassifierName>
                         </configuration>
@@ -77,8 +59,8 @@
                         <id>remap-spigot</id>
                         <configuration>
                             <inputFile>${project.build.directory}/${project.artifactId}-${project.version}-remapped-obf.jar</inputFile>
-                            <srgIn>org.spigotmc:minecraft-server:1.17.1-R0.1-SNAPSHOT:csrg:maps-spigot</srgIn>
-                            <remappedDependencies>org.spigotmc:spigot:1.17.1-R0.1-SNAPSHOT:jar:remapped-obf</remappedDependencies>
+                            <srgIn>org.spigotmc:minecraft-server:1.19.3-R0.1-SNAPSHOT:csrg:maps-spigot</srgIn>
+                            <remappedDependencies>org.spigotmc:spigot:1.19.3-R0.1-SNAPSHOT:jar:remapped-obf</remappedDependencies>
                         </configuration>
                     </execution>
                 </executions>

--- a/nmsutil/nmsutil-v1_19_R2/src/main/java/me/wolfyscript/utilities/api/nms/v1_19_R2/BlockUtilImpl.java
+++ b/nmsutil/nmsutil-v1_19_R2/src/main/java/me/wolfyscript/utilities/api/nms/v1_19_R2/BlockUtilImpl.java
@@ -1,0 +1,36 @@
+/*
+ *       WolfyUtilities, APIs and Utilities for Minecraft Spigot plugins
+ *                      Copyright (C) 2021  WolfyScript
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package me.wolfyscript.utilities.api.nms.v1_19_R2;
+
+import me.wolfyscript.utilities.api.nms.v1_19_R2.block.NMSBrewingStand;
+import me.wolfyscript.utilities.api.nms.BlockUtil;
+import me.wolfyscript.utilities.api.nms.NMSUtil;
+import org.bukkit.block.BrewingStand;
+
+public class BlockUtilImpl extends BlockUtil {
+
+    BlockUtilImpl(NMSUtil nmsUtil) {
+        super(nmsUtil);
+    }
+
+    @Override
+    public NMSBrewingStand getNmsBrewingStand(BrewingStand brewingStand) {
+        return new NMSBrewingStand(brewingStand);
+    }
+}

--- a/nmsutil/nmsutil-v1_19_R2/src/main/java/me/wolfyscript/utilities/api/nms/v1_19_R2/ItemUtilImpl.java
+++ b/nmsutil/nmsutil-v1_19_R2/src/main/java/me/wolfyscript/utilities/api/nms/v1_19_R2/ItemUtilImpl.java
@@ -1,0 +1,84 @@
+/*
+ *       WolfyUtilities, APIs and Utilities for Minecraft Spigot plugins
+ *                      Copyright (C) 2021  WolfyScript
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package me.wolfyscript.utilities.api.nms.v1_19_R2;
+
+import com.mojang.brigadier.exceptions.CommandSyntaxException;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.util.Base64;
+import me.wolfyscript.utilities.api.nms.ItemUtil;
+import me.wolfyscript.utilities.api.nms.NMSUtil;
+import net.minecraft.nbt.CompoundTag;
+import net.minecraft.nbt.NbtIo;
+import net.minecraft.nbt.TagParser;
+import net.minecraft.world.item.ItemStack;
+import org.bukkit.craftbukkit.v1_19_R2.inventory.CraftItemStack;
+
+public class ItemUtilImpl extends ItemUtil {
+
+
+    protected ItemUtilImpl(NMSUtil nmsUtil) {
+        super(nmsUtil);
+    }
+
+    @Override
+    public String getItemStackJson(org.bukkit.inventory.ItemStack itemStack) {
+        var nmsItemStack = CraftItemStack.asNMSCopy(itemStack);
+        return nmsItemStack.save(new CompoundTag()).toString();
+    }
+
+    @Override
+    public org.bukkit.inventory.ItemStack getJsonItemStack(String json) {
+        try {
+            var nbtTagCompound = TagParser.parseTag(json);
+            var itemStack = ItemStack.of(nbtTagCompound);
+            return CraftItemStack.asBukkitCopy(itemStack);
+        } catch (CommandSyntaxException e) {
+            e.printStackTrace();
+        }
+        return null;
+    }
+
+    @Override
+    public String getItemStackBase64(org.bukkit.inventory.ItemStack itemStack) throws IOException {
+        if (itemStack == null) return "null";
+        var nmsItemStack = CraftItemStack.asNMSCopy(itemStack);
+        var outputStream = new ByteArrayOutputStream();
+        NbtIo.writeCompressed(nmsItemStack.save(new CompoundTag()), outputStream);
+        return Base64.getEncoder().encodeToString(outputStream.toByteArray());
+    }
+
+    @Override
+    public org.bukkit.inventory.ItemStack getBase64ItemStack(String data) throws IOException {
+        return getBase64ItemStack(Base64.getDecoder().decode(data));
+    }
+
+    @Override
+    public org.bukkit.inventory.ItemStack getBase64ItemStack(byte[] bytes) throws IOException {
+        if (bytes == null || bytes.length == 0) return null;
+        var inputStream = new ByteArrayInputStream(bytes);
+        var nbtTagCompound = NbtIo.readCompressed(inputStream);
+        var itemStack = ItemStack.of(nbtTagCompound);
+        if (itemStack != null) {
+            return CraftItemStack.asBukkitCopy(itemStack);
+        }
+        return null;
+    }
+}

--- a/nmsutil/nmsutil-v1_19_R2/src/main/java/me/wolfyscript/utilities/api/nms/v1_19_R2/NBTTagImpl.java
+++ b/nmsutil/nmsutil-v1_19_R2/src/main/java/me/wolfyscript/utilities/api/nms/v1_19_R2/NBTTagImpl.java
@@ -1,0 +1,115 @@
+/*
+ *       WolfyUtilities, APIs and Utilities for Minecraft Spigot plugins
+ *                      Copyright (C) 2021  WolfyScript
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package me.wolfyscript.utilities.api.nms.v1_19_R2;
+
+import me.wolfyscript.utilities.api.nms.NBTTag;
+import me.wolfyscript.utilities.api.nms.nbt.NBTCompound;
+import me.wolfyscript.utilities.api.nms.nbt.NBTTagByte;
+import me.wolfyscript.utilities.api.nms.nbt.NBTTagByteArray;
+import me.wolfyscript.utilities.api.nms.nbt.NBTTagDouble;
+import me.wolfyscript.utilities.api.nms.nbt.NBTTagEnd;
+import me.wolfyscript.utilities.api.nms.nbt.NBTTagFloat;
+import me.wolfyscript.utilities.api.nms.nbt.NBTTagInt;
+import me.wolfyscript.utilities.api.nms.nbt.NBTTagIntArray;
+import me.wolfyscript.utilities.api.nms.nbt.NBTTagList;
+import me.wolfyscript.utilities.api.nms.nbt.NBTTagLong;
+import me.wolfyscript.utilities.api.nms.nbt.NBTTagLongArray;
+import me.wolfyscript.utilities.api.nms.nbt.NBTTagShort;
+import me.wolfyscript.utilities.api.nms.nbt.NBTTagString;
+import me.wolfyscript.utilities.api.nms.v1_19_R2.nbt.NBTTagByteArrayImpl;
+import me.wolfyscript.utilities.api.nms.v1_19_R2.nbt.NBTTagByteImpl;
+import me.wolfyscript.utilities.api.nms.v1_19_R2.nbt.NBTTagCompoundImpl;
+import me.wolfyscript.utilities.api.nms.v1_19_R2.nbt.NBTTagDoubleImpl;
+import me.wolfyscript.utilities.api.nms.v1_19_R2.nbt.NBTTagEndImpl;
+import me.wolfyscript.utilities.api.nms.v1_19_R2.nbt.NBTTagFloatImpl;
+import me.wolfyscript.utilities.api.nms.v1_19_R2.nbt.NBTTagIntArrayImpl;
+import me.wolfyscript.utilities.api.nms.v1_19_R2.nbt.NBTTagIntImpl;
+import me.wolfyscript.utilities.api.nms.v1_19_R2.nbt.NBTTagListImpl;
+import me.wolfyscript.utilities.api.nms.v1_19_R2.nbt.NBTTagLongArrayImpl;
+import me.wolfyscript.utilities.api.nms.v1_19_R2.nbt.NBTTagLongImpl;
+import me.wolfyscript.utilities.api.nms.v1_19_R2.nbt.NBTTagShortImpl;
+import me.wolfyscript.utilities.api.nms.v1_19_R2.nbt.NBTTagStringImpl;
+
+public class NBTTagImpl extends NBTTag {
+
+    @Override
+    public NBTTagEnd end() {
+        return NBTTagEndImpl.of();
+    }
+
+    @Override
+    public NBTCompound compound() {
+        return NBTTagCompoundImpl.of();
+    }
+
+    @Override
+    public NBTTagList list() {
+        return NBTTagListImpl.of();
+    }
+
+    @Override
+    public NBTTagByte ofByte(byte value) {
+        return NBTTagByteImpl.of(value);
+    }
+
+    @Override
+    public NBTTagByteArray ofByteArray(byte[] value) {
+        return NBTTagByteArrayImpl.of(value);
+    }
+
+    @Override
+    public NBTTagDouble ofDouble(double value) {
+        return NBTTagDoubleImpl.of(value);
+    }
+
+    @Override
+    public NBTTagFloat ofFloat(float value) {
+        return NBTTagFloatImpl.of(value);
+    }
+
+    @Override
+    public NBTTagInt ofInt(int value) {
+        return NBTTagIntImpl.of(value);
+    }
+
+    @Override
+    public NBTTagIntArray ofIntArray(int[] array) {
+        return NBTTagIntArrayImpl.of(array);
+    }
+
+    @Override
+    public NBTTagLong ofLong(long value) {
+        return NBTTagLongImpl.of(value);
+    }
+
+    @Override
+    public NBTTagLongArray ofLongArray(long[] array) {
+        return NBTTagLongArrayImpl.of(array);
+    }
+
+    @Override
+    public NBTTagShort ofShort(short value) {
+        return NBTTagShortImpl.of(value);
+    }
+
+    @Override
+    public NBTTagString ofString(String value) {
+        return NBTTagStringImpl.of(value);
+    }
+}

--- a/nmsutil/nmsutil-v1_19_R2/src/main/java/me/wolfyscript/utilities/api/nms/v1_19_R2/NBTUtilImpl.java
+++ b/nmsutil/nmsutil-v1_19_R2/src/main/java/me/wolfyscript/utilities/api/nms/v1_19_R2/NBTUtilImpl.java
@@ -1,0 +1,44 @@
+/*
+ *       WolfyUtilities, APIs and Utilities for Minecraft Spigot plugins
+ *                      Copyright (C) 2021  WolfyScript
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package me.wolfyscript.utilities.api.nms.v1_19_R2;
+
+import me.wolfyscript.utilities.api.nms.NBTUtil;
+import me.wolfyscript.utilities.api.nms.NMSUtil;
+import me.wolfyscript.utilities.api.nms.nbt.NBTItem;
+import me.wolfyscript.utilities.api.nms.v1_19_R2.nbt.NBTItemImpl;
+import org.bukkit.inventory.ItemStack;
+
+public class NBTUtilImpl extends NBTUtil {
+
+    protected NBTUtilImpl(NMSUtil nmsUtil) {
+        super(nmsUtil);
+        this.nbtTag = new NBTTagImpl();
+    }
+
+    @Override
+    public NBTItem getItem(ItemStack bukkitItemStack) {
+        return new NBTItemImpl(bukkitItemStack, false);
+    }
+
+    @Override
+    public NBTItem getDirectItem(ItemStack bukkitItemStack) {
+        return new NBTItemImpl(bukkitItemStack, true);
+    }
+
+}

--- a/nmsutil/nmsutil-v1_19_R2/src/main/java/me/wolfyscript/utilities/api/nms/v1_19_R2/NMSEntry.java
+++ b/nmsutil/nmsutil-v1_19_R2/src/main/java/me/wolfyscript/utilities/api/nms/v1_19_R2/NMSEntry.java
@@ -1,0 +1,43 @@
+/*
+ *       WolfyUtilities, APIs and Utilities for Minecraft Spigot plugins
+ *                      Copyright (C) 2021  WolfyScript
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package me.wolfyscript.utilities.api.nms.v1_19_R2;
+
+import com.wolfyscript.utilities.bukkit.nms.fallback.FallbackInventoryUtilImpl;
+import me.wolfyscript.utilities.api.WolfyUtilities;
+import me.wolfyscript.utilities.api.nms.NMSUtil;
+import org.bukkit.plugin.Plugin;
+
+public class NMSEntry extends NMSUtil {
+
+    /**
+     * The class that implements this NMSUtil needs to have a constructor with just the {@link Plugin} parameter.
+     *
+     * @param wolfyUtilities
+     */
+    public NMSEntry(WolfyUtilities wolfyUtilities) {
+        super(wolfyUtilities);
+        this.blockUtil = new BlockUtilImpl(this);
+        this.itemUtil = new ItemUtilImpl(this);
+        this.inventoryUtil = new FallbackInventoryUtilImpl(this);
+        this.nbtUtil = new NBTUtilImpl(this);
+        this.recipeUtil = new RecipeUtilImpl(this);
+        this.networkUtil = new NetworkUtilImpl(this);
+    }
+
+}

--- a/nmsutil/nmsutil-v1_19_R2/src/main/java/me/wolfyscript/utilities/api/nms/v1_19_R2/NetworkUtilImpl.java
+++ b/nmsutil/nmsutil-v1_19_R2/src/main/java/me/wolfyscript/utilities/api/nms/v1_19_R2/NetworkUtilImpl.java
@@ -1,0 +1,42 @@
+/*
+ *       WolfyUtilities, APIs and Utilities for Minecraft Spigot plugins
+ *                      Copyright (C) 2021  WolfyScript
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package me.wolfyscript.utilities.api.nms.v1_19_R2;
+
+import io.netty.buffer.ByteBuf;
+import me.wolfyscript.utilities.api.nms.NMSUtil;
+import me.wolfyscript.utilities.api.nms.NetworkUtil;
+import me.wolfyscript.utilities.api.nms.network.MCByteBuf;
+import me.wolfyscript.utilities.api.nms.v1_19_R2.network.MCByteBufImpl;
+
+public class NetworkUtilImpl extends NetworkUtil {
+
+    protected NetworkUtilImpl(NMSUtil nmsUtil) {
+        super(nmsUtil);
+    }
+
+    @Override
+    public MCByteBuf buffer(ByteBuf byteBuf) {
+        return new MCByteBufImpl(byteBuf);
+    }
+
+    @Override
+    public MCByteBuf buffer() {
+        return new MCByteBufImpl();
+    }
+}

--- a/nmsutil/nmsutil-v1_19_R2/src/main/java/me/wolfyscript/utilities/api/nms/v1_19_R2/RecipeUtilImpl.java
+++ b/nmsutil/nmsutil-v1_19_R2/src/main/java/me/wolfyscript/utilities/api/nms/v1_19_R2/RecipeUtilImpl.java
@@ -1,0 +1,40 @@
+/*
+ *       WolfyUtilities, APIs and Utilities for Minecraft Spigot plugins
+ *                      Copyright (C) 2021  WolfyScript
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package me.wolfyscript.utilities.api.nms.v1_19_R2;
+
+import java.util.Iterator;
+import me.wolfyscript.utilities.api.nms.NMSUtil;
+import me.wolfyscript.utilities.api.nms.inventory.RecipeType;
+import me.wolfyscript.utilities.api.nms.v1_19_R2.inventory.RecipeIterator;
+import org.bukkit.inventory.Recipe;
+import org.jetbrains.annotations.NotNull;
+
+public class RecipeUtilImpl extends me.wolfyscript.utilities.api.nms.RecipeUtil {
+
+    protected RecipeUtilImpl(NMSUtil nmsUtil) {
+        super(nmsUtil);
+    }
+
+    @Override
+    public @NotNull Iterator<Recipe> recipeIterator(RecipeType recipeType) {
+        return new RecipeIterator(recipeType);
+    }
+
+
+}

--- a/nmsutil/nmsutil-v1_19_R2/src/main/java/me/wolfyscript/utilities/api/nms/v1_19_R2/block/NMSBrewingStand.java
+++ b/nmsutil/nmsutil-v1_19_R2/src/main/java/me/wolfyscript/utilities/api/nms/v1_19_R2/block/NMSBrewingStand.java
@@ -1,0 +1,52 @@
+/*
+ *       WolfyUtilities, APIs and Utilities for Minecraft Spigot plugins
+ *                      Copyright (C) 2021  WolfyScript
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package me.wolfyscript.utilities.api.nms.v1_19_R2.block;
+
+import net.minecraft.world.level.block.entity.BrewingStandBlockEntity;
+import org.bukkit.block.BrewingStand;
+import org.bukkit.craftbukkit.v1_19_R2.CraftWorld;
+import org.bukkit.craftbukkit.v1_19_R2.block.CraftBlock;
+import org.bukkit.craftbukkit.v1_19_R2.block.CraftBrewingStand;
+
+public class NMSBrewingStand extends CraftBrewingStand implements me.wolfyscript.utilities.api.nms.block.NMSBrewingStand {
+
+    public NMSBrewingStand(BrewingStand brewingStand) {
+        super(brewingStand.getWorld(), (BrewingStandBlockEntity) ((CraftWorld)brewingStand.getWorld()).getHandle().getBlockEntity(((CraftBlock) brewingStand.getBlock()).getPosition()));
+    }
+
+    @Override
+    public int getFuelLevel() {
+        return getTileEntity().fuel;
+    }
+
+    @Override
+    public void setFuelLevel(int level) {
+        getTileEntity().fuel = level;
+    }
+
+    @Override
+    public int getBrewingTime() {
+        return getTileEntity().brewTime;
+    }
+
+    @Override
+    public void setBrewingTime(int brewTime) {
+        getTileEntity().brewTime = brewTime;
+    }
+}

--- a/nmsutil/nmsutil-v1_19_R2/src/main/java/me/wolfyscript/utilities/api/nms/v1_19_R2/inventory/RecipeIterator.java
+++ b/nmsutil/nmsutil-v1_19_R2/src/main/java/me/wolfyscript/utilities/api/nms/v1_19_R2/inventory/RecipeIterator.java
@@ -1,0 +1,71 @@
+/*
+ *       WolfyUtilities, APIs and Utilities for Minecraft Spigot plugins
+ *                      Copyright (C) 2021  WolfyScript
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package me.wolfyscript.utilities.api.nms.v1_19_R2.inventory;
+
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.List;
+import me.wolfyscript.utilities.api.nms.inventory.RecipeType;
+import net.minecraft.server.MinecraftServer;
+import net.minecraft.world.item.crafting.Recipe;
+
+public class RecipeIterator implements Iterator<org.bukkit.inventory.Recipe> {
+
+    private final Iterator<Recipe<?>> recipes;
+
+    public RecipeIterator(RecipeType recipeType) {
+        net.minecraft.world.item.crafting.RecipeType<?> recipesReg = getRecipes(recipeType);
+        if (recipesReg != null) {
+            this.recipes = MinecraftServer.getServer().getRecipeManager().recipes.get(recipesReg).values().iterator();
+        } else {
+            this.recipes = Collections.emptyIterator();
+        }
+    }
+
+    public RecipeIterator(List<Recipe<?>> recipeList) {
+        this.recipes = recipeList.iterator();
+    }
+
+    private net.minecraft.world.item.crafting.RecipeType<?> getRecipes(RecipeType type) {
+        return switch (type) {
+            case CRAFTING -> net.minecraft.world.item.crafting.RecipeType.CRAFTING;
+            case SMELTING -> net.minecraft.world.item.crafting.RecipeType.SMELTING;
+            case BLASTING -> net.minecraft.world.item.crafting.RecipeType.BLASTING;
+            case SMOKING -> net.minecraft.world.item.crafting.RecipeType.SMOKING;
+            case CAMPFIRE_COOKING -> net.minecraft.world.item.crafting.RecipeType.CAMPFIRE_COOKING;
+            case STONECUTTING -> net.minecraft.world.item.crafting.RecipeType.STONECUTTING;
+            case SMITHING -> net.minecraft.world.item.crafting.RecipeType.SMITHING;
+        };
+    }
+
+    @Override
+    public boolean hasNext() {
+        return this.recipes.hasNext();
+    }
+
+    @Override
+    public org.bukkit.inventory.Recipe next() {
+        return this.recipes.next().toBukkitRecipe();
+    }
+
+    @Override
+    public void remove() {
+        this.recipes.remove();
+    }
+}

--- a/nmsutil/nmsutil-v1_19_R2/src/main/java/me/wolfyscript/utilities/api/nms/v1_19_R2/nbt/NBTBaseImpl.java
+++ b/nmsutil/nmsutil-v1_19_R2/src/main/java/me/wolfyscript/utilities/api/nms/v1_19_R2/nbt/NBTBaseImpl.java
@@ -1,0 +1,44 @@
+/*
+ *       WolfyUtilities, APIs and Utilities for Minecraft Spigot plugins
+ *                      Copyright (C) 2021  WolfyScript
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package me.wolfyscript.utilities.api.nms.v1_19_R2.nbt;
+
+import me.wolfyscript.utilities.api.nms.nbt.NBTBase;
+
+public abstract class NBTBaseImpl<NBT extends net.minecraft.nbt.Tag> implements NBTBase {
+
+    protected final NBT nbt;
+
+    NBTBaseImpl(NBT nbtBase) {
+        this.nbt = nbtBase;
+    }
+
+    @Override
+    public byte getTypeId() {
+        return nbt.getId();
+    }
+
+    @Override
+    public String toString() {
+        return nbt.toString();
+    }
+
+    public NBT getNbt() {
+        return nbt;
+    }
+}

--- a/nmsutil/nmsutil-v1_19_R2/src/main/java/me/wolfyscript/utilities/api/nms/v1_19_R2/nbt/NBTItemImpl.java
+++ b/nmsutil/nmsutil-v1_19_R2/src/main/java/me/wolfyscript/utilities/api/nms/v1_19_R2/nbt/NBTItemImpl.java
@@ -1,0 +1,97 @@
+/*
+ *       WolfyUtilities, APIs and Utilities for Minecraft Spigot plugins
+ *                      Copyright (C) 2021  WolfyScript
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package me.wolfyscript.utilities.api.nms.v1_19_R2.nbt;
+
+import java.lang.reflect.Field;
+import java.util.Set;
+import me.wolfyscript.utilities.api.nms.nbt.NBTBase;
+import me.wolfyscript.utilities.api.nms.nbt.NBTCompound;
+import me.wolfyscript.utilities.api.nms.nbt.NBTItem;
+import me.wolfyscript.utilities.util.Reflection;
+import net.minecraft.nbt.CompoundTag;
+import org.bukkit.craftbukkit.v1_19_R2.inventory.CraftItemStack;
+import org.bukkit.inventory.ItemStack;
+import org.jetbrains.annotations.Nullable;
+
+public class NBTItemImpl extends NBTItem {
+
+    static final Field HANDLE_FIELD = Reflection.getDeclaredField(CraftItemStack.class, "handle");
+
+    final NBTTagCompoundImpl compound;
+    private final net.minecraft.world.item.ItemStack nms;
+
+    public NBTItemImpl(ItemStack bukkitItemStack, boolean directAccess) {
+        super(bukkitItemStack, directAccess);
+        net.minecraft.world.item.ItemStack mcItemStack = null;
+        if (directAccess && HANDLE_FIELD != null && HANDLE_FIELD.trySetAccessible()) {
+            var craftItemStack = (CraftItemStack) bukkitItemStack;
+            try {
+                if (HANDLE_FIELD.get(craftItemStack) instanceof net.minecraft.world.item.ItemStack handle) {
+                    mcItemStack = handle;
+                }
+            } catch (IllegalAccessException e) {
+                e.printStackTrace();
+            }
+        }
+        this.nms = mcItemStack == null ? CraftItemStack.asNMSCopy(bukkitItemStack) : mcItemStack;
+        this.compound = new NBTTagCompoundImpl(this.nms.hasTag() ? this.nms.getTag() : new CompoundTag());
+        this.nms.setTag(compound.nbt);
+    }
+
+    @Override
+    public ItemStack create() {
+        return CraftItemStack.asBukkitCopy(nms);
+    }
+
+    @Override
+    public void setTag(String key, NBTBase nbtBase) {
+        compound.set(key, nbtBase);
+    }
+
+    @Override
+    public @Nullable NBTBase getTag(String key) {
+        return compound.get(key);
+    }
+
+    @Override
+    public NBTCompound getCompound(String key) {
+        return new NBTTagCompoundImpl(this.compound, key);
+    }
+
+    @Override
+    public NBTCompound getCompound() {
+        return this.compound;
+    }
+
+    @Override
+    public boolean hasKey(String key) {
+        return compound.hasKey(key);
+    }
+
+    @Override
+    public boolean hasKeyOfType(String key, int typeId) {
+        return compound.hasKeyOfType(key, typeId);
+    }
+
+    @Override
+    public Set<String> getKeys() {
+        return compound.getKeys();
+    }
+
+}

--- a/nmsutil/nmsutil-v1_19_R2/src/main/java/me/wolfyscript/utilities/api/nms/v1_19_R2/nbt/NBTNumberImpl.java
+++ b/nmsutil/nmsutil-v1_19_R2/src/main/java/me/wolfyscript/utilities/api/nms/v1_19_R2/nbt/NBTNumberImpl.java
@@ -1,0 +1,56 @@
+/*
+ *       WolfyUtilities, APIs and Utilities for Minecraft Spigot plugins
+ *                      Copyright (C) 2021  WolfyScript
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package me.wolfyscript.utilities.api.nms.v1_19_R2.nbt;
+
+public abstract class NBTNumberImpl<NBT extends net.minecraft.nbt.NumericTag> extends NBTBaseImpl<NBT> implements me.wolfyscript.utilities.api.nms.nbt.NBTNumber {
+
+    NBTNumberImpl(NBT nbtBase) {
+        super(nbtBase);
+    }
+
+    @Override
+    public long asLong() {
+        return nbt.getAsLong();
+    }
+
+    @Override
+    public int asInt() {
+        return nbt.getAsInt();
+    }
+
+    @Override
+    public short asShort() {
+        return nbt.getAsShort();
+    }
+
+    @Override
+    public byte asByte() {
+        return nbt.getAsByte();
+    }
+
+    @Override
+    public double asDouble() {
+        return nbt.getAsDouble();
+    }
+
+    @Override
+    public float asFloat() {
+        return nbt.getAsFloat();
+    }
+}

--- a/nmsutil/nmsutil-v1_19_R2/src/main/java/me/wolfyscript/utilities/api/nms/v1_19_R2/nbt/NBTTagByteArrayImpl.java
+++ b/nmsutil/nmsutil-v1_19_R2/src/main/java/me/wolfyscript/utilities/api/nms/v1_19_R2/nbt/NBTTagByteArrayImpl.java
@@ -1,0 +1,41 @@
+/*
+ *       WolfyUtilities, APIs and Utilities for Minecraft Spigot plugins
+ *                      Copyright (C) 2021  WolfyScript
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package me.wolfyscript.utilities.api.nms.v1_19_R2.nbt;
+
+import me.wolfyscript.utilities.api.nms.nbt.NBTTagByteArray;
+import me.wolfyscript.utilities.api.nms.nbt.NBTTagType;
+import net.minecraft.nbt.ByteArrayTag;
+
+public class NBTTagByteArrayImpl extends NBTBaseImpl<ByteArrayTag> implements NBTTagByteArray {
+
+    public static final NBTTagType<NBTTagByteArray> TYPE = new NBTTagTypeImpl<>(NBTTagType.Type.BYTE_ARRAY, nbtBase -> new NBTTagByteArrayImpl((ByteArrayTag) nbtBase));
+
+    NBTTagByteArrayImpl(ByteArrayTag nbtBase) {
+        super(nbtBase);
+    }
+
+    public static NBTTagByteArray of(byte[] value) {
+        return new NBTTagByteArrayImpl(new ByteArrayTag(value));
+    }
+
+    @Override
+    public NBTTagType<NBTTagByteArray> getType() {
+        return TYPE;
+    }
+}

--- a/nmsutil/nmsutil-v1_19_R2/src/main/java/me/wolfyscript/utilities/api/nms/v1_19_R2/nbt/NBTTagByteImpl.java
+++ b/nmsutil/nmsutil-v1_19_R2/src/main/java/me/wolfyscript/utilities/api/nms/v1_19_R2/nbt/NBTTagByteImpl.java
@@ -1,0 +1,45 @@
+/*
+ *       WolfyUtilities, APIs and Utilities for Minecraft Spigot plugins
+ *                      Copyright (C) 2021  WolfyScript
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package me.wolfyscript.utilities.api.nms.v1_19_R2.nbt;
+
+import me.wolfyscript.utilities.api.nms.nbt.NBTTagByte;
+import me.wolfyscript.utilities.api.nms.nbt.NBTTagType;
+import net.minecraft.nbt.ByteTag;
+
+public class NBTTagByteImpl extends NBTNumberImpl<ByteTag> implements NBTTagByte {
+
+    public static final NBTTagType<NBTTagByte> TYPE = new NBTTagTypeImpl<>(NBTTagType.Type.BYTE, nbtBase -> new NBTTagByteImpl((ByteTag) nbtBase));
+
+    private NBTTagByteImpl() {
+        super(ByteTag.ZERO);
+    }
+
+    NBTTagByteImpl(ByteTag nbtBase) {
+        super(nbtBase);
+    }
+
+    public static NBTTagByte of(byte value) {
+        return new NBTTagByteImpl(ByteTag.valueOf(value));
+    }
+
+    @Override
+    public NBTTagType<NBTTagByte> getType() {
+        return TYPE;
+    }
+}

--- a/nmsutil/nmsutil-v1_19_R2/src/main/java/me/wolfyscript/utilities/api/nms/v1_19_R2/nbt/NBTTagCompoundImpl.java
+++ b/nmsutil/nmsutil-v1_19_R2/src/main/java/me/wolfyscript/utilities/api/nms/v1_19_R2/nbt/NBTTagCompoundImpl.java
@@ -1,0 +1,196 @@
+/*
+ *       WolfyUtilities, APIs and Utilities for Minecraft Spigot plugins
+ *                      Copyright (C) 2021  WolfyScript
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package me.wolfyscript.utilities.api.nms.v1_19_R2.nbt;
+
+import java.util.Set;
+import me.wolfyscript.utilities.api.nms.nbt.NBTBase;
+import me.wolfyscript.utilities.api.nms.nbt.NBTCompound;
+import me.wolfyscript.utilities.api.nms.nbt.NBTTagType;
+import net.minecraft.nbt.CompoundTag;
+
+public class NBTTagCompoundImpl extends NBTBaseImpl<CompoundTag> implements NBTCompound {
+
+    public static final NBTTagType<NBTCompound> TYPE = new NBTTagTypeImpl<>(NBTTagType.Type.COMPOUND, nbtBase -> new NBTTagCompoundImpl((CompoundTag) nbtBase));
+
+    private NBTTagCompoundImpl() {
+        super(new CompoundTag());
+    }
+
+    NBTTagCompoundImpl(CompoundTag compound) {
+        super(compound);
+    }
+
+    NBTTagCompoundImpl(NBTTagCompoundImpl parent, String key) {
+        super(parent.hasKeyOfType(key, 10) ? parent.nbt.getCompound(key) : new CompoundTag());
+    }
+
+    public static NBTCompound of() {
+        return new NBTTagCompoundImpl();
+    }
+
+    @Override
+    public Set<String> getKeys() {
+        return nbt.getAllKeys();
+    }
+
+    @Override
+    public int size() {
+        return nbt.size();
+    }
+
+    @Override
+    public boolean hasKey(String key) {
+        return nbt.contains(key);
+    }
+
+    @Override
+    public boolean hasKeyOfType(String key, int typeId) {
+        return nbt.contains(key, typeId);
+    }
+
+    @Override
+    public NBTBase set(String key, NBTBase nbtBase) {
+        return NBTTagTypes.convert(nbt.put(key, ((NBTBaseImpl<?>) nbtBase).nbt));
+    }
+
+    @Override
+    public void setByte(String key, byte value) {
+        nbt.putByte(key, value);
+    }
+
+    @Override
+    public void setBoolean(String key, boolean value) {
+        nbt.putBoolean(key, value);
+    }
+
+    @Override
+    public void setShort(String key, short value) {
+        nbt.putShort(key, value);
+    }
+
+    @Override
+    public void setInt(String key, int value) {
+        nbt.putInt(key, value);
+    }
+
+    @Override
+    public void setLong(String key, long value) {
+        nbt.putLong(key, value);
+    }
+
+    @Override
+    public void setFloat(String key, float value) {
+        nbt.putFloat(key, value);
+    }
+
+    @Override
+    public void setDouble(String key, double value) {
+        nbt.putDouble(key, value);
+    }
+
+    @Override
+    public void setString(String key, String value) {
+        nbt.putString(key, value);
+    }
+
+    @Override
+    public void setByteArray(String key, byte[] value) {
+        nbt.putByteArray(key, value);
+    }
+
+    @Override
+    public void setIntArray(String key, int[] value) {
+        nbt.putIntArray(key, value);
+    }
+
+    @Override
+    public void setLongArray(String key, long[] value) {
+        nbt.putLongArray(key, value);
+    }
+
+    @Override
+    public NBTBase get(String key) {
+        return NBTTagTypes.convert(nbt.get(key));
+    }
+
+    @Override
+    public byte getByte(String key) {
+        return nbt.getByte(key);
+    }
+
+    @Override
+    public boolean getBoolean(String key) {
+        return nbt.getBoolean(key);
+    }
+
+    @Override
+    public short getShort(String key) {
+        return nbt.getShort(key);
+    }
+
+    @Override
+    public int getInt(String key) {
+        return nbt.getInt(key);
+    }
+
+    @Override
+    public long getLong(String key) {
+        return nbt.getLong(key);
+    }
+
+    @Override
+    public float getFloat(String key) {
+        return nbt.getFloat(key);
+    }
+
+    @Override
+    public double getDouble(String key) {
+        return nbt.getDouble(key);
+    }
+
+    @Override
+    public String getString(String key) {
+        return nbt.getString(key);
+    }
+
+    @Override
+    public byte[] getByteArray(String key) {
+        return nbt.getByteArray(key);
+    }
+
+    @Override
+    public int[] getIntArray(String key) {
+        return nbt.getIntArray(key);
+    }
+
+    @Override
+    public long[] getLongArray(String key) {
+        return nbt.getLongArray(key);
+    }
+
+    @Override
+    public NBTCompound getCompound(String key) {
+        return new NBTTagCompoundImpl(this, key);
+    }
+
+    @Override
+    public NBTTagType<NBTCompound> getType() {
+        return TYPE;
+    }
+}

--- a/nmsutil/nmsutil-v1_19_R2/src/main/java/me/wolfyscript/utilities/api/nms/v1_19_R2/nbt/NBTTagDoubleImpl.java
+++ b/nmsutil/nmsutil-v1_19_R2/src/main/java/me/wolfyscript/utilities/api/nms/v1_19_R2/nbt/NBTTagDoubleImpl.java
@@ -1,0 +1,45 @@
+/*
+ *       WolfyUtilities, APIs and Utilities for Minecraft Spigot plugins
+ *                      Copyright (C) 2021  WolfyScript
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package me.wolfyscript.utilities.api.nms.v1_19_R2.nbt;
+
+import me.wolfyscript.utilities.api.nms.nbt.NBTTagDouble;
+import me.wolfyscript.utilities.api.nms.nbt.NBTTagType;
+import net.minecraft.nbt.DoubleTag;
+
+public class NBTTagDoubleImpl extends NBTNumberImpl<DoubleTag> implements NBTTagDouble {
+
+    public static final NBTTagType<NBTTagDouble> TYPE = new NBTTagTypeImpl<>(NBTTagType.Type.DOUBLE, nbtBase -> new NBTTagDoubleImpl((DoubleTag) nbtBase));
+
+    private NBTTagDoubleImpl() {
+        super(DoubleTag.valueOf(0d));
+    }
+
+    NBTTagDoubleImpl(DoubleTag nbtBase) {
+        super(nbtBase);
+    }
+
+    public static NBTTagDouble of(double value) {
+        return new NBTTagDoubleImpl(DoubleTag.valueOf(value));
+    }
+
+    @Override
+    public NBTTagType<NBTTagDouble> getType() {
+        return TYPE;
+    }
+}

--- a/nmsutil/nmsutil-v1_19_R2/src/main/java/me/wolfyscript/utilities/api/nms/v1_19_R2/nbt/NBTTagEndImpl.java
+++ b/nmsutil/nmsutil-v1_19_R2/src/main/java/me/wolfyscript/utilities/api/nms/v1_19_R2/nbt/NBTTagEndImpl.java
@@ -1,0 +1,45 @@
+/*
+ *       WolfyUtilities, APIs and Utilities for Minecraft Spigot plugins
+ *                      Copyright (C) 2021  WolfyScript
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package me.wolfyscript.utilities.api.nms.v1_19_R2.nbt;
+
+import me.wolfyscript.utilities.api.nms.nbt.NBTTagEnd;
+import me.wolfyscript.utilities.api.nms.nbt.NBTTagType;
+import net.minecraft.nbt.EndTag;
+
+public class NBTTagEndImpl extends NBTBaseImpl<EndTag> implements NBTTagEnd {
+
+    public static final NBTTagType<NBTTagEnd> TYPE = new NBTTagTypeImpl<>(NBTTagType.Type.TAG_END, nbtBase -> new NBTTagEndImpl());
+
+    private NBTTagEndImpl() {
+        super(EndTag.INSTANCE);
+    }
+
+    NBTTagEndImpl(EndTag nbtBase) {
+        super(EndTag.INSTANCE);
+    }
+
+    public static NBTTagEnd of() {
+        return new NBTTagEndImpl();
+    }
+
+    @Override
+    public NBTTagType<NBTTagEnd> getType() {
+        return TYPE;
+    }
+}

--- a/nmsutil/nmsutil-v1_19_R2/src/main/java/me/wolfyscript/utilities/api/nms/v1_19_R2/nbt/NBTTagFloatImpl.java
+++ b/nmsutil/nmsutil-v1_19_R2/src/main/java/me/wolfyscript/utilities/api/nms/v1_19_R2/nbt/NBTTagFloatImpl.java
@@ -1,0 +1,45 @@
+/*
+ *       WolfyUtilities, APIs and Utilities for Minecraft Spigot plugins
+ *                      Copyright (C) 2021  WolfyScript
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package me.wolfyscript.utilities.api.nms.v1_19_R2.nbt;
+
+import me.wolfyscript.utilities.api.nms.nbt.NBTTagFloat;
+import me.wolfyscript.utilities.api.nms.nbt.NBTTagType;
+import net.minecraft.nbt.FloatTag;
+
+public class NBTTagFloatImpl extends NBTNumberImpl<FloatTag> implements NBTTagFloat {
+
+    public static final NBTTagType<NBTTagFloat> TYPE = new NBTTagTypeImpl<>(NBTTagType.Type.FLOAT, nbtBase -> new NBTTagFloatImpl((FloatTag) nbtBase));
+
+    private NBTTagFloatImpl() {
+        super(FloatTag.valueOf(0f));
+    }
+
+    NBTTagFloatImpl(FloatTag nbtBase) {
+        super(nbtBase);
+    }
+
+    public static NBTTagFloat of(float value) {
+        return new NBTTagFloatImpl(FloatTag.valueOf(value));
+    }
+
+    @Override
+    public NBTTagType<NBTTagFloat> getType() {
+        return TYPE;
+    }
+}

--- a/nmsutil/nmsutil-v1_19_R2/src/main/java/me/wolfyscript/utilities/api/nms/v1_19_R2/nbt/NBTTagIntArrayImpl.java
+++ b/nmsutil/nmsutil-v1_19_R2/src/main/java/me/wolfyscript/utilities/api/nms/v1_19_R2/nbt/NBTTagIntArrayImpl.java
@@ -1,0 +1,41 @@
+/*
+ *       WolfyUtilities, APIs and Utilities for Minecraft Spigot plugins
+ *                      Copyright (C) 2021  WolfyScript
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package me.wolfyscript.utilities.api.nms.v1_19_R2.nbt;
+
+import me.wolfyscript.utilities.api.nms.nbt.NBTTagIntArray;
+import me.wolfyscript.utilities.api.nms.nbt.NBTTagType;
+import net.minecraft.nbt.IntArrayTag;
+
+public class NBTTagIntArrayImpl extends NBTBaseImpl<IntArrayTag> implements NBTTagIntArray {
+
+    public static final NBTTagType<NBTTagIntArray> TYPE = new NBTTagTypeImpl<>(NBTTagType.Type.INT_ARRAY, nbtBase -> new NBTTagIntArrayImpl((IntArrayTag) nbtBase));
+
+    NBTTagIntArrayImpl(IntArrayTag nbtBase) {
+        super(nbtBase);
+    }
+
+    public static NBTTagIntArray of(int[] array) {
+        return new NBTTagIntArrayImpl(new IntArrayTag(array));
+    }
+
+    @Override
+    public NBTTagType<NBTTagIntArray> getType() {
+        return TYPE;
+    }
+}

--- a/nmsutil/nmsutil-v1_19_R2/src/main/java/me/wolfyscript/utilities/api/nms/v1_19_R2/nbt/NBTTagIntImpl.java
+++ b/nmsutil/nmsutil-v1_19_R2/src/main/java/me/wolfyscript/utilities/api/nms/v1_19_R2/nbt/NBTTagIntImpl.java
@@ -1,0 +1,45 @@
+/*
+ *       WolfyUtilities, APIs and Utilities for Minecraft Spigot plugins
+ *                      Copyright (C) 2021  WolfyScript
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package me.wolfyscript.utilities.api.nms.v1_19_R2.nbt;
+
+import me.wolfyscript.utilities.api.nms.nbt.NBTTagInt;
+import me.wolfyscript.utilities.api.nms.nbt.NBTTagType;
+import net.minecraft.nbt.IntTag;
+
+public class NBTTagIntImpl extends NBTNumberImpl<IntTag> implements NBTTagInt {
+
+    public static final NBTTagType<NBTTagInt> TYPE = new NBTTagTypeImpl<>(NBTTagType.Type.INT, nbtBase -> new NBTTagIntImpl((IntTag) nbtBase));
+
+    private NBTTagIntImpl() {
+        super(IntTag.valueOf(0));
+    }
+
+    NBTTagIntImpl(IntTag nbtBase) {
+        super(nbtBase);
+    }
+
+    public static NBTTagInt of(int value) {
+        return new NBTTagIntImpl(IntTag.valueOf(value));
+    }
+
+    @Override
+    public NBTTagType<NBTTagInt> getType() {
+        return TYPE;
+    }
+}

--- a/nmsutil/nmsutil-v1_19_R2/src/main/java/me/wolfyscript/utilities/api/nms/v1_19_R2/nbt/NBTTagListImpl.java
+++ b/nmsutil/nmsutil-v1_19_R2/src/main/java/me/wolfyscript/utilities/api/nms/v1_19_R2/nbt/NBTTagListImpl.java
@@ -1,0 +1,113 @@
+/*
+ *       WolfyUtilities, APIs and Utilities for Minecraft Spigot plugins
+ *                      Copyright (C) 2021  WolfyScript
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package me.wolfyscript.utilities.api.nms.v1_19_R2.nbt;
+
+import me.wolfyscript.utilities.api.nms.nbt.NBTBase;
+import me.wolfyscript.utilities.api.nms.nbt.NBTCompound;
+import me.wolfyscript.utilities.api.nms.nbt.NBTTagList;
+import me.wolfyscript.utilities.api.nms.nbt.NBTTagType;
+import net.minecraft.nbt.ListTag;
+
+public class NBTTagListImpl extends NBTBaseImpl<ListTag> implements NBTTagList {
+
+    public static final NBTTagType<NBTTagList> TYPE = new NBTTagTypeImpl<>(NBTTagType.Type.LIST, nbtBase -> new NBTTagListImpl((ListTag) nbtBase));
+
+    NBTTagListImpl(ListTag nbtBase) {
+        super(nbtBase);
+    }
+
+    public static NBTTagList of() {
+        return new NBTTagListImpl(new ListTag());
+    }
+
+    @Override
+    public NBTTagType<NBTTagList> getType() {
+        return TYPE;
+    }
+
+    @Override
+    public NBTCompound getCompound(int index) {
+        return new NBTTagCompoundImpl(nbt.getCompound(index));
+    }
+
+    @Override
+    public NBTTagList getTagList(int index) {
+        return new NBTTagListImpl(nbt.getList(index));
+    }
+
+    @Override
+    public NBTBase getTag(int index) {
+        return NBTTagTypes.convert(nbt.get(index));
+    }
+
+    @Override
+    public NBTBase remove(int index) {
+        return NBTTagTypes.convert(nbt.remove(index));
+    }
+
+    @Override
+    public short getShort(int index) {
+        return nbt.getShort(index);
+    }
+
+    @Override
+    public int getInt(int index) {
+        return nbt.getInt(index);
+    }
+
+    @Override
+    public int[] getIntArray(int index) {
+        return nbt.getIntArray(index);
+    }
+
+    @Override
+    public double getDouble(int index) {
+        return nbt.getDouble(index);
+    }
+
+    @Override
+    public float getFloat(int index) {
+        return nbt.getFloat(index);
+    }
+
+    @Override
+    public String getString(int index) {
+        return nbt.getString(index);
+    }
+
+    @Override
+    public int size() {
+        return nbt.size();
+    }
+
+    @Override
+    public NBTBase set(int index, NBTBase value) {
+        return NBTTagTypes.convert(nbt.set(index, ((NBTBaseImpl<?>) value).nbt));
+    }
+
+    @Override
+    public void add(int index, NBTBase value) {
+        nbt.add(index, ((NBTBaseImpl<?>) value).nbt);
+    }
+
+    @Override
+    public void clear() {
+        nbt.clear();
+    }
+}

--- a/nmsutil/nmsutil-v1_19_R2/src/main/java/me/wolfyscript/utilities/api/nms/v1_19_R2/nbt/NBTTagLongArrayImpl.java
+++ b/nmsutil/nmsutil-v1_19_R2/src/main/java/me/wolfyscript/utilities/api/nms/v1_19_R2/nbt/NBTTagLongArrayImpl.java
@@ -1,0 +1,41 @@
+/*
+ *       WolfyUtilities, APIs and Utilities for Minecraft Spigot plugins
+ *                      Copyright (C) 2021  WolfyScript
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package me.wolfyscript.utilities.api.nms.v1_19_R2.nbt;
+
+import me.wolfyscript.utilities.api.nms.nbt.NBTTagLongArray;
+import me.wolfyscript.utilities.api.nms.nbt.NBTTagType;
+import net.minecraft.nbt.LongArrayTag;
+
+public class NBTTagLongArrayImpl extends NBTBaseImpl<LongArrayTag> implements NBTTagLongArray {
+
+    public static final NBTTagType<NBTTagLongArray> TYPE = new NBTTagTypeImpl<>(NBTTagType.Type.LONG_ARRAY, nbtBase -> new NBTTagLongArrayImpl((LongArrayTag) nbtBase));
+
+    NBTTagLongArrayImpl(LongArrayTag nbtBase) {
+        super(nbtBase);
+    }
+
+    public static NBTTagLongArray of(long[] array) {
+        return new NBTTagLongArrayImpl(new LongArrayTag(array));
+    }
+
+    @Override
+    public NBTTagType<NBTTagLongArray> getType() {
+        return TYPE;
+    }
+}

--- a/nmsutil/nmsutil-v1_19_R2/src/main/java/me/wolfyscript/utilities/api/nms/v1_19_R2/nbt/NBTTagLongImpl.java
+++ b/nmsutil/nmsutil-v1_19_R2/src/main/java/me/wolfyscript/utilities/api/nms/v1_19_R2/nbt/NBTTagLongImpl.java
@@ -1,0 +1,45 @@
+/*
+ *       WolfyUtilities, APIs and Utilities for Minecraft Spigot plugins
+ *                      Copyright (C) 2021  WolfyScript
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package me.wolfyscript.utilities.api.nms.v1_19_R2.nbt;
+
+import me.wolfyscript.utilities.api.nms.nbt.NBTTagLong;
+import me.wolfyscript.utilities.api.nms.nbt.NBTTagType;
+import net.minecraft.nbt.LongTag;
+
+public class NBTTagLongImpl extends NBTNumberImpl<LongTag> implements NBTTagLong {
+
+    public static final NBTTagType<NBTTagLong> TYPE = new NBTTagTypeImpl<>(NBTTagType.Type.LONG, nbtBase -> new NBTTagLongImpl((LongTag) nbtBase));
+
+    private NBTTagLongImpl() {
+        super(LongTag.valueOf(0));
+    }
+
+    NBTTagLongImpl(LongTag nbtBase) {
+        super(nbtBase);
+    }
+
+    public static NBTTagLong of(long value) {
+        return new NBTTagLongImpl(LongTag.valueOf(value));
+    }
+
+    @Override
+    public NBTTagType<NBTTagLong> getType() {
+        return TYPE;
+    }
+}

--- a/nmsutil/nmsutil-v1_19_R2/src/main/java/me/wolfyscript/utilities/api/nms/v1_19_R2/nbt/NBTTagShortImpl.java
+++ b/nmsutil/nmsutil-v1_19_R2/src/main/java/me/wolfyscript/utilities/api/nms/v1_19_R2/nbt/NBTTagShortImpl.java
@@ -1,0 +1,45 @@
+/*
+ *       WolfyUtilities, APIs and Utilities for Minecraft Spigot plugins
+ *                      Copyright (C) 2021  WolfyScript
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package me.wolfyscript.utilities.api.nms.v1_19_R2.nbt;
+
+import me.wolfyscript.utilities.api.nms.nbt.NBTTagShort;
+import me.wolfyscript.utilities.api.nms.nbt.NBTTagType;
+import net.minecraft.nbt.ShortTag;
+
+public class NBTTagShortImpl extends NBTNumberImpl<ShortTag> implements NBTTagShort {
+
+    public static final NBTTagType<NBTTagShort> TYPE = new NBTTagTypeImpl<>(NBTTagType.Type.SHORT, nbtBase -> new NBTTagShortImpl((ShortTag) nbtBase));
+
+    private NBTTagShortImpl() {
+        super(ShortTag.valueOf((short) 0));
+    }
+
+    NBTTagShortImpl(ShortTag nbtBase) {
+        super(nbtBase);
+    }
+
+    public static NBTTagShort of(short value) {
+        return new NBTTagShortImpl(ShortTag.valueOf(value));
+    }
+
+    @Override
+    public NBTTagType<NBTTagShort> getType() {
+        return TYPE;
+    }
+}

--- a/nmsutil/nmsutil-v1_19_R2/src/main/java/me/wolfyscript/utilities/api/nms/v1_19_R2/nbt/NBTTagStringImpl.java
+++ b/nmsutil/nmsutil-v1_19_R2/src/main/java/me/wolfyscript/utilities/api/nms/v1_19_R2/nbt/NBTTagStringImpl.java
@@ -1,0 +1,51 @@
+/*
+ *       WolfyUtilities, APIs and Utilities for Minecraft Spigot plugins
+ *                      Copyright (C) 2021  WolfyScript
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package me.wolfyscript.utilities.api.nms.v1_19_R2.nbt;
+
+import me.wolfyscript.utilities.api.nms.nbt.NBTTagString;
+import me.wolfyscript.utilities.api.nms.nbt.NBTTagType;
+import net.minecraft.nbt.StringTag;
+
+public class NBTTagStringImpl extends NBTBaseImpl<StringTag> implements NBTTagString {
+
+    public static final NBTTagType<NBTTagString> TYPE = new NBTTagTypeImpl<>(NBTTagType.Type.STRING, nbtBase -> new NBTTagStringImpl((StringTag) nbtBase));
+
+    NBTTagStringImpl(StringTag nbtBase) {
+        super(nbtBase);
+    }
+
+    public static NBTTagString of(String value) {
+        return new NBTTagStringImpl(StringTag.valueOf(value));
+    }
+
+    @Override
+    public NBTTagType<NBTTagString> getType() {
+        return TYPE;
+    }
+
+    @Override
+    public String asString() {
+        return nbt.getAsString();
+    }
+
+    @Override
+    public String toString() {
+        return nbt.toString();
+    }
+}

--- a/nmsutil/nmsutil-v1_19_R2/src/main/java/me/wolfyscript/utilities/api/nms/v1_19_R2/nbt/NBTTagTypeImpl.java
+++ b/nmsutil/nmsutil-v1_19_R2/src/main/java/me/wolfyscript/utilities/api/nms/v1_19_R2/nbt/NBTTagTypeImpl.java
@@ -1,0 +1,49 @@
+/*
+ *       WolfyUtilities, APIs and Utilities for Minecraft Spigot plugins
+ *                      Copyright (C) 2021  WolfyScript
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package me.wolfyscript.utilities.api.nms.v1_19_R2.nbt;
+
+import java.util.function.Function;
+import me.wolfyscript.utilities.api.nms.nbt.NBTBase;
+import me.wolfyscript.utilities.api.nms.nbt.NBTTagType;
+import net.minecraft.nbt.Tag;
+import org.jetbrains.annotations.Nullable;
+
+public class NBTTagTypeImpl<T extends NBTBase> implements NBTTagType<T> {
+
+    protected final Type type;
+    private final Function<Object, T> function;
+
+    public NBTTagTypeImpl(Type type, Function<Object, T> nbtBase) {
+        this.type = type;
+        this.function = nbtBase;
+    }
+
+    public T get(@Nullable Object nbtBase) {
+        if (nbtBase instanceof Tag && type.is(((Tag) nbtBase).getId())) {
+            return function.apply(nbtBase);
+        }
+        return null;
+    }
+
+    @Override
+    public Type getType() {
+        return type;
+    }
+
+}

--- a/nmsutil/nmsutil-v1_19_R2/src/main/java/me/wolfyscript/utilities/api/nms/v1_19_R2/nbt/NBTTagTypes.java
+++ b/nmsutil/nmsutil-v1_19_R2/src/main/java/me/wolfyscript/utilities/api/nms/v1_19_R2/nbt/NBTTagTypes.java
@@ -1,0 +1,50 @@
+/*
+ *       WolfyUtilities, APIs and Utilities for Minecraft Spigot plugins
+ *                      Copyright (C) 2021  WolfyScript
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package me.wolfyscript.utilities.api.nms.v1_19_R2.nbt;
+
+import me.wolfyscript.utilities.api.nms.nbt.NBTBase;
+import me.wolfyscript.utilities.api.nms.nbt.NBTTagType;
+import net.minecraft.nbt.Tag;
+
+public class NBTTagTypes {
+
+    private static final NBTTagType<?>[] types = new NBTTagType<?>[]{
+            NBTTagEndImpl.TYPE,
+            NBTTagByteImpl.TYPE,
+            NBTTagShortImpl.TYPE,
+            NBTTagIntImpl.TYPE,
+            NBTTagLongImpl.TYPE,
+            NBTTagFloatImpl.TYPE,
+            NBTTagDoubleImpl.TYPE,
+            NBTTagByteArrayImpl.TYPE,
+            NBTTagStringImpl.TYPE,
+            NBTTagListImpl.TYPE,
+            NBTTagCompoundImpl.TYPE,
+            NBTTagIntArrayImpl.TYPE,
+            NBTTagLongArrayImpl.TYPE
+    };
+
+    public static NBTTagType<?> of(int typeId) {
+        return typeId >= 0 && typeId < types.length ? types[typeId] : NBTTagType.invalidType(typeId);
+    }
+
+    public static NBTBase convert(Tag base) {
+        return base != null ? NBTTagTypes.of(base.getId()).get(base) : null;
+    }
+}

--- a/nmsutil/nmsutil-v1_19_R2/src/main/java/me/wolfyscript/utilities/api/nms/v1_19_R2/network/MCByteBufImpl.java
+++ b/nmsutil/nmsutil-v1_19_R2/src/main/java/me/wolfyscript/utilities/api/nms/v1_19_R2/network/MCByteBufImpl.java
@@ -1,0 +1,941 @@
+/*
+ *       WolfyUtilities, APIs and Utilities for Minecraft Spigot plugins
+ *                      Copyright (C) 2021  WolfyScript
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package me.wolfyscript.utilities.api.nms.v1_19_R2.network;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.ByteBufAllocator;
+import io.netty.buffer.Unpooled;
+import io.netty.util.ByteProcessor;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.nio.channels.FileChannel;
+import java.nio.channels.GatheringByteChannel;
+import java.nio.channels.ScatteringByteChannel;
+import java.nio.charset.Charset;
+import java.util.Date;
+import java.util.UUID;
+import me.wolfyscript.utilities.api.nms.nbt.NBTCompound;
+import me.wolfyscript.utilities.api.nms.network.MCByteBuf;
+import me.wolfyscript.utilities.api.nms.v1_19_R2.nbt.NBTTagCompoundImpl;
+import me.wolfyscript.utilities.util.NamespacedKey;
+import net.minecraft.network.FriendlyByteBuf;
+import net.minecraft.resources.ResourceLocation;
+import org.bukkit.craftbukkit.v1_19_R2.inventory.CraftItemStack;
+import org.bukkit.inventory.ItemStack;
+import org.jetbrains.annotations.Nullable;
+
+public class MCByteBufImpl implements MCByteBuf {
+
+    private final FriendlyByteBuf byteBuf;
+
+    public MCByteBufImpl() {
+        this.byteBuf = new FriendlyByteBuf(Unpooled.buffer());
+    }
+
+    public MCByteBufImpl(ByteBuf byteBuf) {
+        this.byteBuf = new FriendlyByteBuf(byteBuf);
+    }
+
+    @Override
+    public MCByteBuf writeByteArray(byte[] byteArray) {
+        this.byteBuf.writeByteArray(byteArray);
+        return this;
+    }
+
+    @Override
+    public byte[] readByteArray() {
+        return this.byteBuf.readByteArray();
+    }
+
+    @Override
+    public byte[] readByteArray(int i) {
+        return this.byteBuf.readByteArray(i);
+    }
+
+    @Override
+    public MCByteBuf writeVarIntArray(int[] intArray) {
+        this.byteBuf.writeVarIntArray(intArray);
+        return this;
+    }
+
+    @Override
+    public int[] readVarIntArray() {
+        return this.byteBuf.readVarIntArray();
+    }
+
+    @Override
+    public int[] readVarIntArray(int i) {
+        return this.byteBuf.readVarIntArray(i);
+    }
+
+    @Override
+    public MCByteBuf writeLongArray(long[] longArray) {
+        this.byteBuf.writeLongArray(longArray);
+        return this;
+    }
+
+    @Override
+    public <T extends Enum<T>> T readEnum(Class<T> enumType) {
+        return this.byteBuf.readEnum(enumType);
+    }
+
+    @Override
+    public MCByteBuf writeEnum(Enum<?> anEnum) {
+        this.byteBuf.writeEnum(anEnum);
+        return this;
+    }
+
+    @Override
+    public int readVarInt() {
+        return this.byteBuf.readVarInt();
+    }
+
+    @Override
+    public long readVarLong() {
+        return this.byteBuf.readVarLong();
+    }
+
+    @Override
+    public MCByteBuf writeUUID(UUID uuid) {
+        this.byteBuf.writeUUID(uuid);
+        return this;
+    }
+
+    @Override
+    public UUID readUUID() {
+        return this.byteBuf.readUUID();
+    }
+
+    @Override
+    public MCByteBuf writeVarInt(int i) {
+        this.byteBuf.writeVarInt(i);
+        return this;
+    }
+
+    @Override
+    public MCByteBuf writeVarLong(long i) {
+        this.byteBuf.writeVarLong(i);
+        return this;
+    }
+
+    @Override
+    public MCByteBuf writeNBT(@Nullable NBTCompound nbtTagCompound) {
+        if (nbtTagCompound instanceof NBTTagCompoundImpl impl) {
+            this.byteBuf.writeNbt(impl.getNbt());
+        }
+        return this;
+    }
+
+    @Nullable
+    @Override
+    public NBTCompound readNBT() {
+        return NBTTagCompoundImpl.TYPE.get(this.byteBuf.readNbt());
+    }
+
+    @Nullable
+    @Override
+    public NBTCompound readAnySizeNBT() {
+        return NBTTagCompoundImpl.TYPE.get(this.byteBuf.readAnySizeNbt());
+    }
+
+    @Override
+    public MCByteBuf writeItemStack(ItemStack itemstack) {
+        this.byteBuf.writeItem(CraftItemStack.asNMSCopy(itemstack));
+        return this;
+    }
+
+    @Override
+    public ItemStack readItemStack() {
+        return CraftItemStack.asBukkitCopy(this.byteBuf.readItem());
+    }
+
+    @Override
+    public String readUtf(int i) {
+        return this.byteBuf.readUtf(i);
+    }
+
+    @Override
+    public MCByteBuf writeUtf(String s) {
+        this.byteBuf.writeUtf(s);
+        return this;
+    }
+
+    @Override
+    public MCByteBuf writeUtf(String s, int i) {
+        this.byteBuf.writeUtf(s, i);
+        return this;
+    }
+
+    @Override
+    public NamespacedKey readNamespacedKey() {
+        return NamespacedKey.of(this.byteBuf.readResourceLocation().toString());
+    }
+
+    @Override
+    public MCByteBuf writeNamespacedKey(NamespacedKey namespacedKey) {
+        this.byteBuf.writeResourceLocation(ResourceLocation.tryParse(namespacedKey.toString()));
+        return this;
+    }
+
+    @Override
+    public Date readDate() {
+        return this.byteBuf.readDate();
+    }
+
+    @Override
+    public MCByteBuf writeDate(Date date) {
+        this.byteBuf.writeDate(date);
+        return this;
+    }
+
+    public int capacity() {
+        return this.byteBuf.capacity();
+    }
+
+    public ByteBuf capacity(int i) {
+        return this.byteBuf.capacity(i);
+    }
+
+    public int maxCapacity() {
+        return this.byteBuf.maxCapacity();
+    }
+
+    public ByteBufAllocator alloc() {
+        return this.byteBuf.alloc();
+    }
+
+    public ByteOrder order() {
+        return this.byteBuf.order();
+    }
+
+    public ByteBuf order(ByteOrder byteorder) {
+        return this.byteBuf.order(byteorder);
+    }
+
+    public ByteBuf unwrap() {
+        return this.byteBuf.unwrap();
+    }
+
+    public boolean isDirect() {
+        return this.byteBuf.isDirect();
+    }
+
+    public boolean isReadOnly() {
+        return this.byteBuf.isReadOnly();
+    }
+
+    public ByteBuf asReadOnly() {
+        return this.byteBuf.asReadOnly();
+    }
+
+    public int readerIndex() {
+        return this.byteBuf.readerIndex();
+    }
+
+    public ByteBuf readerIndex(int i) {
+        return this.byteBuf.readerIndex(i);
+    }
+
+    public int writerIndex() {
+        return this.byteBuf.writerIndex();
+    }
+
+    public ByteBuf writerIndex(int i) {
+        return this.byteBuf.writerIndex(i);
+    }
+
+    public ByteBuf setIndex(int i, int j) {
+        return this.byteBuf.setIndex(i, j);
+    }
+
+    public int readableBytes() {
+        return this.byteBuf.readableBytes();
+    }
+
+    public int writableBytes() {
+        return this.byteBuf.writableBytes();
+    }
+
+    public int maxWritableBytes() {
+        return this.byteBuf.maxWritableBytes();
+    }
+
+    public boolean isReadable() {
+        return this.byteBuf.isReadable();
+    }
+
+    public boolean isReadable(int i) {
+        return this.byteBuf.isReadable(i);
+    }
+
+    public boolean isWritable() {
+        return this.byteBuf.isWritable();
+    }
+
+    public boolean isWritable(int i) {
+        return this.byteBuf.isWritable(i);
+    }
+
+    public ByteBuf clear() {
+        return this.byteBuf.clear();
+    }
+
+    public ByteBuf markReaderIndex() {
+        return this.byteBuf.markReaderIndex();
+    }
+
+    public ByteBuf resetReaderIndex() {
+        return this.byteBuf.resetReaderIndex();
+    }
+
+    public ByteBuf markWriterIndex() {
+        return this.byteBuf.markWriterIndex();
+    }
+
+    public ByteBuf resetWriterIndex() {
+        return this.byteBuf.resetWriterIndex();
+    }
+
+    public ByteBuf discardReadBytes() {
+        return this.byteBuf.discardReadBytes();
+    }
+
+    public ByteBuf discardSomeReadBytes() {
+        return this.byteBuf.discardSomeReadBytes();
+    }
+
+    public ByteBuf ensureWritable(int i) {
+        return this.byteBuf.ensureWritable(i);
+    }
+
+    public int ensureWritable(int i, boolean flag) {
+        return this.byteBuf.ensureWritable(i, flag);
+    }
+
+    public boolean getBoolean(int i) {
+        return this.byteBuf.getBoolean(i);
+    }
+
+    public byte getByte(int i) {
+        return this.byteBuf.getByte(i);
+    }
+
+    public short getUnsignedByte(int i) {
+        return this.byteBuf.getUnsignedByte(i);
+    }
+
+    public short getShort(int i) {
+        return this.byteBuf.getShort(i);
+    }
+
+    public short getShortLE(int i) {
+        return this.byteBuf.getShortLE(i);
+    }
+
+    public int getUnsignedShort(int i) {
+        return this.byteBuf.getUnsignedShort(i);
+    }
+
+    public int getUnsignedShortLE(int i) {
+        return this.byteBuf.getUnsignedShortLE(i);
+    }
+
+    public int getMedium(int i) {
+        return this.byteBuf.getMedium(i);
+    }
+
+    public int getMediumLE(int i) {
+        return this.byteBuf.getMediumLE(i);
+    }
+
+    public int getUnsignedMedium(int i) {
+        return this.byteBuf.getUnsignedMedium(i);
+    }
+
+    public int getUnsignedMediumLE(int i) {
+        return this.byteBuf.getUnsignedMediumLE(i);
+    }
+
+    public int getInt(int i) {
+        return this.byteBuf.getInt(i);
+    }
+
+    public int getIntLE(int i) {
+        return this.byteBuf.getIntLE(i);
+    }
+
+    public long getUnsignedInt(int i) {
+        return this.byteBuf.getUnsignedInt(i);
+    }
+
+    public long getUnsignedIntLE(int i) {
+        return this.byteBuf.getUnsignedIntLE(i);
+    }
+
+    public long getLong(int i) {
+        return this.byteBuf.getLong(i);
+    }
+
+    public long getLongLE(int i) {
+        return this.byteBuf.getLongLE(i);
+    }
+
+    public char getChar(int i) {
+        return this.byteBuf.getChar(i);
+    }
+
+    public float getFloat(int i) {
+        return this.byteBuf.getFloat(i);
+    }
+
+    public double getDouble(int i) {
+        return this.byteBuf.getDouble(i);
+    }
+
+    public ByteBuf getBytes(int i, ByteBuf bytebuf) {
+        return this.byteBuf.getBytes(i, bytebuf);
+    }
+
+    public ByteBuf getBytes(int i, ByteBuf bytebuf, int j) {
+        return this.byteBuf.getBytes(i, bytebuf, j);
+    }
+
+    public ByteBuf getBytes(int i, ByteBuf bytebuf, int j, int k) {
+        return this.byteBuf.getBytes(i, bytebuf, j, k);
+    }
+
+    public ByteBuf getBytes(int i, byte[] abyte) {
+        return this.byteBuf.getBytes(i, abyte);
+    }
+
+    public ByteBuf getBytes(int i, byte[] abyte, int j, int k) {
+        return this.byteBuf.getBytes(i, abyte, j, k);
+    }
+
+    public ByteBuf getBytes(int i, ByteBuffer bytebuffer) {
+        return this.byteBuf.getBytes(i, bytebuffer);
+    }
+
+    public ByteBuf getBytes(int i, OutputStream outputstream, int j) throws IOException {
+        return this.byteBuf.getBytes(i, outputstream, j);
+    }
+
+    public int getBytes(int i, GatheringByteChannel gatheringbytechannel, int j) throws IOException {
+        return this.byteBuf.getBytes(i, gatheringbytechannel, j);
+    }
+
+    public int getBytes(int i, FileChannel filechannel, long j, int k) throws IOException {
+        return this.byteBuf.getBytes(i, filechannel, j, k);
+    }
+
+    public CharSequence getCharSequence(int i, int j, Charset charset) {
+        return this.byteBuf.getCharSequence(i, j, charset);
+    }
+
+    public ByteBuf setBoolean(int i, boolean flag) {
+        return this.byteBuf.setBoolean(i, flag);
+    }
+
+    public ByteBuf setByte(int i, int j) {
+        return this.byteBuf.setByte(i, j);
+    }
+
+    public ByteBuf setShort(int i, int j) {
+        return this.byteBuf.setShort(i, j);
+    }
+
+    public ByteBuf setShortLE(int i, int j) {
+        return this.byteBuf.setShortLE(i, j);
+    }
+
+    public ByteBuf setMedium(int i, int j) {
+        return this.byteBuf.setMedium(i, j);
+    }
+
+    public ByteBuf setMediumLE(int i, int j) {
+        return this.byteBuf.setMediumLE(i, j);
+    }
+
+    public ByteBuf setInt(int i, int j) {
+        return this.byteBuf.setInt(i, j);
+    }
+
+    public ByteBuf setIntLE(int i, int j) {
+        return this.byteBuf.setIntLE(i, j);
+    }
+
+    public ByteBuf setLong(int i, long j) {
+        return this.byteBuf.setLong(i, j);
+    }
+
+    public ByteBuf setLongLE(int i, long j) {
+        return this.byteBuf.setLongLE(i, j);
+    }
+
+    public ByteBuf setChar(int i, int j) {
+        return this.byteBuf.setChar(i, j);
+    }
+
+    public ByteBuf setFloat(int i, float f) {
+        return this.byteBuf.setFloat(i, f);
+    }
+
+    public ByteBuf setDouble(int i, double d0) {
+        return this.byteBuf.setDouble(i, d0);
+    }
+
+    public ByteBuf setBytes(int i, ByteBuf bytebuf) {
+        return this.byteBuf.setBytes(i, bytebuf);
+    }
+
+    public ByteBuf setBytes(int i, ByteBuf bytebuf, int j) {
+        return this.byteBuf.setBytes(i, bytebuf, j);
+    }
+
+    public ByteBuf setBytes(int i, ByteBuf bytebuf, int j, int k) {
+        return this.byteBuf.setBytes(i, bytebuf, j, k);
+    }
+
+    public ByteBuf setBytes(int i, byte[] abyte) {
+        return this.byteBuf.setBytes(i, abyte);
+    }
+
+    public ByteBuf setBytes(int i, byte[] abyte, int j, int k) {
+        return this.byteBuf.setBytes(i, abyte, j, k);
+    }
+
+    public ByteBuf setBytes(int i, ByteBuffer bytebuffer) {
+        return this.byteBuf.setBytes(i, bytebuffer);
+    }
+
+    public int setBytes(int i, InputStream inputstream, int j) throws IOException {
+        return this.byteBuf.setBytes(i, inputstream, j);
+    }
+
+    public int setBytes(int i, ScatteringByteChannel scatteringbytechannel, int j) throws IOException {
+        return this.byteBuf.setBytes(i, scatteringbytechannel, j);
+    }
+
+    public int setBytes(int i, FileChannel filechannel, long j, int k) throws IOException {
+        return this.byteBuf.setBytes(i, filechannel, j, k);
+    }
+
+    public ByteBuf setZero(int i, int j) {
+        return this.byteBuf.setZero(i, j);
+    }
+
+    public int setCharSequence(int i, CharSequence charsequence, Charset charset) {
+        return this.byteBuf.setCharSequence(i, charsequence, charset);
+    }
+
+    public boolean readBoolean() {
+        return this.byteBuf.readBoolean();
+    }
+
+    public byte readByte() {
+        return this.byteBuf.readByte();
+    }
+
+    public short readUnsignedByte() {
+        return this.byteBuf.readUnsignedByte();
+    }
+
+    public short readShort() {
+        return this.byteBuf.readShort();
+    }
+
+    public short readShortLE() {
+        return this.byteBuf.readShortLE();
+    }
+
+    public int readUnsignedShort() {
+        return this.byteBuf.readUnsignedShort();
+    }
+
+    public int readUnsignedShortLE() {
+        return this.byteBuf.readUnsignedShortLE();
+    }
+
+    public int readMedium() {
+        return this.byteBuf.readMedium();
+    }
+
+    public int readMediumLE() {
+        return this.byteBuf.readMediumLE();
+    }
+
+    public int readUnsignedMedium() {
+        return this.byteBuf.readUnsignedMedium();
+    }
+
+    public int readUnsignedMediumLE() {
+        return this.byteBuf.readUnsignedMediumLE();
+    }
+
+    public int readInt() {
+        return this.byteBuf.readInt();
+    }
+
+    public int readIntLE() {
+        return this.byteBuf.readIntLE();
+    }
+
+    public long readUnsignedInt() {
+        return this.byteBuf.readUnsignedInt();
+    }
+
+    public long readUnsignedIntLE() {
+        return this.byteBuf.readUnsignedIntLE();
+    }
+
+    public long readLong() {
+        return this.byteBuf.readLong();
+    }
+
+    public long readLongLE() {
+        return this.byteBuf.readLongLE();
+    }
+
+    public char readChar() {
+        return this.byteBuf.readChar();
+    }
+
+    public float readFloat() {
+        return this.byteBuf.readFloat();
+    }
+
+    public double readDouble() {
+        return this.byteBuf.readDouble();
+    }
+
+    public ByteBuf readSlice(int i) {
+        return this.byteBuf.readSlice(i);
+    }
+
+    public ByteBuf readRetainedSlice(int i) {
+        return this.byteBuf.readRetainedSlice(i);
+    }
+
+    public ByteBuf readBytes(int i) {
+        return this.byteBuf.readBytes(i);
+    }
+
+    public ByteBuf readBytes(ByteBuf bytebuf) {
+        return this.byteBuf.readBytes(bytebuf);
+    }
+
+    public ByteBuf readBytes(ByteBuf bytebuf, int i) {
+        return this.byteBuf.readBytes(bytebuf, i);
+    }
+
+    public ByteBuf readBytes(ByteBuf bytebuf, int i, int j) {
+        return this.byteBuf.readBytes(bytebuf, i, j);
+    }
+
+    public ByteBuf readBytes(byte[] abyte) {
+        return this.byteBuf.readBytes(abyte);
+    }
+
+    public ByteBuf readBytes(byte[] abyte, int i, int j) {
+        return this.byteBuf.readBytes(abyte, i, j);
+    }
+
+    public ByteBuf readBytes(ByteBuffer bytebuffer) {
+        return this.byteBuf.readBytes(bytebuffer);
+    }
+
+    public ByteBuf readBytes(OutputStream outputstream, int i) throws IOException {
+        return this.byteBuf.readBytes(outputstream, i);
+    }
+
+    public int readBytes(GatheringByteChannel gatheringbytechannel, int i) throws IOException {
+        return this.byteBuf.readBytes(gatheringbytechannel, i);
+    }
+
+    public int readBytes(FileChannel filechannel, long i, int j) throws IOException {
+        return this.byteBuf.readBytes(filechannel, i, j);
+    }
+
+    public CharSequence readCharSequence(int i, Charset charset) {
+        return this.byteBuf.readCharSequence(i, charset);
+    }
+
+    public ByteBuf skipBytes(int i) {
+        return this.byteBuf.skipBytes(i);
+    }
+
+    public ByteBuf writeBoolean(boolean flag) {
+        return this.byteBuf.writeBoolean(flag);
+    }
+
+    public ByteBuf writeByte(int i) {
+        return this.byteBuf.writeByte(i);
+    }
+
+    public ByteBuf writeShort(int i) {
+        return this.byteBuf.writeShort(i);
+    }
+
+    public ByteBuf writeShortLE(int i) {
+        return this.byteBuf.writeShortLE(i);
+    }
+
+    public ByteBuf writeMedium(int i) {
+        return this.byteBuf.writeMedium(i);
+    }
+
+    public ByteBuf writeMediumLE(int i) {
+        return this.byteBuf.writeMediumLE(i);
+    }
+
+    public ByteBuf writeInt(int i) {
+        return this.byteBuf.writeInt(i);
+    }
+
+    public ByteBuf writeIntLE(int i) {
+        return this.byteBuf.writeIntLE(i);
+    }
+
+    public ByteBuf writeLong(long i) {
+        return this.byteBuf.writeLong(i);
+    }
+
+    public ByteBuf writeLongLE(long i) {
+        return this.byteBuf.writeLongLE(i);
+    }
+
+    public ByteBuf writeChar(int i) {
+        return this.byteBuf.writeChar(i);
+    }
+
+    public ByteBuf writeFloat(float f) {
+        return this.byteBuf.writeFloat(f);
+    }
+
+    public ByteBuf writeDouble(double d0) {
+        return this.byteBuf.writeDouble(d0);
+    }
+
+    public ByteBuf writeBytes(ByteBuf bytebuf) {
+        return this.byteBuf.writeBytes(bytebuf);
+    }
+
+    public ByteBuf writeBytes(ByteBuf bytebuf, int i) {
+        return this.byteBuf.writeBytes(bytebuf, i);
+    }
+
+    public ByteBuf writeBytes(ByteBuf bytebuf, int i, int j) {
+        return this.byteBuf.writeBytes(bytebuf, i, j);
+    }
+
+    public ByteBuf writeBytes(byte[] abyte) {
+        return this.byteBuf.writeBytes(abyte);
+    }
+
+    public ByteBuf writeBytes(byte[] abyte, int i, int j) {
+        return this.byteBuf.writeBytes(abyte, i, j);
+    }
+
+    public ByteBuf writeBytes(ByteBuffer bytebuffer) {
+        return this.byteBuf.writeBytes(bytebuffer);
+    }
+
+    public int writeBytes(InputStream inputstream, int i) throws IOException {
+        return this.byteBuf.writeBytes(inputstream, i);
+    }
+
+    public int writeBytes(ScatteringByteChannel scatteringbytechannel, int i) throws IOException {
+        return this.byteBuf.writeBytes(scatteringbytechannel, i);
+    }
+
+    public int writeBytes(FileChannel filechannel, long i, int j) throws IOException {
+        return this.byteBuf.writeBytes(filechannel, i, j);
+    }
+
+    public ByteBuf writeZero(int i) {
+        return this.byteBuf.writeZero(i);
+    }
+
+    public int writeCharSequence(CharSequence charsequence, Charset charset) {
+        return this.byteBuf.writeCharSequence(charsequence, charset);
+    }
+
+    public int indexOf(int i, int j, byte b0) {
+        return this.byteBuf.indexOf(i, j, b0);
+    }
+
+    public int bytesBefore(byte b0) {
+        return this.byteBuf.bytesBefore(b0);
+    }
+
+    public int bytesBefore(int i, byte b0) {
+        return this.byteBuf.bytesBefore(i, b0);
+    }
+
+    public int bytesBefore(int i, int j, byte b0) {
+        return this.byteBuf.bytesBefore(i, j, b0);
+    }
+
+    public int forEachByte(ByteProcessor byteprocessor) {
+        return this.byteBuf.forEachByte(byteprocessor);
+    }
+
+    public int forEachByte(int i, int j, ByteProcessor byteprocessor) {
+        return this.byteBuf.forEachByte(i, j, byteprocessor);
+    }
+
+    public int forEachByteDesc(ByteProcessor byteprocessor) {
+        return this.byteBuf.forEachByteDesc(byteprocessor);
+    }
+
+    public int forEachByteDesc(int i, int j, ByteProcessor byteprocessor) {
+        return this.byteBuf.forEachByteDesc(i, j, byteprocessor);
+    }
+
+    public ByteBuf copy() {
+        return this.byteBuf.copy();
+    }
+
+    public ByteBuf copy(int i, int j) {
+        return this.byteBuf.copy(i, j);
+    }
+
+    public ByteBuf slice() {
+        return this.byteBuf.slice();
+    }
+
+    public ByteBuf slice(int i, int j) {
+        return this.byteBuf.slice(i, j);
+    }
+
+    public ByteBuf retainedSlice() {
+        return this.byteBuf.retainedSlice();
+    }
+
+    public ByteBuf retainedSlice(int i, int j) {
+        return this.byteBuf.retainedSlice(i, j);
+    }
+
+    public ByteBuf duplicate() {
+        return this.byteBuf.duplicate();
+    }
+
+    public ByteBuf retainedDuplicate() {
+        return this.byteBuf.retainedDuplicate();
+    }
+
+    public int nioBufferCount() {
+        return this.byteBuf.nioBufferCount();
+    }
+
+    public ByteBuffer nioBuffer() {
+        return this.byteBuf.nioBuffer();
+    }
+
+    public ByteBuffer nioBuffer(int i, int j) {
+        return this.byteBuf.nioBuffer(i, j);
+    }
+
+    public ByteBuffer internalNioBuffer(int i, int j) {
+        return this.byteBuf.internalNioBuffer(i, j);
+    }
+
+    public ByteBuffer[] nioBuffers() {
+        return this.byteBuf.nioBuffers();
+    }
+
+    public ByteBuffer[] nioBuffers(int i, int j) {
+        return this.byteBuf.nioBuffers(i, j);
+    }
+
+    public boolean hasArray() {
+        return this.byteBuf.hasArray();
+    }
+
+    public byte[] array() {
+        return this.byteBuf.array();
+    }
+
+    public int arrayOffset() {
+        return this.byteBuf.arrayOffset();
+    }
+
+    public boolean hasMemoryAddress() {
+        return this.byteBuf.hasMemoryAddress();
+    }
+
+    public long memoryAddress() {
+        return this.byteBuf.memoryAddress();
+    }
+
+    public String toString(Charset charset) {
+        return this.byteBuf.toString(charset);
+    }
+
+    public String toString(int i, int j, Charset charset) {
+        return this.byteBuf.toString(i, j, charset);
+    }
+
+    public String toString() {
+        return this.byteBuf.toString();
+    }
+
+    public int hashCode() {
+        return this.byteBuf.hashCode();
+    }
+
+    public boolean equals(Object object) {
+        return this.byteBuf.equals(object);
+    }
+
+    public int compareTo(ByteBuf bytebuf) {
+        return this.byteBuf.compareTo(bytebuf);
+    }
+
+    public ByteBuf retain(int i) {
+        return this.byteBuf.retain(i);
+    }
+
+    public ByteBuf retain() {
+        return this.byteBuf.retain();
+    }
+
+    public ByteBuf touch() {
+        return this.byteBuf.touch();
+    }
+
+    public ByteBuf touch(Object object) {
+        return this.byteBuf.touch(object);
+    }
+
+    public int refCnt() {
+        return this.byteBuf.refCnt();
+    }
+
+    public boolean release() {
+        return this.byteBuf.release();
+    }
+
+    public boolean release(int i) {
+        return this.byteBuf.release(i);
+    }
+}

--- a/nmsutil/pom.xml
+++ b/nmsutil/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <artifactId>wolfyutils-parent</artifactId>
         <groupId>com.wolfyscript.wolfyutils.spigot</groupId>
-        <version>4.16.9.3</version>
+        <version>4.16.9.4-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <packaging>pom</packaging>
@@ -40,6 +40,7 @@
         <module>nmsutil-v1_18_R1_P1</module>
         <module>nmsutil-v1_18_R2</module>
         <module>nmsutil-v1_19_R1</module>
+        <module>nmsutil-v1_19_R2</module>
         <module>nmsutil-artifact</module>
     </modules>
 

--- a/plugin-compatibility/plugin-compatibility-artifact/pom.xml
+++ b/plugin-compatibility/plugin-compatibility-artifact/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <artifactId>plugin-compatibility</artifactId>
         <groupId>com.wolfyscript.wolfyutils.spigot</groupId>
-        <version>4.16.9.3</version>
+        <version>4.16.9.4-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/plugin-compatibility/pom.xml
+++ b/plugin-compatibility/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>wolfyutils-parent</artifactId>
         <groupId>com.wolfyscript.wolfyutils.spigot</groupId>
-        <version>4.16.9.3</version>
+        <version>4.16.9.4-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <packaging>pom</packaging>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.wolfyscript.wolfyutils.spigot</groupId>
     <artifactId>wolfyutils-parent</artifactId>
-    <version>4.16.9.3</version>
+    <version>4.16.9.4-SNAPSHOT</version>
     <packaging>pom</packaging>
     <name>WolfyUtils-Spigot</name>
 

--- a/wolfyutils-spigot/pom.xml
+++ b/wolfyutils-spigot/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <artifactId>wolfyutils-parent</artifactId>
         <groupId>com.wolfyscript.wolfyutils.spigot</groupId>
-        <version>4.16.9.3</version>
+        <version>4.16.9.4-SNAPSHOT</version>
     </parent>
 
     <build>


### PR DESCRIPTION
Minecraft 1.19.3 broke quite a few things regarding the creative menu tabs and recipes.

By the looks of it the creative menu tab information of items is now client-side only, so there is no way right now to get that information (without painstakingly making my own categories...).

Recipes must be provided with the Recipe Book Category and are put into the 'misc' category by default.

These changes also massively affect CustomCrafting:
* The filter methods in the plugins recipe book will no longer work, because they rely on the creative menu tabs.
* There is no option to change the vanilla recipe book category, yet so all custom recipes will be put into the 'misc' category.
  * Even in the future it'll require you to specify the category per recipe, so that might be a lot of work.