### PR TITLE
Fixed MythicMobs5Ref (MM v5) not being initiated properly

### DIFF
--- a/plugin-compatibility/plugin-compatibility-artifact/src/main/java/me/wolfyscript/utilities/compatibility/plugins/mythicmobs/AbstractMythicMobsRef.java
+++ b/plugin-compatibility/plugin-compatibility-artifact/src/main/java/me/wolfyscript/utilities/compatibility/plugins/mythicmobs/AbstractMythicMobsRef.java
@@ -70,7 +70,7 @@ public abstract class AbstractMythicMobsRef extends APIReference implements Myth
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
         if (!super.equals(o)) return false;
-        MythicMobsRefImpl that = (MythicMobsRefImpl) o;
+        AbstractMythicMobsRef that = (AbstractMythicMobsRef) o;
         return Objects.equals(itemName, that.itemName);
     }
 


### PR DESCRIPTION
When using MythicMobs v5 the according reference implementation broke and couldn't load properly.