### PR TITLE
Fix StackReference Parser Swapping

### DIFF
--- a/core/src/main/java/com/wolfyscript/utilities/bukkit/world/items/reference/StackReference.java
+++ b/core/src/main/java/com/wolfyscript/utilities/bukkit/world/items/reference/StackReference.java
@@ -187,7 +187,7 @@ public class StackReference implements Copyable<StackReference> {
      * @return The current {@link StackIdentifierParser}
      */
     public StackIdentifierParser<?> parser() {
-        if (parser == null) {
+        if (parser == null || !parser.getNamespacedKey().equals(parserKey)) {
             parser = core.getRegistries().getStackIdentifierParsers().get(parserKey);
         }
         return parser;


### PR DESCRIPTION
When selecting a new Parser for a StackReference the new Parser wasn't being used. This fixes that issue.
And the ItemEditor in CustomCrafting works as intended again.