### PR TITLE
Replace NMS GUI Generation with GUIInventoryHolder

### DIFF
--- a/core/src/main/java/com/wolfyscript/utilities/bukkit/gui/GUIInventoryDeferrer.java
+++ b/core/src/main/java/com/wolfyscript/utilities/bukkit/gui/GUIInventoryDeferrer.java
@@ -47,6 +47,11 @@ public class GUIInventoryDeferrer<C extends CustomCache> implements GUIInventory
     }
 
     @Override
+    public Inventory inventory() {
+        return inventory;
+    }
+
+    @Override
     public int getSize() {
         return inventory.getSize();
     }

--- a/core/src/main/java/com/wolfyscript/utilities/bukkit/gui/GUIInventoryDeferrer.java
+++ b/core/src/main/java/com/wolfyscript/utilities/bukkit/gui/GUIInventoryDeferrer.java
@@ -1,0 +1,223 @@
+package com.wolfyscript.utilities.bukkit.gui;
+
+import me.wolfyscript.utilities.api.inventory.gui.GuiHandler;
+import me.wolfyscript.utilities.api.inventory.gui.GuiWindow;
+import me.wolfyscript.utilities.api.inventory.gui.cache.CustomCache;
+import me.wolfyscript.utilities.api.nms.inventory.GUIInventory;
+import org.bukkit.Location;
+import org.bukkit.Material;
+import org.bukkit.entity.HumanEntity;
+import org.bukkit.event.inventory.InventoryType;
+import org.bukkit.inventory.Inventory;
+import org.bukkit.inventory.InventoryHolder;
+import org.bukkit.inventory.ItemStack;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.ListIterator;
+
+/**
+ * Acts as a drop-in replacement for the old generated GUIInventory.
+ * The old GUIInventory was a direct Inventory implementation, so this needs to defer to the inventory methods to keep compatibility.
+ *
+ * @param <C> The cache type
+ */
+public class GUIInventoryDeferrer<C extends CustomCache> implements GUIInventory<C> {
+
+    private final Inventory inventory;
+    private final GuiWindow<C> window;
+    private final GuiHandler<C> handler;
+
+    public GUIInventoryDeferrer(Inventory inventory, GuiWindow<C> window, GuiHandler<C> handler) {
+        this.inventory = inventory;
+        this.window = window;
+        this.handler = handler;
+    }
+
+    @Override
+    public GuiWindow<C> getWindow() {
+        return window;
+    }
+
+    @Override
+    public GuiHandler<C> getGuiHandler() {
+        return handler;
+    }
+
+    @Override
+    public int getSize() {
+        return inventory.getSize();
+    }
+
+    @Override
+    public int getMaxStackSize() {
+        return inventory.getMaxStackSize();
+    }
+
+    @Override
+    public void setMaxStackSize(int size) {
+        inventory.setMaxStackSize(size);
+    }
+
+    @Override
+    public @Nullable ItemStack getItem(int index) {
+        return inventory.getItem(index);
+    }
+
+    @Override
+    public void setItem(int index, @Nullable ItemStack item) {
+        inventory.setItem(index, item);
+    }
+
+    @Override
+    public @NotNull HashMap<Integer, ItemStack> addItem(@NotNull ItemStack... items) throws IllegalArgumentException {
+        return inventory.addItem(items);
+    }
+
+    @Override
+    public @NotNull HashMap<Integer, ItemStack> removeItem(@NotNull ItemStack... items) throws IllegalArgumentException {
+        return inventory.removeItem(items);
+    }
+
+    @Override
+    public @NotNull HashMap<Integer, ItemStack> removeItemAnySlot(@NotNull ItemStack... items) throws IllegalArgumentException {
+        return inventory.removeItemAnySlot(items);
+    }
+
+    @Override
+    public @Nullable ItemStack @NotNull [] getContents() {
+        return inventory.getContents();
+    }
+
+    @Override
+    public void setContents(@Nullable ItemStack @NotNull [] items) throws IllegalArgumentException {
+        inventory.setContents(items);
+    }
+
+    @Override
+    public @Nullable ItemStack @NotNull [] getStorageContents() {
+        return inventory.getStorageContents();
+    }
+
+    @Override
+    public void setStorageContents(@Nullable ItemStack @NotNull [] items) throws IllegalArgumentException {
+        inventory.setStorageContents(items);
+    }
+
+    @Override
+    public boolean contains(@NotNull Material material) throws IllegalArgumentException {
+        return inventory.contains(material);
+    }
+
+    @Override
+    public boolean contains(@Nullable ItemStack item) {
+        return inventory.contains(item);
+    }
+
+    @Override
+    public boolean contains(@NotNull Material material, int amount) throws IllegalArgumentException {
+        return inventory.contains(material, amount);
+    }
+
+    @Override
+    public boolean contains(@Nullable ItemStack item, int amount) {
+        return inventory.contains(item, amount);
+    }
+
+    @Override
+    public boolean containsAtLeast(@Nullable ItemStack item, int amount) {
+        return inventory.containsAtLeast(item, amount);
+    }
+
+    @Override
+    public @NotNull HashMap<Integer, ? extends ItemStack> all(@NotNull Material material) throws IllegalArgumentException {
+        return inventory.all(material);
+    }
+
+    @Override
+    public @NotNull HashMap<Integer, ? extends ItemStack> all(@Nullable ItemStack item) {
+        return inventory.all(item);
+    }
+
+    @Override
+    public int first(@NotNull Material material) throws IllegalArgumentException {
+        return inventory.first(material);
+    }
+
+    @Override
+    public int first(@NotNull ItemStack item) {
+        return inventory.first(item);
+    }
+
+    @Override
+    public int firstEmpty() {
+        return inventory.firstEmpty();
+    }
+
+    @Override
+    public boolean isEmpty() {
+        return inventory.isEmpty();
+    }
+
+    @Override
+    public void remove(@NotNull Material material) throws IllegalArgumentException {
+        inventory.remove(material);
+    }
+
+    @Override
+    public void remove(@NotNull ItemStack item) {
+        inventory.remove(item);
+    }
+
+    @Override
+    public void clear(int index) {
+        inventory.clear(index);
+    }
+
+    @Override
+    public void clear() {
+        inventory.clear();
+    }
+
+    @Override
+    public int close() {
+        return inventory.close();
+    }
+
+    @Override
+    public @NotNull List<HumanEntity> getViewers() {
+        return inventory.getViewers();
+    }
+
+    @Override
+    public @NotNull InventoryType getType() {
+        return inventory.getType();
+    }
+
+    @Override
+    public @Nullable InventoryHolder getHolder() {
+        return inventory.getHolder();
+    }
+
+    @Override
+    public @Nullable InventoryHolder getHolder(boolean useSnapshot) {
+        return inventory.getHolder(useSnapshot);
+    }
+
+    @Override
+    public @NotNull ListIterator<ItemStack> iterator() {
+        return inventory.iterator();
+    }
+
+    @Override
+    public @NotNull ListIterator<ItemStack> iterator(int index) {
+        return inventory.iterator(index);
+    }
+
+    @Override
+    public @Nullable Location getLocation() {
+        return inventory.getLocation();
+    }
+}

