### PR TITLE
Fix StackReference `matches` Performance Issues

### DIFF
--- a/core/src/main/java/com/wolfyscript/utilities/bukkit/world/items/reference/StackReference.java
+++ b/core/src/main/java/com/wolfyscript/utilities/bukkit/world/items/reference/StackReference.java
@@ -52,7 +52,7 @@ public class StackReference implements Copyable<StackReference> {
     private StackIdentifierParser<?> parser;
 
     public static StackReference of(ItemStack itemStack) {
-        return new StackReference(WolfyUtilCore.getInstance(), new BukkitStackIdentifier(itemStack), 1, 1, itemStack);
+        return new StackReference(WolfyUtilCore.getInstance(), new BukkitStackIdentifier(itemStack), 1, itemStack.getAmount(), itemStack);
     }
 
     public StackReference(WolfyUtilCore core, NamespacedKey parserKey, double weight, int amount, ItemStack item) {
@@ -117,6 +117,8 @@ public class StackReference implements Copyable<StackReference> {
     }
 
     public boolean matches(ItemStack other, boolean exact, boolean ignoreAmount) {
+        if (ItemUtils.isAirOrNull(other)) return false;
+        if (!ignoreAmount && other.getAmount() < amount) return false;
         return identifier().map(identifier -> identifier.matches(other, amount, exact, ignoreAmount)).orElse(false);
     }
 

--- a/plugin-compatibility/src/main/java/me/wolfyscript/utilities/compatibility/plugins/executableblocks/ExecutableBlocksStackIdentifier.java
+++ b/plugin-compatibility/src/main/java/me/wolfyscript/utilities/compatibility/plugins/executableblocks/ExecutableBlocksStackIdentifier.java
@@ -42,7 +42,6 @@ public class ExecutableBlocksStackIdentifier implements StackIdentifier {
     @Override
     public boolean matches(ItemStack other, int count, boolean exact, boolean ignoreAmount) {
         if (ItemUtils.isAirOrNull(other)) return false;
-        if (!ignoreAmount && other.getAmount() < stack(ItemCreateContext.empty(count)).getAmount() * count) return false;
         return integration.getExecutableBlock(other).map(eB -> eB.equals(id)).orElse(false);
     }
 

--- a/plugin-compatibility/src/main/java/me/wolfyscript/utilities/compatibility/plugins/executableitems/ExecutableItemsStackIdentifier.java
+++ b/plugin-compatibility/src/main/java/me/wolfyscript/utilities/compatibility/plugins/executableitems/ExecutableItemsStackIdentifier.java
@@ -38,8 +38,6 @@ public class ExecutableItemsStackIdentifier implements StackIdentifier {
     @Override
     public boolean matches(ItemStack other, int count, boolean exact, boolean ignoreAmount) {
         if (ItemUtils.isAirOrNull(other)) return false;
-        // TODO: DO NOT build the stack here!!!!
-        if (!ignoreAmount && other.getAmount() < stack(ItemCreateContext.empty(count)).getAmount() * count) return false;
         return manager.getExecutableItem(other).map(exeItem -> exeItem.getId().equals(id)).orElse(false);
     }
 


### PR DESCRIPTION
This removes some very resource intensive procedures from the Executable Items & Blocks StackIdentifier matches method, to fix the performance issues.