### PR TITLE
Update UpdateInventory Utils to 1.19.4 mappings

### DIFF
--- a/core/src/main/java/me/wolfyscript/utilities/util/reflection/InventoryUpdate.java
+++ b/core/src/main/java/me/wolfyscript/utilities/util/reflection/InventoryUpdate.java
@@ -90,13 +90,17 @@ public final class InventoryUpdate {
 
             // Initialize fields.
             int version = ServerVersion.getVersion().getMinor();
-            activeContainerField = ENTITY_PLAYER_CLASS.getField(switch (ServerVersion.getVersion().getMinor()) {
+            int patchVersion = ServerVersion.getVersion().getPatch();
+            activeContainerField = ENTITY_PLAYER_CLASS.getField(switch (version) {
                 case 17 -> "bV";
-                case 18 -> switch (ServerVersion.getVersion().getPatch()) {
+                case 18 -> switch (patchVersion) {
                     case 0, 1 -> "bW";
                     default -> "bV";
                 };
-                case 19 -> "bU";
+                case 19 -> switch (patchVersion) {
+                    case 0, 1, 2, 3 -> "bU";
+                    default -> "bP";
+                };
                 default -> "activeContainer";
             });
             windowIdField = CONTAINER_CLASS.getField("j");

--- a/core/src/main/java/me/wolfyscript/utilities/util/reflection/InventoryUpdate.java
+++ b/core/src/main/java/me/wolfyscript/utilities/util/reflection/InventoryUpdate.java
@@ -99,7 +99,7 @@ public final class InventoryUpdate {
                 case 19 -> "bU";
                 default -> "activeContainer";
             });
-            windowIdField = (version > 16) ? CONTAINER_CLASS.getField("j") : CONTAINER_CLASS.getField("windowId");
+            windowIdField = CONTAINER_CLASS.getField("j");
         } catch (ReflectiveOperationException exception) {
             exception.printStackTrace();
         }


### PR DESCRIPTION
Add missing 1.19.4 mapping for the 'activeContainer' field in HumanEntity.