### PR TITLE
Fix priority and other APIReference related issue

### DIFF
--- a/core/src/main/java/me/wolfyscript/utilities/api/inventory/custom_items/CustomItem.java
+++ b/core/src/main/java/me/wolfyscript/utilities/api/inventory/custom_items/CustomItem.java
@@ -36,6 +36,7 @@ import com.wolfyscript.utilities.bukkit.items.CustomItemData;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Comparator;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
@@ -347,7 +348,7 @@ public class CustomItem extends AbstractItemBuilder<CustomItem> implements Keyed
      */
     public static CustomItem getReferenceByItemStack(ItemStack itemStack) {
         if (itemStack != null) {
-            APIReference apiReference = API_REFERENCE_PARSER.values().stream().sorted(APIReference.Parser::compareTo).map(parser -> parser.construct(itemStack)).filter(Objects::nonNull).findFirst().orElse(null);
+            APIReference apiReference = API_REFERENCE_PARSER.values().stream().sorted(Comparator.reverseOrder()).map(parser -> parser.construct(itemStack)).filter(Objects::nonNull).findFirst().orElse(null);
             if (apiReference != null) {
                 apiReference.setAmount(itemStack.getAmount());
                 return new CustomItem(apiReference);

--- a/core/src/main/java/me/wolfyscript/utilities/api/inventory/custom_items/CustomItem.java
+++ b/core/src/main/java/me/wolfyscript/utilities/api/inventory/custom_items/CustomItem.java
@@ -111,7 +111,7 @@ public class CustomItem extends AbstractItemBuilder<CustomItem> implements Keyed
      * @param parser an {@link APIReference.Parser} instance.
      */
     public static void registerAPIReferenceParser(APIReference.Parser<?> parser) {
-        if (parser instanceof APIReference.PluginParser pluginParser) {
+        if (parser instanceof APIReference.PluginParser<?> pluginParser) {
             if (!WolfyUtilities.hasPlugin(pluginParser.getPluginName())) {
                 return;
             }

--- a/core/src/main/java/me/wolfyscript/utilities/api/inventory/custom_items/references/VanillaRef.java
+++ b/core/src/main/java/me/wolfyscript/utilities/api/inventory/custom_items/references/VanillaRef.java
@@ -88,7 +88,7 @@ public class VanillaRef extends APIReference {
     public static class Parser extends APIReference.Parser<APIReference> {
 
         public Parser() {
-            super("item", 1000);
+            super("item", Integer.MIN_VALUE);
         }
 
         @Override

--- a/plugin-compatibility/plugin-compatibility-artifact/src/main/java/me/wolfyscript/utilities/compatibility/plugins/DenizenIntegrationImpl.java
+++ b/plugin-compatibility/plugin-compatibility-artifact/src/main/java/me/wolfyscript/utilities/compatibility/plugins/DenizenIntegrationImpl.java
@@ -29,7 +29,7 @@ public class DenizenIntegrationImpl extends PluginIntegrationAbstract {
 
     @Override
     public void init(Plugin plugin) {
-        core.registerAPIReference(new EcoRefImpl.Parser());
+        core.registerAPIReference(new DenizenRefImpl.Parser());
     }
 
     @Override

--- a/plugin-compatibility/plugin-compatibility-artifact/src/main/java/me/wolfyscript/utilities/compatibility/plugins/executableblocks/ExecutableBlocksRef.java
+++ b/plugin-compatibility/plugin-compatibility-artifact/src/main/java/me/wolfyscript/utilities/compatibility/plugins/executableblocks/ExecutableBlocksRef.java
@@ -57,7 +57,7 @@ public class ExecutableBlocksRef extends APIReference {
         private final ExecutableBlocksManagerInterface manager;
 
         public Parser(ExecutableBlocksIntegration integration, ExecutableBlocksManagerInterface manager) {
-            super(ExecutableBlocksIntegration.PLUGIN_NAME, ExecutableBlocksIntegration.PLUGIN_NAME.toLowerCase(Locale.ROOT));
+            super(ExecutableBlocksIntegration.PLUGIN_NAME, ExecutableBlocksIntegration.PLUGIN_NAME.toLowerCase(Locale.ROOT), 1000);
             this.integration = integration;
             this.manager = manager;
         }


### PR DESCRIPTION
* Change priority of the ExecutableBlocksRef.Parser to be higher than IA, Oraxen, etc.
* Change priority of the VanillaRef.Parser to the lowest value.
* Fix DenizenIntegrationImpl not registering DenizenRefImpl.Parser