### PR TITLE
Elite Crafting Table Configuration Issues

### DIFF
--- a/core/src/main/java/me/wolfyscript/utilities/api/inventory/custom_items/CustomItem.java
+++ b/core/src/main/java/me/wolfyscript/utilities/api/inventory/custom_items/CustomItem.java
@@ -268,6 +268,10 @@ public class CustomItem extends AbstractItemBuilder<CustomItem> implements Keyed
         for (Map.Entry<NamespacedKey, CustomData> entry : customItem.customDataMap.entrySet()) {
             this.customDataMap.put(entry.getKey(), entry.getValue().clone());
         }
+        this.indexedData.clear();
+        for (Map.Entry<NamespacedKey, CustomItemData> entry : customItem.indexedData.entrySet()) {
+            this.indexedData.put(entry.getKey(), entry.getValue().copy());
+        }
         this.equipmentSlots = new ArrayList<>(customItem.equipmentSlots);
         this.particleContent = customItem.particleContent;
         this.blockPlacement = customItem.blockPlacement;

--- a/core/src/main/java/me/wolfyscript/utilities/api/inventory/gui/button/buttons/MultipleChoiceButton.java
+++ b/core/src/main/java/me/wolfyscript/utilities/api/inventory/gui/button/buttons/MultipleChoiceButton.java
@@ -128,8 +128,12 @@ public class MultipleChoiceButton<C extends CustomCache> extends Button<C> {
     @Override
     public void preRender(GuiHandler<C> guiHandler, Player player, GUIInventory<C> inventory, ItemStack itemStack, int slot, boolean help) {
         int setting = stateFunction.run(guiHandler.getCustomCache(), guiHandler, player, inventory, slot);
-        if (states != null && states.size() > setting && states.get(setting).getPrepareRender() != null) {
-            states.get(setting).getPrepareRender().prepare(guiHandler.getCustomCache(), guiHandler, player, inventory, itemStack, slot, help);
+        if (states != null && states.size() > setting) {
+            setState(guiHandler, setting);
+
+            if (states.get(setting).getPrepareRender() != null) {
+                states.get(setting).getPrepareRender().prepare(guiHandler.getCustomCache(), guiHandler, player, inventory, itemStack, slot, help);
+            }
         }
     }
 


### PR DESCRIPTION
These fixes primarily address issues that were causing the elite crafting table settings to not load correctly on custom items in the CustomCrafting editor GUI but would effect other areas. One of these that I noted was the `vanillaBook` / `autoDiscover` multi choice configuration button.

1. The initial issue of `indexedData` not being copied in clone operations was causing all elite crafting table settings to not load in the CustomCrafting item editor GUI as these are now stored under the `data` field. The behaviour was somewhat odd as it was falling back to the old `customDataMap` which the GUI no longer controls.
2. The `gridSize` multiple choice button was then always defaulting to the 3x3 option. I noted that `preRender` which actually runs the `stateFunction` was getting the right state setting but then never doing anything with it which caused all the following functions ( `render`, `execute`, etc ) to always use the default of zero. Calling `setState` for valid states in `preRender` seemed to fix this.