### PR TITLE
Remove Invalid CustomPlayerData when fetching it

### DIFF
--- a/core/src/main/java/com/wolfyscript/utilities/bukkit/persistent/player/PlayerStorage.java
+++ b/core/src/main/java/com/wolfyscript/utilities/bukkit/persistent/player/PlayerStorage.java
@@ -120,7 +120,7 @@ public class PlayerStorage {
                 org.bukkit.NamespacedKey key = dataID.bukkit();
                 if (dataContainer.has(key, PersistentDataType.STRING)) {
                     String jsonData = dataContainer.get(key, PersistentDataType.STRING);
-                    if (jsonData != null) {
+                    if (jsonData != null && !jsonData.equals("null") && !jsonData.isBlank()) {
                         try {
                             return objectMapper.reader(new InjectableValues.Std()
                                             .addValue(WolfyCoreBukkit.class, core)
@@ -129,7 +129,10 @@ public class PlayerStorage {
                                     .forType(CustomPlayerData.class)
                                     .readValue(jsonData);
                         } catch (JsonProcessingException e) {
-                            e.printStackTrace();
+                            core.getLogger().warning("Unable to load custom data from '" + jsonData + "'! Removing it now to prevent further issues!");
+                            // Directly modify the container instead of calling removeData() as the unload method will never be called anyway.
+                            dataContainer.remove(key);
+                            container.set(DATA_KEY, PersistentDataType.TAG_CONTAINER, dataContainer);
                         }
                     }
                 }


### PR DESCRIPTION
When the CustomPlayerData cannot be loaded when requested, it prints a warning and removes the faulty data to prevent the error from occurring again.