--- a/core/src/main/java/com/wolfyscript/utilities/bukkit/gui/GUIInventoryHolder.java
+++ b/core/src/main/java/com/wolfyscript/utilities/bukkit/gui/GUIInventoryHolder.java
@@ -1,5 +1,6 @@
 package com.wolfyscript.utilities.bukkit.gui;
 
+import com.google.common.base.Preconditions;
 import me.wolfyscript.utilities.api.inventory.gui.GuiHandler;
 import me.wolfyscript.utilities.api.inventory.gui.GuiWindow;
 import me.wolfyscript.utilities.api.inventory.gui.cache.CustomCache;
@@ -20,6 +21,7 @@ public class GUIInventoryHolder<C extends CustomCache> implements InventoryHolde
 
     private final GuiWindow<C> window;
     private final GuiHandler<C> guiHandler;
+    private Inventory inventory;
 
     public GUIInventoryHolder(GuiHandler<C> guiHandler, GuiWindow<C> window) {
         this.guiHandler = guiHandler;
@@ -34,21 +36,25 @@ public class GUIInventoryHolder<C extends CustomCache> implements InventoryHolde
         return window;
     }
 
+    public void setInventory(Inventory inventory) {
+        this.inventory = inventory;
+    }
+
     @NotNull
     @Override
     public Inventory getInventory() {
-        return guiHandler.getPlayer().getInventory();
+        return inventory;
     }
 
     public void onClick(InventoryClickEvent event) {
-        guiHandler.getInvAPI().onClick(guiHandler, new GUIInventoryDeferrer<>(getInventory(), window, guiHandler), event);
+        guiHandler.getInvAPI().onClick(guiHandler, new GUIInventoryDeferrer<>(inventory, window, guiHandler), event);
     }
 
     public void onDrag(InventoryDragEvent event) {
-        guiHandler.getInvAPI().onDrag(guiHandler, new GUIInventoryDeferrer<>(getInventory(), window, guiHandler), event);
+        guiHandler.getInvAPI().onDrag(guiHandler, new GUIInventoryDeferrer<>(inventory, window, guiHandler), event);
     }
 
     public void onClose(InventoryCloseEvent event) {
-        guiHandler.onClose(new GUIInventoryDeferrer<>(getInventory(), window, guiHandler), event);
+        guiHandler.onClose(new GUIInventoryDeferrer<>(inventory, window, guiHandler), event);
     }
 }

