### PR TITLE
Fix Oraxen StackIdentifier Editing Original Item Amount

### DIFF
--- a/plugin-compatibility/src/main/java/me/wolfyscript/utilities/compatibility/plugins/oraxen/OraxenStackIdentifier.java
+++ b/plugin-compatibility/src/main/java/me/wolfyscript/utilities/compatibility/plugins/oraxen/OraxenStackIdentifier.java
@@ -34,7 +34,9 @@ public class OraxenStackIdentifier implements StackIdentifier {
     @Override
     public ItemStack stack(ItemCreateContext context) {
         if (OraxenItems.exists(itemID)) {
-            return OraxenItems.getItemById(itemID).setAmount(context.amount()).regen().build();
+            ItemStack stack = OraxenItems.getItemById(itemID).build();
+            stack.setAmount(context.amount());
+            return stack;
         }
         return ItemUtils.AIR;
     }


### PR DESCRIPTION
This fixes an issue, where the OraxenStackIdentifier was manipulating the amount of the original Oraxen Item whenever it created a new stack.