### PR TITLE
Fix amount handling in StackIdentifiers & References

### DIFF
--- a/core/src/main/java/com/wolfyscript/utilities/bukkit/registry/RegistryStackIdentifierParsers.java
+++ b/core/src/main/java/com/wolfyscript/utilities/bukkit/registry/RegistryStackIdentifierParsers.java
@@ -57,7 +57,7 @@ public class RegistryStackIdentifierParsers extends RegistrySimple<StackIdentifi
      * @return
      */
     public StackReference parseFrom(ItemStack stack) {
-        return new StackReference(registries.getCore(), parseIdentifier(stack), 1, 1, stack);
+        return new StackReference(registries.getCore(), parseIdentifier(stack), 1, stack.getAmount(), stack);
     }
 
     private void reIndexParsers() {

--- a/core/src/main/java/com/wolfyscript/utilities/bukkit/world/items/reference/StackIdentifier.java
+++ b/core/src/main/java/com/wolfyscript/utilities/bukkit/world/items/reference/StackIdentifier.java
@@ -86,7 +86,7 @@ public interface StackIdentifier extends Keyed {
         if (stack(ItemCreateContext.empty(count)).getMaxStackSize() == 1 && stack.getAmount() == 1) {
             return shrinkUnstackableItem(stack, useRemains);
         }
-        int amount = stack.getAmount() - (stack(ItemCreateContext.empty(count)).getAmount() * count);
+        int amount = stack.getAmount() - count;
         if (amount <= 0) {
             stack = new ItemStack(Material.AIR);
         } else {

--- a/core/src/main/java/com/wolfyscript/utilities/bukkit/world/items/reference/StackIdentifier.java
+++ b/core/src/main/java/com/wolfyscript/utilities/bukkit/world/items/reference/StackIdentifier.java
@@ -162,7 +162,7 @@ public interface StackIdentifier extends Keyed {
                         }
                     }
                     return originalStack;
-                }).orElse(new ItemStack(Material.AIR)));
+                }).orElse(stack));
     }
 
     /**

--- a/core/src/main/java/com/wolfyscript/utilities/bukkit/world/items/reference/StackReference.java
+++ b/core/src/main/java/com/wolfyscript/utilities/bukkit/world/items/reference/StackReference.java
@@ -230,7 +230,7 @@ public class StackReference implements Copyable<StackReference> {
      * @return The manipulated stack, default remain, or custom remains.
      */
     public ItemStack shrink(@NotNull ItemStack stack, int count, boolean useRemains, @NotNull BiFunction<StackIdentifier, ItemStack, ItemStack> stackReplacement) {
-        return identifier().shrink(stack, count * amount(), useRemains, stackReplacement);
+        return identifier().shrink(stack, count, useRemains, stackReplacement);
     }
 
     /**

--- a/core/src/main/java/com/wolfyscript/utilities/bukkit/world/items/reference/StackReference.java
+++ b/core/src/main/java/com/wolfyscript/utilities/bukkit/world/items/reference/StackReference.java
@@ -230,7 +230,7 @@ public class StackReference implements Copyable<StackReference> {
      * @return The manipulated stack, default remain, or custom remains.
      */
     public ItemStack shrink(@NotNull ItemStack stack, int count, boolean useRemains, @NotNull BiFunction<StackIdentifier, ItemStack, ItemStack> stackReplacement) {
-        return identifier().shrink(stack, count, useRemains, stackReplacement);
+        return identifier().shrink(stack, count * amount(), useRemains, stackReplacement);
     }
 
     /**
@@ -273,7 +273,7 @@ public class StackReference implements Copyable<StackReference> {
      * @return The manipulated stack, default remain, or custom remains.
      */
     public ItemStack shrink(ItemStack stack, int count, boolean useRemains, @Nullable final Inventory inventory, @Nullable final Player player, @Nullable final Location location) {
-        return identifier().shrink(stack, count, useRemains, inventory, player, location);
+        return identifier().shrink(stack, count * amount(), useRemains, inventory, player, location);
     }
 
     /**

--- a/plugin-compatibility/src/main/java/me/wolfyscript/utilities/compatibility/plugins/eco/EcoStackIdentifier.java
+++ b/plugin-compatibility/src/main/java/me/wolfyscript/utilities/compatibility/plugins/eco/EcoStackIdentifier.java
@@ -26,7 +26,9 @@ public class EcoStackIdentifier implements StackIdentifier {
 
     @Override
     public ItemStack stack(ItemCreateContext context) {
-        return Items.lookup(itemKey.toString()).getItem();
+        ItemStack stack = Items.lookup(itemKey.toString()).getItem();
+        stack.setAmount(context.amount());
+        return stack;
     }
 
     @Override

--- a/plugin-compatibility/src/main/java/me/wolfyscript/utilities/compatibility/plugins/fancybags/FancyBagsStackIdentifier.java
+++ b/plugin-compatibility/src/main/java/me/wolfyscript/utilities/compatibility/plugins/fancybags/FancyBagsStackIdentifier.java
@@ -33,7 +33,9 @@ public class FancyBagsStackIdentifier implements StackIdentifier {
     public ItemStack stack(ItemCreateContext context) {
         Backpack bag = CustomBackpacks.getBackpack(id);
         if (bag != null) {
-            return Utils.createBackpackItemStack(bag.getName(), bag.getTexture(), bag.getSlotsAmount(), bag.getId());
+            ItemStack stack = Utils.createBackpackItemStack(bag.getName(), bag.getTexture(), bag.getSlotsAmount(), bag.getId());
+            stack.setAmount(context.amount());
+            return stack;
         }
         return new ItemStack(Material.AIR);
     }

--- a/plugin-compatibility/src/main/java/me/wolfyscript/utilities/compatibility/plugins/itemsadder/ItemsAdderStackIdentifier.java
+++ b/plugin-compatibility/src/main/java/me/wolfyscript/utilities/compatibility/plugins/itemsadder/ItemsAdderStackIdentifier.java
@@ -33,7 +33,9 @@ public class ItemsAdderStackIdentifier implements StackIdentifier {
     public ItemStack stack(ItemCreateContext context) {
         var customStack = CustomStack.getInstance(itemId);
         if (customStack != null) {
-            return customStack.getItemStack();
+            ItemStack stack = customStack.getItemStack();
+            stack.setAmount(context.amount());
+            return stack;
         }
         return ItemUtils.AIR;
     }

--- a/plugin-compatibility/src/main/java/me/wolfyscript/utilities/compatibility/plugins/magic/MagicStackIdentifier.java
+++ b/plugin-compatibility/src/main/java/me/wolfyscript/utilities/compatibility/plugins/magic/MagicStackIdentifier.java
@@ -32,7 +32,9 @@ public class MagicStackIdentifier implements StackIdentifier {
 
     @Override
     public ItemStack stack(ItemCreateContext context) {
-        return Objects.requireNonNullElse(magicAPI.getController().createItem(itemKey), ItemUtils.AIR);
+        ItemStack stack = Objects.requireNonNullElse(magicAPI.getController().createItem(itemKey), ItemUtils.AIR);
+        stack.setAmount(context.amount());
+        return stack;
     }
 
     @Override

--- a/plugin-compatibility/src/main/java/me/wolfyscript/utilities/compatibility/plugins/mmoitems/MMOItemsStackIdentifier.java
+++ b/plugin-compatibility/src/main/java/me/wolfyscript/utilities/compatibility/plugins/mmoitems/MMOItemsStackIdentifier.java
@@ -32,7 +32,10 @@ public class MMOItemsStackIdentifier implements StackIdentifier {
     @Override
     public ItemStack stack(ItemCreateContext context) {
         MMOItem item = MMOItems.plugin.getMMOItem(itemType, itemName);
-        return item != null ? item.newBuilder().buildSilently() : null;
+        if (item == null) return null;
+        ItemStack stack = item.newBuilder().buildSilently();
+        stack.setAmount(context.amount());
+        return stack;
     }
 
     @Override

--- a/plugin-compatibility/src/main/java/me/wolfyscript/utilities/compatibility/plugins/mythicmobs/MythicMobsStackIdentifier.java
+++ b/plugin-compatibility/src/main/java/me/wolfyscript/utilities/compatibility/plugins/mythicmobs/MythicMobsStackIdentifier.java
@@ -30,7 +30,9 @@ public class MythicMobsStackIdentifier implements StackIdentifier {
 
     @Override
     public ItemStack stack(ItemCreateContext context) {
-        return mythicBukkit.getItemManager().getItemStack(itemName);
+        ItemStack stack = mythicBukkit.getItemManager().getItemStack(itemName);
+        stack.setAmount(context.amount());
+        return stack;
     }
 
     @Override

--- a/plugin-compatibility/src/main/java/me/wolfyscript/utilities/compatibility/plugins/oraxen/OraxenStackIdentifier.java
+++ b/plugin-compatibility/src/main/java/me/wolfyscript/utilities/compatibility/plugins/oraxen/OraxenStackIdentifier.java
@@ -32,7 +32,7 @@ public class OraxenStackIdentifier implements StackIdentifier {
     @Override
     public ItemStack stack(ItemCreateContext context) {
         if (OraxenItems.exists(itemID)) {
-            return OraxenItems.getItemById(itemID).build();
+            return OraxenItems.getItemById(itemID).setAmount(context.amount()).regen().build();
         }
         return ItemUtils.AIR;
     }


### PR DESCRIPTION
This fixes the following issues:
* Some Plugin specific StackIdentifiers don't apply the stack amount in the #stack method
* The BukkitStackReference Parseer doesn't store the original stack amount
* StackIdentifier#shrink is consuming the whole stack and doesn't respect the amount