--- a/core/src/main/java/com/wolfyscript/utilities/bukkit/gui/GUIInventoryHolder.java
+++ b/core/src/main/java/com/wolfyscript/utilities/bukkit/gui/GUIInventoryHolder.java
@@ -3,10 +3,19 @@ package com.wolfyscript.utilities.bukkit.gui;
 import me.wolfyscript.utilities.api.inventory.gui.GuiHandler;
 import me.wolfyscript.utilities.api.inventory.gui.GuiWindow;
 import me.wolfyscript.utilities.api.inventory.gui.cache.CustomCache;
+import org.bukkit.event.inventory.InventoryClickEvent;
+import org.bukkit.event.inventory.InventoryCloseEvent;
+import org.bukkit.event.inventory.InventoryDragEvent;
 import org.bukkit.inventory.Inventory;
 import org.bukkit.inventory.InventoryHolder;
 import org.jetbrains.annotations.NotNull;
 
+/**
+ * An InventoryHolder implementation that keeps track of the GUI that belongs to an Inventory.
+ * This replaces the old GUIInventory, that was generated via NMS.
+ *
+ * @param <C> The CustomCache type
+ */
 public class GUIInventoryHolder<C extends CustomCache> implements InventoryHolder {
 
     private final GuiWindow<C> window;
@@ -17,11 +26,11 @@ public class GUIInventoryHolder<C extends CustomCache> implements InventoryHolde
         this.window = window;
     }
 
