### PR TITLE
Fix StackReference Not Updating & Backwards Compatibility 

### DIFF
--- a/core/src/main/java/com/wolfyscript/utilities/bukkit/world/items/reference/LegacyParser.java
+++ b/core/src/main/java/com/wolfyscript/utilities/bukkit/world/items/reference/LegacyParser.java
@@ -1,0 +1,11 @@
+package com.wolfyscript.utilities.bukkit.world.items.reference;
+
+import com.fasterxml.jackson.databind.JsonNode;
+
+import java.util.Optional;
+
+public interface LegacyParser<T extends StackIdentifier> {
+
+    Optional<T> from(JsonNode legacyData);
+
+}

--- a/core/src/main/java/com/wolfyscript/utilities/bukkit/world/items/reference/LegacyParser.java
+++ b/core/src/main/java/com/wolfyscript/utilities/bukkit/world/items/reference/LegacyParser.java
@@ -4,6 +4,11 @@ import com.fasterxml.jackson.databind.JsonNode;
 
 import java.util.Optional;
 
+/**
+ * Marks a legacy StackIdentifier Parser, that parses the StackIdentifier from the old {@link me.wolfyscript.utilities.api.inventory.custom_items.references.APIReference} data "format".
+ *
+ * @param <T> The type of the StackIdentifier
+ */
 public interface LegacyParser<T extends StackIdentifier> {
 
     Optional<T> from(JsonNode legacyData);

--- a/core/src/main/java/com/wolfyscript/utilities/bukkit/world/items/reference/LegacyStackReference.java
+++ b/core/src/main/java/com/wolfyscript/utilities/bukkit/world/items/reference/LegacyStackReference.java
@@ -4,6 +4,10 @@ import com.fasterxml.jackson.databind.JsonNode;
 import me.wolfyscript.utilities.api.WolfyUtilCore;
 import me.wolfyscript.utilities.util.NamespacedKey;
 
+/**
+ * Used to keep track of old {@link me.wolfyscript.utilities.api.inventory.custom_items.references.APIReference} data from the config.
+ * Because APIReferences did not store the original ItemStack in the config, the StackIdentifiers need to be parsed from the old data instead.
+ */
 public class LegacyStackReference extends StackReference {
 
     private final JsonNode data;

--- a/core/src/main/java/com/wolfyscript/utilities/bukkit/world/items/reference/LegacyStackReference.java
+++ b/core/src/main/java/com/wolfyscript/utilities/bukkit/world/items/reference/LegacyStackReference.java
@@ -3,6 +3,7 @@ package com.wolfyscript.utilities.bukkit.world.items.reference;
 import com.fasterxml.jackson.databind.JsonNode;
 import me.wolfyscript.utilities.api.WolfyUtilCore;
 import me.wolfyscript.utilities.util.NamespacedKey;
+import org.bukkit.inventory.ItemStack;
 
 /**
  * Used to keep track of old {@link me.wolfyscript.utilities.api.inventory.custom_items.references.APIReference} data from the config.
@@ -19,6 +20,14 @@ public class LegacyStackReference extends StackReference {
 
     public JsonNode data() {
         return data;
+    }
+
+    @Override
+    public ItemStack originalStack() {
+        if (stack == null) {
+            stack = identifier().map(stackIdentifier -> stackIdentifier.stack(ItemCreateContext.empty(amount()))).orElse(null);
+        }
+        return super.originalStack();
     }
 
     @Override

--- a/core/src/main/java/com/wolfyscript/utilities/bukkit/world/items/reference/LegacyStackReference.java
+++ b/core/src/main/java/com/wolfyscript/utilities/bukkit/world/items/reference/LegacyStackReference.java
@@ -1,0 +1,28 @@
+package com.wolfyscript.utilities.bukkit.world.items.reference;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import me.wolfyscript.utilities.api.WolfyUtilCore;
+import me.wolfyscript.utilities.util.NamespacedKey;
+
+public class LegacyStackReference extends StackReference {
+
+    private final JsonNode data;
+
+    public LegacyStackReference(WolfyUtilCore core, NamespacedKey parserKey, double weight, int amount, JsonNode data) {
+        super(core, parserKey, weight, amount, null);
+        this.data = data;
+    }
+
+    public JsonNode data() {
+        return data;
+    }
+
+    @Override
+    protected StackIdentifier parseIdentifier() {
+        if (identifier != null) return identifier;
+        if (parser() instanceof LegacyParser<?> legacyParser) {
+            return legacyParser.from(data).orElse(null);
+        }
+        return super.parseIdentifier();
+    }
+}

--- a/core/src/main/java/com/wolfyscript/utilities/bukkit/world/items/reference/StackReference.java
+++ b/core/src/main/java/com/wolfyscript/utilities/bukkit/world/items/reference/StackReference.java
@@ -43,7 +43,7 @@ public class StackReference implements Copyable<StackReference> {
     /**
      * Used to store the original stack
      */
-    private ItemStack stack;
+    protected ItemStack stack;
     /**
      * Used to store the previous parser result
      */

--- a/core/src/main/java/me/wolfyscript/utilities/util/json/jackson/serialization/APIReferenceSerialization.java
+++ b/core/src/main/java/me/wolfyscript/utilities/util/json/jackson/serialization/APIReferenceSerialization.java
@@ -32,8 +32,8 @@ import java.util.stream.Collectors;
 
 public class APIReferenceSerialization {
 
-    private static final String CUSTOM_AMOUNT = "custom_amount";
-    private static final String WEIGHT = "weight";
+    public static final String CUSTOM_AMOUNT = "custom_amount";
+    public static final String WEIGHT = "weight";
 
     private APIReferenceSerialization() {
     }

--- a/plugin-compatibility/src/main/java/me/wolfyscript/utilities/compatibility/plugins/denizen/DenizenStackIdentifier.java
+++ b/plugin-compatibility/src/main/java/me/wolfyscript/utilities/compatibility/plugins/denizen/DenizenStackIdentifier.java
@@ -1,10 +1,14 @@
 package me.wolfyscript.utilities.compatibility.plugins.denizen;
 
 import com.denizenscript.denizen.scripts.containers.core.ItemScriptHelper;
+import com.fasterxml.jackson.databind.JsonNode;
 import com.wolfyscript.utilities.bukkit.world.items.reference.ItemCreateContext;
+import com.wolfyscript.utilities.bukkit.world.items.reference.LegacyParser;
 import com.wolfyscript.utilities.bukkit.world.items.reference.StackIdentifier;
 import com.wolfyscript.utilities.bukkit.world.items.reference.StackIdentifierParser;
+import me.wolfyscript.utilities.api.WolfyUtilCore;
 import me.wolfyscript.utilities.util.NamespacedKey;
+import me.wolfyscript.utilities.util.inventory.ItemUtils;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.format.NamedTextColor;
 import net.kyori.adventure.text.format.TextDecoration;
@@ -50,7 +54,7 @@ public class DenizenStackIdentifier implements StackIdentifier {
         return ID;
     }
 
-    public static class Parser implements StackIdentifierParser<DenizenStackIdentifier> {
+    public static class Parser implements StackIdentifierParser<DenizenStackIdentifier>, LegacyParser<DenizenStackIdentifier> {
 
         @Override
         public int priority() {
@@ -77,6 +81,20 @@ public class DenizenStackIdentifier implements StackIdentifier {
                     Component.text("Denizen").color(NamedTextColor.YELLOW).decorate(TextDecoration.BOLD),
                     new DisplayConfiguration.MaterialIconSettings(Material.COMMAND_BLOCK)
             );
+        }
+
+        @Override
+        public Optional<DenizenStackIdentifier> from(JsonNode legacyData) {
+            if (legacyData.isObject()) {
+                ItemStack item = WolfyUtilCore.getInstance().getWolfyUtils().getJacksonMapperUtil().getGlobalMapper().convertValue(legacyData.path("display_item"), ItemStack.class);
+                if(!ItemUtils.isAirOrNull(item)) {
+                    String script = legacyData.path("script").asText("");
+                    if (!script.isBlank()) {
+                        return Optional.of(new DenizenStackIdentifier(item, script));
+                    }
+                }
+            }
+            return Optional.empty();
         }
     }
 

--- a/plugin-compatibility/src/main/java/me/wolfyscript/utilities/compatibility/plugins/eco/EcoStackIdentifier.java
+++ b/plugin-compatibility/src/main/java/me/wolfyscript/utilities/compatibility/plugins/eco/EcoStackIdentifier.java
@@ -1,7 +1,9 @@
 package me.wolfyscript.utilities.compatibility.plugins.eco;
 
+import com.fasterxml.jackson.databind.JsonNode;
 import com.willfp.eco.core.items.Items;
 import com.wolfyscript.utilities.bukkit.world.items.reference.ItemCreateContext;
+import com.wolfyscript.utilities.bukkit.world.items.reference.LegacyParser;
 import com.wolfyscript.utilities.bukkit.world.items.reference.StackIdentifier;
 import com.wolfyscript.utilities.bukkit.world.items.reference.StackIdentifierParser;
 import me.wolfyscript.utilities.util.NamespacedKey;
@@ -54,7 +56,7 @@ public class EcoStackIdentifier implements StackIdentifier {
         return ID;
     }
 
-    public static class Parser implements StackIdentifierParser<EcoStackIdentifier> {
+    public static class Parser implements StackIdentifierParser<EcoStackIdentifier>, LegacyParser<EcoStackIdentifier> {
 
         @Override
         public int priority() {
@@ -83,6 +85,11 @@ public class EcoStackIdentifier implements StackIdentifier {
                     Component.text("Eco").color(NamedTextColor.GREEN).decorate(TextDecoration.BOLD),
                     new DisplayConfiguration.MaterialIconSettings(Material.EMERALD)
             );
+        }
+
+        @Override
+        public Optional<EcoStackIdentifier> from(JsonNode legacyData) {
+            return Optional.of(new EcoStackIdentifier(org.bukkit.NamespacedKey.fromString(legacyData.asText())));
         }
     }
 

--- a/plugin-compatibility/src/main/java/me/wolfyscript/utilities/compatibility/plugins/executableblocks/ExecutableBlocksStackIdentifier.java
+++ b/plugin-compatibility/src/main/java/me/wolfyscript/utilities/compatibility/plugins/executableblocks/ExecutableBlocksStackIdentifier.java
@@ -1,7 +1,9 @@
 package me.wolfyscript.utilities.compatibility.plugins.executableblocks;
 
+import com.fasterxml.jackson.databind.JsonNode;
 import com.ssomar.executableblocks.executableblocks.ExecutableBlocksManager;
 import com.wolfyscript.utilities.bukkit.world.items.reference.ItemCreateContext;
+import com.wolfyscript.utilities.bukkit.world.items.reference.LegacyParser;
 import com.wolfyscript.utilities.bukkit.world.items.reference.StackIdentifier;
 import com.wolfyscript.utilities.bukkit.world.items.reference.StackIdentifierParser;
 import me.wolfyscript.utilities.compatibility.plugins.ExecutableBlocksIntegration;
@@ -57,7 +59,7 @@ public class ExecutableBlocksStackIdentifier implements StackIdentifier {
         return ID;
     }
 
-    public static class Parser implements StackIdentifierParser<ExecutableBlocksStackIdentifier> {
+    public static class Parser implements StackIdentifierParser<ExecutableBlocksStackIdentifier>, LegacyParser<ExecutableBlocksStackIdentifier> {
 
         private final ExecutableBlocksIntegration integration;
         private final ExecutableBlocksManager manager;
@@ -80,6 +82,11 @@ public class ExecutableBlocksStackIdentifier implements StackIdentifier {
         @Override
         public NamespacedKey getNamespacedKey() {
             return ID;
+        }
+
+        @Override
+        public Optional<ExecutableBlocksStackIdentifier> from(JsonNode legacyData) {
+            return Optional.of(new ExecutableBlocksStackIdentifier(integration, manager, legacyData.asText()));
         }
     }
 

--- a/plugin-compatibility/src/main/java/me/wolfyscript/utilities/compatibility/plugins/executableitems/ExecutableItemsStackIdentifier.java
+++ b/plugin-compatibility/src/main/java/me/wolfyscript/utilities/compatibility/plugins/executableitems/ExecutableItemsStackIdentifier.java
@@ -1,7 +1,9 @@
 package me.wolfyscript.utilities.compatibility.plugins.executableitems;
 
+import com.fasterxml.jackson.databind.JsonNode;
 import com.ssomar.score.api.executableitems.config.ExecutableItemsManagerInterface;
 import com.wolfyscript.utilities.bukkit.world.items.reference.ItemCreateContext;
+import com.wolfyscript.utilities.bukkit.world.items.reference.LegacyParser;
 import com.wolfyscript.utilities.bukkit.world.items.reference.StackIdentifier;
 import com.wolfyscript.utilities.bukkit.world.items.reference.StackIdentifierParser;
 import me.wolfyscript.utilities.util.NamespacedKey;
@@ -36,6 +38,7 @@ public class ExecutableItemsStackIdentifier implements StackIdentifier {
     @Override
     public boolean matches(ItemStack other, int count, boolean exact, boolean ignoreAmount) {
         if (ItemUtils.isAirOrNull(other)) return false;
+        // TODO: DO NOT build the stack here!!!!
         if (!ignoreAmount && other.getAmount() < stack(ItemCreateContext.empty(count)).getAmount() * count) return false;
         return manager.getExecutableItem(other).map(exeItem -> exeItem.getId().equals(id)).orElse(false);
     }
@@ -53,7 +56,7 @@ public class ExecutableItemsStackIdentifier implements StackIdentifier {
         return ID;
     }
 
-    public static class Parser implements StackIdentifierParser<ExecutableItemsStackIdentifier> {
+    public static class Parser implements StackIdentifierParser<ExecutableItemsStackIdentifier>, LegacyParser<ExecutableItemsStackIdentifier> {
 
         private final ExecutableItemsManagerInterface manager;
 
@@ -74,6 +77,11 @@ public class ExecutableItemsStackIdentifier implements StackIdentifier {
         @Override
         public NamespacedKey getNamespacedKey() {
             return ID;
+        }
+
+        @Override
+        public Optional<ExecutableItemsStackIdentifier> from(JsonNode legacyData) {
+            return Optional.of(new ExecutableItemsStackIdentifier(manager, legacyData.asText()));
         }
     }
 

--- a/plugin-compatibility/src/main/java/me/wolfyscript/utilities/compatibility/plugins/fancybags/FancyBagsStackIdentifier.java
+++ b/plugin-compatibility/src/main/java/me/wolfyscript/utilities/compatibility/plugins/fancybags/FancyBagsStackIdentifier.java
@@ -1,6 +1,8 @@
 package me.wolfyscript.utilities.compatibility.plugins.fancybags;
 
+import com.fasterxml.jackson.databind.JsonNode;
 import com.wolfyscript.utilities.bukkit.world.items.reference.ItemCreateContext;
+import com.wolfyscript.utilities.bukkit.world.items.reference.LegacyParser;
 import com.wolfyscript.utilities.bukkit.world.items.reference.StackIdentifier;
 import com.wolfyscript.utilities.bukkit.world.items.reference.StackIdentifierParser;
 import de.tr7zw.changeme.nbtapi.NBTItem;
@@ -63,7 +65,7 @@ public class FancyBagsStackIdentifier implements StackIdentifier {
         return ID;
     }
 
-    public static class Parser implements StackIdentifierParser<FancyBagsStackIdentifier> {
+    public static class Parser implements StackIdentifierParser<FancyBagsStackIdentifier>, LegacyParser<FancyBagsStackIdentifier> {
 
         @Override
         public int priority() {
@@ -83,6 +85,11 @@ public class FancyBagsStackIdentifier implements StackIdentifier {
         @Override
         public NamespacedKey getNamespacedKey() {
             return ID;
+        }
+
+        @Override
+        public Optional<FancyBagsStackIdentifier> from(JsonNode legacyData) {
+            return Optional.of(new FancyBagsStackIdentifier(legacyData.asInt()));
         }
     }
 

--- a/plugin-compatibility/src/main/java/me/wolfyscript/utilities/compatibility/plugins/itemsadder/ItemsAdderStackIdentifier.java
+++ b/plugin-compatibility/src/main/java/me/wolfyscript/utilities/compatibility/plugins/itemsadder/ItemsAdderStackIdentifier.java
@@ -1,6 +1,8 @@
 package me.wolfyscript.utilities.compatibility.plugins.itemsadder;
 
+import com.fasterxml.jackson.databind.JsonNode;
 import com.wolfyscript.utilities.bukkit.world.items.reference.ItemCreateContext;
+import com.wolfyscript.utilities.bukkit.world.items.reference.LegacyParser;
 import com.wolfyscript.utilities.bukkit.world.items.reference.StackIdentifier;
 import com.wolfyscript.utilities.bukkit.world.items.reference.StackIdentifierParser;
 import dev.lone.itemsadder.api.CustomStack;
@@ -61,7 +63,7 @@ public class ItemsAdderStackIdentifier implements StackIdentifier {
         return ID;
     }
 
-    public static class Parser implements StackIdentifierParser<ItemsAdderStackIdentifier> {
+    public static class Parser implements StackIdentifierParser<ItemsAdderStackIdentifier>, LegacyParser<ItemsAdderStackIdentifier> {
 
         @Override
         public int priority() {
@@ -88,6 +90,11 @@ public class ItemsAdderStackIdentifier implements StackIdentifier {
                     Component.text("ItemsAdder").color(NamedTextColor.YELLOW).decorate(TextDecoration.BOLD),
                     new DisplayConfiguration.MaterialIconSettings(Material.GRASS_BLOCK)
             );
+        }
+
+        @Override
+        public Optional<ItemsAdderStackIdentifier> from(JsonNode legacyData) {
+            return Optional.of(new ItemsAdderStackIdentifier(legacyData.asText()));
         }
     }
 

--- a/plugin-compatibility/src/main/java/me/wolfyscript/utilities/compatibility/plugins/magic/MagicStackIdentifier.java
+++ b/plugin-compatibility/src/main/java/me/wolfyscript/utilities/compatibility/plugins/magic/MagicStackIdentifier.java
@@ -1,8 +1,10 @@
 package me.wolfyscript.utilities.compatibility.plugins.magic;
 
 import com.elmakers.mine.bukkit.api.magic.MagicAPI;
+import com.fasterxml.jackson.databind.JsonNode;
 import com.google.common.base.Preconditions;
 import com.wolfyscript.utilities.bukkit.world.items.reference.ItemCreateContext;
+import com.wolfyscript.utilities.bukkit.world.items.reference.LegacyParser;
 import com.wolfyscript.utilities.bukkit.world.items.reference.StackIdentifier;
 import com.wolfyscript.utilities.bukkit.world.items.reference.StackIdentifierParser;
 import me.wolfyscript.utilities.util.NamespacedKey;
@@ -55,7 +57,7 @@ public class MagicStackIdentifier implements StackIdentifier {
         return ID;
     }
 
-    public static class Parser implements StackIdentifierParser<MagicStackIdentifier> {
+    public static class Parser implements StackIdentifierParser<MagicStackIdentifier>, LegacyParser<MagicStackIdentifier> {
 
         private final MagicAPI magicAPI;
 
@@ -79,6 +81,11 @@ public class MagicStackIdentifier implements StackIdentifier {
         @Override
         public NamespacedKey getNamespacedKey() {
             return ID;
+        }
+
+        @Override
+        public Optional<MagicStackIdentifier> from(JsonNode legacyData) {
+            return Optional.of(new MagicStackIdentifier(legacyData.asText()));
         }
     }
 

--- a/plugin-compatibility/src/main/java/me/wolfyscript/utilities/compatibility/plugins/mmoitems/MMOItemsStackIdentifier.java
+++ b/plugin-compatibility/src/main/java/me/wolfyscript/utilities/compatibility/plugins/mmoitems/MMOItemsStackIdentifier.java
@@ -1,6 +1,8 @@
 package me.wolfyscript.utilities.compatibility.plugins.mmoitems;
 
+import com.fasterxml.jackson.databind.JsonNode;
 import com.wolfyscript.utilities.bukkit.world.items.reference.ItemCreateContext;
+import com.wolfyscript.utilities.bukkit.world.items.reference.LegacyParser;
 import com.wolfyscript.utilities.bukkit.world.items.reference.StackIdentifier;
 import com.wolfyscript.utilities.bukkit.world.items.reference.StackIdentifierParser;
 import io.lumine.mythic.lib.api.item.NBTItem;
@@ -60,7 +62,7 @@ public class MMOItemsStackIdentifier implements StackIdentifier {
         return ID;
     }
 
-    public static class Parser implements StackIdentifierParser<MMOItemsStackIdentifier> {
+    public static class Parser implements StackIdentifierParser<MMOItemsStackIdentifier>, LegacyParser<MMOItemsStackIdentifier> {
 
         @Override
         public int priority() {
@@ -90,6 +92,17 @@ public class MMOItemsStackIdentifier implements StackIdentifier {
                     Component.text("MMOItems").color(NamedTextColor.DARK_GRAY).decorate(TextDecoration.BOLD),
                     new DisplayConfiguration.MaterialIconSettings(Material.IRON_SWORD)
             );
+        }
+
+        @Override
+        public Optional<MMOItemsStackIdentifier> from(JsonNode legacyData) {
+            if (legacyData.has("type") && legacyData.has("name")) {
+                String typeID = legacyData.get("type").asText();
+                if (MMOItems.plugin.getTypes().has(typeID)) {
+                    return Optional.of(new MMOItemsStackIdentifier(MMOItems.plugin.getTypes().get(typeID), legacyData.get("name").asText()));
+                }
+            }
+            return Optional.empty();
         }
     }
 

--- a/plugin-compatibility/src/main/java/me/wolfyscript/utilities/compatibility/plugins/mythicmobs/MythicMobsStackIdentifier.java
+++ b/plugin-compatibility/src/main/java/me/wolfyscript/utilities/compatibility/plugins/mythicmobs/MythicMobsStackIdentifier.java
@@ -1,6 +1,8 @@
 package me.wolfyscript.utilities.compatibility.plugins.mythicmobs;
 
+import com.fasterxml.jackson.databind.JsonNode;
 import com.wolfyscript.utilities.bukkit.world.items.reference.ItemCreateContext;
+import com.wolfyscript.utilities.bukkit.world.items.reference.LegacyParser;
 import com.wolfyscript.utilities.bukkit.world.items.reference.StackIdentifier;
 import com.wolfyscript.utilities.bukkit.world.items.reference.StackIdentifierParser;
 import de.tr7zw.changeme.nbtapi.NBTItem;
@@ -61,7 +63,7 @@ public class MythicMobsStackIdentifier implements StackIdentifier {
         return ID;
     }
 
-    public static class Parser implements StackIdentifierParser<MythicMobsStackIdentifier> {
+    public static class Parser implements StackIdentifierParser<MythicMobsStackIdentifier>, LegacyParser<MythicMobsStackIdentifier> {
 
         @Override
         public int priority() {
@@ -91,6 +93,11 @@ public class MythicMobsStackIdentifier implements StackIdentifier {
                     Component.text("MythicMobs").color(NamedTextColor.DARK_PURPLE).decorate(TextDecoration.BOLD),
                     new DisplayConfiguration.MaterialIconSettings(Material.WITHER_SKELETON_SKULL)
             );
+        }
+
+        @Override
+        public Optional<MythicMobsStackIdentifier> from(JsonNode legacyData) {
+            return Optional.of(new MythicMobsStackIdentifier(legacyData.asText()));
         }
     }
 

--- a/plugin-compatibility/src/main/java/me/wolfyscript/utilities/compatibility/plugins/oraxen/OraxenStackIdentifier.java
+++ b/plugin-compatibility/src/main/java/me/wolfyscript/utilities/compatibility/plugins/oraxen/OraxenStackIdentifier.java
@@ -1,6 +1,8 @@
 package me.wolfyscript.utilities.compatibility.plugins.oraxen;
 
+import com.fasterxml.jackson.databind.JsonNode;
 import com.wolfyscript.utilities.bukkit.world.items.reference.ItemCreateContext;
+import com.wolfyscript.utilities.bukkit.world.items.reference.LegacyParser;
 import com.wolfyscript.utilities.bukkit.world.items.reference.StackIdentifier;
 import com.wolfyscript.utilities.bukkit.world.items.reference.StackIdentifierParser;
 import io.th0rgal.oraxen.api.OraxenItems;
@@ -59,7 +61,7 @@ public class OraxenStackIdentifier implements StackIdentifier {
         return ID;
     }
 
-    public static class Parser implements StackIdentifierParser<OraxenStackIdentifier> {
+    public static class Parser implements StackIdentifierParser<OraxenStackIdentifier>, LegacyParser<OraxenStackIdentifier> {
 
         @Override
         public int priority() {
@@ -86,6 +88,11 @@ public class OraxenStackIdentifier implements StackIdentifier {
                     Component.text("Oraxen").color(NamedTextColor.DARK_AQUA).decorate(TextDecoration.BOLD),
                     new DisplayConfiguration.MaterialIconSettings(Material.DIAMOND)
             );
+        }
+
+        @Override
+        public Optional<OraxenStackIdentifier> from(JsonNode legacyData) {
+            return Optional.of(new OraxenStackIdentifier(legacyData.asText()));
         }
     }
 


### PR DESCRIPTION
This PR makes sure, that StackReferences parse the StackIdentifier whenever the Parser becomes available. (Previoulsy they were not updated and caused issues)

Additionally, it introduces a legacy Parser and StackReference, that are used to deserialize StackReferences from the old APIReference data.