### PR TITLE
ExecutableBlocks Item Reference Implementation

### DIFF
--- a/core/src/main/java/me/wolfyscript/utilities/api/inventory/custom_items/references/APIReference.java
+++ b/core/src/main/java/me/wolfyscript/utilities/api/inventory/custom_items/references/APIReference.java
@@ -211,6 +211,11 @@ public abstract class APIReference {
             this.pluginName = pluginName;
         }
 
+        protected PluginParser(String pluginName, String id, int priority, String... aliases) {
+            super(id, priority, aliases);
+            this.pluginName = pluginName;
+        }
+
         /**
          * Can be used to initialize some values or API.
          * It is run when the parser is registered and the plugin that this parser requires is available.

--- a/core/src/main/java/me/wolfyscript/utilities/compatibility/plugins/ExecutableBlocksIntegration.java
+++ b/core/src/main/java/me/wolfyscript/utilities/compatibility/plugins/ExecutableBlocksIntegration.java
@@ -1,0 +1,36 @@
+package me.wolfyscript.utilities.compatibility.plugins;
+
+import java.util.List;
+import java.util.Locale;
+import java.util.Optional;
+import org.bukkit.NamespacedKey;
+import org.bukkit.inventory.ItemStack;
+
+public interface ExecutableBlocksIntegration {
+
+    String PLUGIN_NAME = "ExecutableBlocks";
+    NamespacedKey BLOCK_ID = new NamespacedKey(PLUGIN_NAME.toLowerCase(Locale.ROOT), "eb-id");
+
+    /**
+     * Verify if id is a valid ExecutableBlock ID
+     *
+     * @param id The ID to verify
+     * @return true if it is a valid ID, false otherwise
+     **/
+    boolean isValidID(String id);
+
+    /**
+     * Get all ExecutableBlock Ids
+     *
+     * @return All ExecutableBlock ids
+     **/
+    List<String> getExecutableBlockIdsList();
+
+    /**
+     * Gets the ExecutableBlock id that belongs to the specified ItemStack.
+     *
+     * @param stack The ItemStack that belongs to an ExecutableBlock
+     * @return The id of the ExecutableBlock or an empty Optional.
+     */
+    Optional<String> getExecutableBlock(ItemStack stack);
+}

--- a/plugin-compatibility/plugin-compatibility-artifact/src/main/java/me/wolfyscript/utilities/compatibility/plugins/executableblocks/ExecutableBlocksImpl.java
+++ b/plugin-compatibility/plugin-compatibility-artifact/src/main/java/me/wolfyscript/utilities/compatibility/plugins/executableblocks/ExecutableBlocksImpl.java
@@ -20,11 +20,9 @@ public class ExecutableBlocksImpl extends PluginIntegrationAbstract implements E
     /**
      * The main constructor that is called whenever the integration is created.<br>
      *  @param core The WolfyUtilCore.
-     *
-     * @param pluginName The name of the associated plugin.
      */
