### PR TITLE
Read Server Properties File to determine Server settings

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>wolfyutils-parent</artifactId>
         <groupId>com.wolfyscript.wolfyutils.spigot</groupId>
-        <version>4.16.10.2</version>
+        <version>4.16.11-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/core/src/main/java/com/wolfyscript/utilities/bukkit/nms/ServerProperties.java
+++ b/core/src/main/java/com/wolfyscript/utilities/bukkit/nms/ServerProperties.java
@@ -1,0 +1,24 @@
+package com.wolfyscript.utilities.bukkit.nms;
+
+import java.io.BufferedReader;
+import java.io.FileReader;
+import java.io.IOException;
+import java.util.Properties;
+
+public class ServerProperties {
+
+    private static Properties properties = null;
+
+    public static Properties get() {
+        if (properties == null) {
+            properties = new Properties();
+            try (BufferedReader is = new BufferedReader(new FileReader("server.properties"))) {
+                properties.load(is);
+            } catch (IOException e) {
+                throw new RuntimeException(e);
+            }
+        }
+        return properties;
+    }
+
+}

--- a/core/src/main/java/me/wolfyscript/utilities/compatibility/CompatibilityManager.java
+++ b/core/src/main/java/me/wolfyscript/utilities/compatibility/CompatibilityManager.java
@@ -4,5 +4,7 @@ public interface CompatibilityManager {
 
     void init();
 
+    boolean has1_20Features();
+
     Plugins getPlugins();
 }

--- a/core/src/main/java/me/wolfyscript/utilities/compatibility/CompatibilityManagerBukkit.java
+++ b/core/src/main/java/me/wolfyscript/utilities/compatibility/CompatibilityManagerBukkit.java
@@ -18,10 +18,15 @@
 
 package me.wolfyscript.utilities.compatibility;
 
+import com.wolfyscript.utilities.bukkit.nms.ServerProperties;
+import java.util.Properties;
 import me.wolfyscript.utilities.api.WolfyUtilCore;
