### PR TITLE
Include Fastutil library in plugin.yml

### DIFF
--- a/wolfyutils-spigot/src/main/resources/plugin.yml
+++ b/wolfyutils-spigot/src/main/resources/plugin.yml
@@ -8,6 +8,7 @@ load: STARTUP
 libraries:
   - "com.google.inject:guice:5.1.0"
   - "org.apache.commons:commons-lang3:3.12.0"
+  - "it.unimi.dsi:fastutil:8.5.6"
 
 loadbefore:
   - ChatColor


### PR DESCRIPTION
Fixes NoSuchMethodException on 1.17 and prior versions.