-    protected ExecutableBlocksImpl(WolfyUtilCore core, String pluginName) {
-        super(core, pluginName);
+    protected ExecutableBlocksImpl(WolfyUtilCore core) {
+        super(core, ExecutableBlocksIntegration.PLUGIN_NAME);
     }
 
     @Override

--- a/plugin-compatibility/plugin-compatibility-artifact/src/main/java/me/wolfyscript/utilities/compatibility/plugins/executableblocks/ExecutableBlocksImpl.java
+++ b/plugin-compatibility/plugin-compatibility-artifact/src/main/java/me/wolfyscript/utilities/compatibility/plugins/executableblocks/ExecutableBlocksImpl.java
@@ -1,0 +1,56 @@
+package me.wolfyscript.utilities.compatibility.plugins.executableblocks;
+
+import com.ssomar.score.api.executableblocks.ExecutableBlocksAPI;
+import com.ssomar.score.api.executableblocks.config.ExecutableBlocksManagerInterface;
+import java.util.List;
+import java.util.Optional;
+import me.wolfyscript.utilities.annotations.WUPluginIntegration;
+import me.wolfyscript.utilities.api.WolfyUtilCore;
+import me.wolfyscript.utilities.compatibility.PluginIntegrationAbstract;
+import me.wolfyscript.utilities.compatibility.plugins.ExecutableBlocksIntegration;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.persistence.PersistentDataType;
+import org.bukkit.plugin.Plugin;
+
+@WUPluginIntegration(pluginName = ExecutableBlocksIntegration.PLUGIN_NAME)
+public class ExecutableBlocksImpl extends PluginIntegrationAbstract implements ExecutableBlocksIntegration {
+
+    private ExecutableBlocksManagerInterface manager;
+
+    /**
+     * The main constructor that is called whenever the integration is created.<br>
+     *  @param core The WolfyUtilCore.
+     *
+     * @param pluginName The name of the associated plugin.
+     */
+    protected ExecutableBlocksImpl(WolfyUtilCore core, String pluginName) {
+        super(core, pluginName);
+    }
+
+    @Override
+    public void init(Plugin plugin) {
+        this.manager = ExecutableBlocksAPI.getExecutableBlocksManager();
+        core.registerAPIReference(new ExecutableBlocksRef.Parser(this, manager));
+    }
+
+    @Override
+    public boolean hasAsyncLoading() {
+        return false;
+    }
+
+    @Override
+    public boolean isValidID(String id) {
+        return manager.isValidID(id);
+    }
+
+    @Override
+    public List<String> getExecutableBlockIdsList() {
+        return manager.getExecutableBlockIdsList();
+    }
+
+    @Override
+    public Optional<String> getExecutableBlock(ItemStack stack) {
+        if (stack == null || stack.getItemMeta() == null || stack.getItemMeta().getPersistentDataContainer().isEmpty()) return Optional.empty();
+        return Optional.ofNullable(stack.getItemMeta().getPersistentDataContainer().get(BLOCK_ID, PersistentDataType.STRING)).map(s -> manager.isValidID(s) ? s : null);
+    }
+}

--- a/plugin-compatibility/plugin-compatibility-artifact/src/main/java/me/wolfyscript/utilities/compatibility/plugins/executableblocks/ExecutableBlocksRef.java
+++ b/plugin-compatibility/plugin-compatibility-artifact/src/main/java/me/wolfyscript/utilities/compatibility/plugins/executableblocks/ExecutableBlocksRef.java
@@ -1,0 +1,76 @@
+package me.wolfyscript.utilities.compatibility.plugins.executableblocks;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import com.ssomar.score.api.executableblocks.config.ExecutableBlocksManagerInterface;
+import java.io.IOException;
+import java.util.Locale;
+import java.util.Optional;
+import me.wolfyscript.utilities.api.inventory.custom_items.references.APIReference;
+import me.wolfyscript.utilities.compatibility.plugins.ExecutableBlocksIntegration;
+import org.bukkit.Material;
+import org.bukkit.inventory.ItemStack;
+import org.jetbrains.annotations.Nullable;
+
+public class ExecutableBlocksRef extends APIReference {
+
+    private final ExecutableBlocksIntegration integration;
+    private final ExecutableBlocksManagerInterface manager;
+    private final String id;
+
+    public ExecutableBlocksRef(ExecutableBlocksIntegration integration, ExecutableBlocksManagerInterface manager, String id) {
+        this.id = id;
+        this.manager = manager;
+        this.integration = integration;
+    }
+
+    private ExecutableBlocksRef(ExecutableBlocksRef other) {
+        this.id = other.id;
+        this.manager = other.manager;
+        this.integration = other.integration;
+    }
+
+    @Override
+    public ItemStack getLinkedItem() {
+        return manager.getExecutableBlock(id).map(eb -> eb.buildItem(amount, Optional.empty())).orElseGet(() -> new ItemStack(Material.AIR));
+    }
+
+    @Override
+    public boolean isValidItem(ItemStack itemStack) {
+        return integration.getExecutableBlock(itemStack).map(eB -> eB.equals(id)).orElse(false);
+    }
+
+    @Override
+    public void serialize(JsonGenerator gen, SerializerProvider provider) throws IOException {
+        gen.writeStringField(ExecutableBlocksIntegration.PLUGIN_NAME.toLowerCase(Locale.ROOT), id);
+    }
+
+    @Override
+    public APIReference clone() {
+        return new ExecutableBlocksRef(this);
+    }
+
+    public static class Parser extends PluginParser<ExecutableBlocksRef> {
+
+        private final ExecutableBlocksIntegration integration;
+        private final ExecutableBlocksManagerInterface manager;
+
+        public Parser(ExecutableBlocksIntegration integration, ExecutableBlocksManagerInterface manager) {
+            super(ExecutableBlocksIntegration.PLUGIN_NAME, ExecutableBlocksIntegration.PLUGIN_NAME.toLowerCase(Locale.ROOT));
+            this.integration = integration;
+            this.manager = manager;
+        }
+
+        @Override
+        public @Nullable ExecutableBlocksRef construct(ItemStack itemStack) {
+            return integration.getExecutableBlock(itemStack).map(ebID -> new ExecutableBlocksRef(integration, manager, ebID)).orElse(null);
+        }
+
+        @Override
+        public @Nullable ExecutableBlocksRef parse(JsonNode element) {
+            return new ExecutableBlocksRef(integration, manager, element.asText());
+        }
+    }
+
+}


### PR DESCRIPTION
Adds support for referencing items that are part of ExecutableBlocks, which makes it possible to properly use them inside recipes (CustomCrafting).