+import me.wolfyscript.utilities.util.version.MinecraftVersion;
+import me.wolfyscript.utilities.util.version.ServerVersion;
 
 public final class CompatibilityManagerBukkit implements CompatibilityManager {
 
+    private boolean has1_20Features = false;
     private final WolfyUtilCore core;
     private final PluginsBukkit pluginsBukkit;
 
@@ -32,6 +37,22 @@ public final class CompatibilityManagerBukkit implements CompatibilityManager {
 
     public void init() {
         pluginsBukkit.init();
+        Properties properties = ServerProperties.get();
+        has1_20Features = ServerVersion.getVersion().isAfterOrEq(MinecraftVersion.of(1, 20, 0));
+        // If the version is already 1.20 or later, then it has 1.20 features!
+        if (!has1_20Features && ServerVersion.getVersion().isAfterOrEq(MinecraftVersion.of(1, 19, 4))) {
+            String initialEnabledDataPacks = properties.getProperty("initial-enabled-packs", "vanilla");
+            for (String s : initialEnabledDataPacks.split(",")) {
+                if (s.equalsIgnoreCase("update_1_20")) {
+                    has1_20Features = true;
+                    break;
+                }
+            }
+        }
+    }
+
+    public boolean has1_20Features() {
+        return has1_20Features;
     }
 
     public Plugins getPlugins() {

--- a/nmsutil/nmsutil-artifact/pom.xml
+++ b/nmsutil/nmsutil-artifact/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <artifactId>nmsutil</artifactId>
         <groupId>com.wolfyscript.wolfyutils.spigot</groupId>
-        <version>4.16.10.2</version>
+        <version>4.16.11-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/nmsutil/nmsutil-v1_16_R1/pom.xml
+++ b/nmsutil/nmsutil-v1_16_R1/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <artifactId>nmsutil</artifactId>
         <groupId>com.wolfyscript.wolfyutils.spigot</groupId>
-        <version>4.16.10.2</version>
+        <version>4.16.11-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/nmsutil/nmsutil-v1_16_R2/pom.xml
+++ b/nmsutil/nmsutil-v1_16_R2/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <artifactId>nmsutil</artifactId>
         <groupId>com.wolfyscript.wolfyutils.spigot</groupId>
-        <version>4.16.10.2</version>
+        <version>4.16.11-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/nmsutil/nmsutil-v1_16_R3/pom.xml
+++ b/nmsutil/nmsutil-v1_16_R3/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <artifactId>nmsutil</artifactId>
         <groupId>com.wolfyscript.wolfyutils.spigot</groupId>
-        <version>4.16.10.2</version>
+        <version>4.16.11-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/nmsutil/nmsutil-v1_17_R1/pom.xml
+++ b/nmsutil/nmsutil-v1_17_R1/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <artifactId>nmsutil</artifactId>
         <groupId>com.wolfyscript.wolfyutils.spigot</groupId>
-        <version>4.16.10.2</version>
+        <version>4.16.11-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/nmsutil/nmsutil-v1_17_R1_P1/pom.xml
+++ b/nmsutil/nmsutil-v1_17_R1_P1/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <artifactId>nmsutil</artifactId>
         <groupId>com.wolfyscript.wolfyutils.spigot</groupId>
-        <version>4.16.10.2</version>
+        <version>4.16.11-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/nmsutil/nmsutil-v1_18_R1/pom.xml
+++ b/nmsutil/nmsutil-v1_18_R1/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <artifactId>nmsutil</artifactId>
         <groupId>com.wolfyscript.wolfyutils.spigot</groupId>
-        <version>4.16.10.2</version>
+        <version>4.16.11-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/nmsutil/nmsutil-v1_18_R1_P1/pom.xml
+++ b/nmsutil/nmsutil-v1_18_R1_P1/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <artifactId>nmsutil</artifactId>
         <groupId>com.wolfyscript.wolfyutils.spigot</groupId>
-        <version>4.16.10.2</version>
+        <version>4.16.11-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/nmsutil/nmsutil-v1_18_R2/pom.xml
+++ b/nmsutil/nmsutil-v1_18_R2/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <artifactId>nmsutil</artifactId>
         <groupId>com.wolfyscript.wolfyutils.spigot</groupId>
-        <version>4.16.10.2</version>
+        <version>4.16.11-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/nmsutil/nmsutil-v1_19_R1/pom.xml
+++ b/nmsutil/nmsutil-v1_19_R1/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>nmsutil</artifactId>
         <groupId>com.wolfyscript.wolfyutils.spigot</groupId>
-        <version>4.16.10.2</version>
+        <version>4.16.11-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/nmsutil/nmsutil-v1_19_R2/pom.xml
+++ b/nmsutil/nmsutil-v1_19_R2/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>nmsutil</artifactId>
         <groupId>com.wolfyscript.wolfyutils.spigot</groupId>
-        <version>4.16.10.2</version>
+        <version>4.16.11-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/nmsutil/nmsutil-v1_19_R3/pom.xml
+++ b/nmsutil/nmsutil-v1_19_R3/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>nmsutil</artifactId>
         <groupId>com.wolfyscript.wolfyutils.spigot</groupId>
-        <version>4.16.10.2</version>
+        <version>4.16.11-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/nmsutil/pom.xml
+++ b/nmsutil/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <artifactId>wolfyutils-parent</artifactId>
         <groupId>com.wolfyscript.wolfyutils.spigot</groupId>
-        <version>4.16.10.2</version>
+        <version>4.16.11-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <packaging>pom</packaging>

--- a/plugin-compatibility/plugin-compatibility-artifact/pom.xml
+++ b/plugin-compatibility/plugin-compatibility-artifact/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <artifactId>plugin-compatibility</artifactId>
         <groupId>com.wolfyscript.wolfyutils.spigot</groupId>
-        <version>4.16.10.2</version>
+        <version>4.16.11-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/plugin-compatibility/pom.xml
+++ b/plugin-compatibility/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>wolfyutils-parent</artifactId>
         <groupId>com.wolfyscript.wolfyutils.spigot</groupId>
-        <version>4.16.10.2</version>
+        <version>4.16.11-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <packaging>pom</packaging>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.wolfyscript.wolfyutils.spigot</groupId>
     <artifactId>wolfyutils-parent</artifactId>
-    <version>4.16.10.2</version>
+    <version>4.16.11-SNAPSHOT</version>
     <packaging>pom</packaging>
     <name>WolfyUtils-Spigot</name>
 

--- a/wolfyutils-spigot/pom.xml
+++ b/wolfyutils-spigot/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <artifactId>wolfyutils-parent</artifactId>
         <groupId>com.wolfyscript.wolfyutils.spigot</groupId>
-        <version>4.16.10.2</version>
+        <version>4.16.11-SNAPSHOT</version>
     </parent>
 
     <build>


### PR DESCRIPTION
Since Spigot still has no API to determine what datapacks are enabled, and we don't want to use NMS, we simply read the `server.properties` file and read the datapack settings.
That means we can only determine the datapacks that are enabled on startup, but that should be enough for now.