-    public GuiHandler<C> getGuiHandler() {
+    public GuiHandler<C> guiHandler() {
         return guiHandler;
     }
 
-    public GuiWindow<C> getWindow() {
+    public GuiWindow<C> window() {
         return window;
     }
 
@@ -29,5 +38,17 @@ public class GUIInventoryHolder<C extends CustomCache> implements InventoryHolde
     @Override
     public Inventory getInventory() {
         return guiHandler.getPlayer().getInventory();
+    }
+
+    public void onClick(InventoryClickEvent event) {
+        guiHandler.getInvAPI().onClick(guiHandler, new GUIInventoryDeferrer<>(getInventory(), window, guiHandler), event);
+    }
+
+    public void onDrag(InventoryDragEvent event) {
+        guiHandler.getInvAPI().onDrag(guiHandler, new GUIInventoryDeferrer<>(getInventory(), window, guiHandler), event);
+    }
+
+    public void onClose(InventoryCloseEvent event) {
+        guiHandler.onClose(new GUIInventoryDeferrer<>(getInventory(), window, guiHandler), event);
     }
 }

--- a/core/src/main/java/com/wolfyscript/utilities/bukkit/listeners/GUIInventoryListener.java
+++ b/core/src/main/java/com/wolfyscript/utilities/bukkit/listeners/GUIInventoryListener.java
@@ -18,7 +18,7 @@
 
 package com.wolfyscript.utilities.bukkit.listeners;
 
-import me.wolfyscript.utilities.api.nms.inventory.GUIInventory;
+import com.wolfyscript.utilities.bukkit.gui.GUIInventoryHolder;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
@@ -30,22 +30,22 @@ public class GUIInventoryListener implements Listener {
 
     @EventHandler(priority = EventPriority.HIGHEST)
     public void onInvClick(InventoryClickEvent event) {
-        if (event.getInventory() instanceof GUIInventory<?> inventory) {
-            inventory.onClick(event);
+        if (event.getInventory().getHolder() instanceof GUIInventoryHolder<?> holder) {
+            holder.onClick(event);
         }
     }
 
     @EventHandler(priority = EventPriority.HIGH)
     public void onItemDrag(InventoryDragEvent event) {
-        if (event.getInventory() instanceof GUIInventory<?> inventory) {
-            inventory.onDrag(event);
+        if (event.getInventory().getHolder() instanceof GUIInventoryHolder<?> holder) {
+            holder.onDrag(event);
         }
     }
 
     @EventHandler(priority = EventPriority.HIGH)
     public void onClose(InventoryCloseEvent event) {
-        if (event.getInventory() instanceof GUIInventory<?> inventory) {
-            inventory.onClose(event);
+        if (event.getInventory().getHolder() instanceof GUIInventoryHolder<?> holder) {
+            holder.onClose(event);
         }
     }
 

--- a/core/src/main/java/me/wolfyscript/utilities/api/inventory/gui/GuiUpdate.java
+++ b/core/src/main/java/me/wolfyscript/utilities/api/inventory/gui/GuiUpdate.java
@@ -55,15 +55,15 @@ public class GuiUpdate<C extends CustomCache> {
     private final Inventory queueInventory;
     private final GuiWindow<C> guiWindow;
 
-    GuiUpdate(GUIInventory<C> inventory, GuiHandler<C> guiHandler, GuiWindow<C> guiWindow) {
+    GuiUpdate(GUIInventory<C> guiInventory, GuiHandler<C> guiHandler, GuiWindow<C> guiWindow) {
         this.guiHandler = guiHandler;
         this.inventoryAPI = guiHandler.getInvAPI();
         this.wolfyUtilities = guiHandler.getApi();
         this.player = guiHandler.getPlayer();
         this.guiWindow = guiWindow;
         this.queueInventory = Bukkit.createInventory(null, 54, "");
-        if (inventory != null) {
-            this.inventory = inventory;
+        if (guiInventory != null) {
+            this.inventory = guiInventory.inventory();
         } else {
             String title = BukkitComponentSerializer.legacy().serializeOr(guiWindow.updateTitle(player, null, guiHandler), " ");
             var inventoryHolder = new GUIInventoryHolder<>(guiHandler, guiWindow);
@@ -72,8 +72,9 @@ public class GuiUpdate<C extends CustomCache> {
             } else {
                 this.inventory = Bukkit.createInventory(inventoryHolder, guiWindow.getInventoryType(), title);
             }
+            inventoryHolder.setInventory(this.inventory);
         }
-        this.inventoryDeferrer = new GUIInventoryDeferrer<>(inventory, guiWindow, guiHandler);
+        this.inventoryDeferrer = new GUIInventoryDeferrer<>(this.inventory, guiWindow, guiHandler);
     }
 
     /**

--- a/core/src/main/java/me/wolfyscript/utilities/api/inventory/gui/GuiWindow.java
+++ b/core/src/main/java/me/wolfyscript/utilities/api/inventory/gui/GuiWindow.java
@@ -19,6 +19,7 @@
 package me.wolfyscript.utilities.api.inventory.gui;
 
 import com.wolfyscript.utilities.bukkit.TagResolverUtil;
+import com.wolfyscript.utilities.bukkit.gui.GUIInventoryDeferrer;
 import me.wolfyscript.utilities.api.chat.Chat;
 import me.wolfyscript.utilities.api.chat.ClickAction;
 import me.wolfyscript.utilities.api.chat.ClickData;
@@ -46,6 +47,7 @@ import org.bukkit.entity.Player;
 import org.bukkit.event.Listener;
 import org.bukkit.event.inventory.InventoryInteractEvent;
 import org.bukkit.event.inventory.InventoryType;
+import org.bukkit.inventory.Inventory;
 import org.bukkit.inventory.InventoryView;
 import org.bukkit.permissions.Permission;
 import org.jetbrains.annotations.Nullable;
@@ -486,7 +488,7 @@ public abstract class GuiWindow<C extends CustomCache> extends GuiMenuComponent<
         return wolfyUtilities.getLanguageAPI().getComponent("inventories." + namespacedKey.getNamespace() + "." + namespacedKey.getKey() + ".gui_name", TagResolverUtil.papi(player));
     }
 
-    Component updateTitle(Player player, GUIInventory<C> guiInventory, GuiHandler<C> guiHandler) {
+    Component updateTitle(Player player, Inventory guiInventory, GuiHandler<C> guiHandler) {
         if (useLegacyTitleUpdate) {
             //This window still uses the deprecated update method
             String title = onUpdateTitle(BukkitComponentSerializer.legacy().serialize(getInventoryTitle(player)), null, guiHandler);
@@ -499,7 +501,7 @@ public abstract class GuiWindow<C extends CustomCache> extends GuiMenuComponent<
             }
             return BukkitComponentSerializer.legacy().deserialize(title);
         }
-        return onUpdateTitle(player, guiInventory, guiHandler);
+        return onUpdateTitle(player, new GUIInventoryDeferrer<>(guiInventory, this, guiHandler), guiHandler);
     }
 
     /**

--- a/core/src/main/java/me/wolfyscript/utilities/api/inventory/gui/InventoryAPI.java
+++ b/core/src/main/java/me/wolfyscript/utilities/api/inventory/gui/InventoryAPI.java
@@ -205,8 +205,9 @@ public class InventoryAPI<C extends CustomCache> implements Listener {
         return cluster != null ? cluster.getButton(namespacedKey.getKey()) : null;
     }
 
-    public void onClick(GuiHandler<C> guiHandler, GUIInventory<C> inventory, InventoryClickEvent event) {
-        GuiWindow<C> guiWindow = inventory.getWindow();
+    public void onClick(GuiHandler<C> guiHandler, GUIInventory<C> guiInventory, InventoryClickEvent event) {
+        GuiWindow<C> guiWindow = guiInventory.getWindow();
+        var inventory = guiInventory.inventory();
         event.setCancelled(true);
         if (guiWindow == null) return;
         HashMap<Integer, Button<C>> buttons = new HashMap<>();
@@ -214,7 +215,7 @@ public class InventoryAPI<C extends CustomCache> implements Listener {
             Button<C> clickedBtn = guiHandler.getButton(guiWindow, event.getSlot());
             if (clickedBtn != null) {
                 buttons.put(event.getSlot(), clickedBtn);
-                event.setCancelled(executeButton(clickedBtn, guiHandler, (Player) event.getWhoClicked(), inventory, event.getSlot(), event));
+                event.setCancelled(executeButton(clickedBtn, guiHandler, (Player) event.getWhoClicked(), guiInventory, event.getSlot(), event));
                 if (Objects.equals(clickedBtn.getType(), ButtonType.ITEM_SLOT)) { //If the button is marked as an Item slot it may affect other buttons too!
                     if (event.getAction().equals(InventoryAction.COLLECT_TO_CURSOR) || event.getAction().equals(InventoryAction.MOVE_TO_OTHER_INVENTORY)) {
                         var clickedBtnClass = clickedBtn.getClass();
@@ -223,7 +224,7 @@ public class InventoryAPI<C extends CustomCache> implements Listener {
                                 Button<C> button = guiWindow.getButton(buttonEntry.getValue());
                                 if (clickedBtnClass.isInstance(button)) { //Make sure to only execute the buttons that are of the same type as the clicked one.
                                     buttons.put(buttonEntry.getKey(), button);
-                                    event.setCancelled(executeButton(button, guiHandler, (Player) event.getWhoClicked(), inventory, buttonEntry.getKey(), event));
+                                    event.setCancelled(executeButton(button, guiHandler, (Player) event.getWhoClicked(), guiInventory, buttonEntry.getKey(), event));
                                 }
                             }
                         }
@@ -237,7 +238,7 @@ public class InventoryAPI<C extends CustomCache> implements Listener {
                     Button<C> button = guiWindow.getButton(buttonEntry.getValue());
                     if (button instanceof ItemInputButton) {
                         buttons.put(buttonEntry.getKey(), button);
-                        if (executeButton(button, guiHandler, (Player) event.getWhoClicked(), inventory, buttonEntry.getKey(), event)) {
+                        if (executeButton(button, guiHandler, (Player) event.getWhoClicked(), guiInventory, buttonEntry.getKey(), event)) {
                             event.setCancelled(true);
                             break;
                         }
@@ -248,11 +249,12 @@ public class InventoryAPI<C extends CustomCache> implements Listener {
         if (guiHandler.openedPreviousWindow) {
             guiHandler.openedPreviousWindow = false;
         } else if (guiHandler.getWindow() != null && guiHandler.isWindowOpen()) {
-            guiWindow.update(inventory, buttons, event);
+            guiWindow.update(guiInventory, buttons, event);
         }
     }
 
-    public void onDrag(GuiHandler<C> guiHandler, GUIInventory<C> inventory, InventoryDragEvent event) {
+    public void onDrag(GuiHandler<C> guiHandler, GUIInventory<C> guiInventory, InventoryDragEvent event) {
+        var inventory = guiInventory.inventory();
         if (event.getRawSlots().parallelStream().anyMatch(rawSlot -> !Objects.equals(event.getView().getInventory(rawSlot), inventory))) {
             event.setCancelled(true);
             return;
@@ -269,12 +271,12 @@ public class InventoryAPI<C extends CustomCache> implements Listener {
                 buttons.put(slot, button);
             }
             for (Map.Entry<Integer, Button<C>> button : buttons.entrySet()) {
-                event.setCancelled(executeButton(button.getValue(), guiHandler, (Player) event.getWhoClicked(), inventory, button.getKey(), event));
+                event.setCancelled(executeButton(button.getValue(), guiHandler, (Player) event.getWhoClicked(), guiInventory, button.getKey(), event));
             }
             if (guiHandler.openedPreviousWindow) {
                 guiHandler.openedPreviousWindow = false;
             } else if (guiHandler.getWindow() != null) {
-                guiWindow.update(inventory, buttons, event);
+                guiWindow.update(guiInventory, buttons, event);
             }
         }
     }

--- a/core/src/main/java/me/wolfyscript/utilities/api/nms/InventoryUtil.java
+++ b/core/src/main/java/me/wolfyscript/utilities/api/nms/InventoryUtil.java
@@ -41,21 +41,37 @@ public abstract class InventoryUtil extends UtilComponent {
         super(nmsUtil);
     }
 
+    /**
+     * @deprecated Does not work on Paper and may break on Spigot in later versions than 1.20.4
+     */
+    @Deprecated
     public <C extends CustomCache> GUIInventory<C> createGUIInventory(GuiHandler<C> guiHandler, GuiWindow<C> window, InventoryType type) {
         Inventory inventory = Bukkit.createInventory(null, type);
         return InjectGUIInventory.patchInventory(guiHandler, window, inventory, null);
     }
 
+    /**
+     * @deprecated Does not work on Paper and may break on Spigot in later versions than 1.20.4
+     */
+    @Deprecated
     public <C extends CustomCache> GUIInventory<C> createGUIInventory(GuiHandler<C> guiHandler, GuiWindow<C> window, InventoryType type, String title) {
         Inventory inventory = Bukkit.createInventory(null, type, title);
         return InjectGUIInventory.patchInventory(guiHandler, window, inventory, title);
     }
 
+    /**
+     * @deprecated Does not work on Paper and may break on Spigot in later versions than 1.20.4
+     */
+    @Deprecated
     public <C extends CustomCache> GUIInventory<C> createGUIInventory(GuiHandler<C> guiHandler, GuiWindow<C> window, int size) {
         Inventory inventory = Bukkit.createInventory(null, size);
         return InjectGUIInventory.patchInventory(guiHandler, window, inventory, null);
     }
 
+    /**
+     * @deprecated Does not work on Paper and may break on Spigot in later versions than 1.20.4
+     */
+    @Deprecated
     public <C extends CustomCache> GUIInventory<C> createGUIInventory(GuiHandler<C> guiHandler, GuiWindow<C> window, int size, String title) {
         Inventory inventory = Bukkit.createInventory(null, size, title);
         return InjectGUIInventory.patchInventory(guiHandler, window, inventory, title);

--- a/core/src/main/java/me/wolfyscript/utilities/api/nms/inventory/GUIInventory.java
+++ b/core/src/main/java/me/wolfyscript/utilities/api/nms/inventory/GUIInventory.java
@@ -35,6 +35,7 @@ import org.bukkit.inventory.Inventory;
  *
  * @param <C> The type of {@link CustomCache}
  */
+@Deprecated
 public interface GUIInventory<C extends CustomCache> extends Inventory {
 
     /**
@@ -47,14 +48,17 @@ public interface GUIInventory<C extends CustomCache> extends Inventory {
      */
     GuiHandler<C> getGuiHandler();
 
+    @Deprecated(forRemoval = true)
     default void onClick(InventoryClickEvent event) {
         getGuiHandler().getInvAPI().onClick(getGuiHandler(), this, event);
     }
 
+    @Deprecated(forRemoval = true)
     default void onDrag(InventoryDragEvent event) {
         getGuiHandler().getInvAPI().onDrag(getGuiHandler(), this, event);
     }
 
+    @Deprecated(forRemoval = true)
     default void onClose(InventoryCloseEvent event) {
         getGuiHandler().onClose(this, event);
     }

--- a/core/src/main/java/me/wolfyscript/utilities/api/nms/inventory/GUIInventory.java
+++ b/core/src/main/java/me/wolfyscript/utilities/api/nms/inventory/GUIInventory.java
@@ -48,6 +48,8 @@ public interface GUIInventory<C extends CustomCache> extends Inventory {
      */
     GuiHandler<C> getGuiHandler();
 
+    Inventory inventory();
+
     @Deprecated(forRemoval = true)
     default void onClick(InventoryClickEvent event) {
         getGuiHandler().getInvAPI().onClick(getGuiHandler(), this, event);


### PR DESCRIPTION
The previous GUIInventory was created dynamically via code generation, but that is bound to fail at some point and requires maintenance. In-fact this way of creating the GUIInventory is already broken on paper.

This PR replaces the old system with Spigots InventoryHolder API.
While Spigot seems to discourage the use of InventoryHolders, it also does not provide an alternative. So I am going to use the API to keep track of the GUI anyway.