### PR TITLE
Fix CustomItem Replacement & Durability Cost

### DIFF
--- a/core/src/main/java/com/wolfyscript/utilities/bukkit/world/items/reference/StackIdentifier.java
+++ b/core/src/main/java/com/wolfyscript/utilities/bukkit/world/items/reference/StackIdentifier.java
@@ -17,6 +17,7 @@ import org.jetbrains.annotations.Nullable;
 
 import java.util.Optional;
 import java.util.function.BiFunction;
+import java.util.function.Function;
 
 public interface StackIdentifier extends Keyed {
 
@@ -165,6 +166,17 @@ public interface StackIdentifier extends Keyed {
                     }
                     return originalStack;
                 }).orElse(resultStack));
+    }
+
+    default ItemStack shrinkUnstackableItem(ItemStack stack, boolean useRemains, BiFunction<StackIdentifier, ItemStack, Optional<ItemStack>> remainsFunction, Function<ItemStack, ItemStack> manipulator) {
+        return remainsFunction.apply(this, stack)
+                .map(itemStack -> stack(ItemCreateContext.empty(1)))
+                .or(() -> {
+                    if (useRemains) return CustomItem.craftRemain(stack).map(ItemStack::new);
+                    return Optional.empty();
+                })
+                .map(manipulator)
+                .orElse(ItemUtils.AIR);
     }
 
     /**

--- a/core/src/main/java/com/wolfyscript/utilities/bukkit/world/items/reference/StackIdentifier.java
+++ b/core/src/main/java/com/wolfyscript/utilities/bukkit/world/items/reference/StackIdentifier.java
@@ -86,7 +86,7 @@ public interface StackIdentifier extends Keyed {
      * @return The manipulated stack, default remain, or custom remains.
      */
     default ItemStack shrink(@NotNull ItemStack stack, int count, boolean useRemains, @NotNull BiFunction<StackIdentifier, ItemStack, ItemStack> stackReplacement) {
-        if (stack(ItemCreateContext.empty(count)).getMaxStackSize() == 1 && stack.getAmount() == 1) {
+        if (stack.getMaxStackSize() == 1 && stack.getAmount() == 1) {
             return shrinkUnstackableItem(stack, useRemains);
         }
         int amount = stack.getAmount() - count;

--- a/core/src/main/java/com/wolfyscript/utilities/bukkit/world/items/reference/StackReference.java
+++ b/core/src/main/java/com/wolfyscript/utilities/bukkit/world/items/reference/StackReference.java
@@ -26,6 +26,7 @@ import java.io.IOException;
 import java.util.Optional;
 import java.util.function.BiFunction;
 import java.util.function.Consumer;
+import java.util.function.Function;
 
 /**
  * Acts as a wrapper for {@link StackIdentifier}, that links to an external ItemStack (like other Plugins).

--- a/core/src/main/java/com/wolfyscript/utilities/bukkit/world/items/reference/StackReference.java
+++ b/core/src/main/java/com/wolfyscript/utilities/bukkit/world/items/reference/StackReference.java
@@ -306,6 +306,11 @@ public class StackReference implements Copyable<StackReference> {
         return identifier().map(stackIdentifier -> stackIdentifier.shrinkUnstackableItem(stack, useRemains)).orElse(stack);
     }
 
+
+    public ItemStack shrinkUnstackableItem(ItemStack stack, boolean useRemains, BiFunction<StackIdentifier, ItemStack, Optional<ItemStack>> remainsFunction, Function<ItemStack, ItemStack> manipulator) {
+        return identifier().map(stackIdentifier -> stackIdentifier.shrinkUnstackableItem(stack, useRemains, remainsFunction, manipulator)).orElse(stack);
+    }
+
     /**
      * Converts this StackReference into a legacy APIReference.
      */

--- a/core/src/main/java/me/wolfyscript/utilities/api/inventory/custom_items/CustomItem.java
+++ b/core/src/main/java/me/wolfyscript/utilities/api/inventory/custom_items/CustomItem.java
@@ -1055,7 +1055,7 @@ public class CustomItem extends AbstractItemBuilder<CustomItem> implements Keyed
      * @param replacement The new replacement, or null to unset it
      */
     public void replacement(StackReference replacement) {
-        if(replacement != null && replacement.identifier().map(stackIdentifier -> !ItemUtils.isAirOrNull(stackIdentifier.stack(ItemCreateContext.empty(getAmount())))).orElse(false)) {
+        if (replacement != null && replacement.identifier().map(stackIdentifier -> !ItemUtils.isAirOrNull(stackIdentifier.stack(ItemCreateContext.empty(getAmount())))).orElse(false)) {
             this.replacement = replacement;
         } else {
             this.replacement = null;
@@ -1210,36 +1210,7 @@ public class CustomItem extends AbstractItemBuilder<CustomItem> implements Keyed
      * @return The manipulated stack, default remain, or custom remains.
      */
     public ItemStack shrink(ItemStack stack, int count, boolean useRemains, @Nullable final Inventory inventory, @Nullable final Player player, @Nullable final Location location) {
-        return shrink(stack, count, useRemains, (customItem, resultStack) -> {
-            ItemStack replacement = replacement()
-                    .map(StackReference::originalStack)
-                    .orElseGet(() -> isConsumed() && useRemains && craftRemain != null ? new ItemStack(craftRemain) : null);
-            if (!ItemUtils.isAirOrNull(replacement)) {
-                int replacementAmount = replacement.getAmount() * count;
-                if (ItemUtils.isAirOrNull(resultStack)) {
-                    int returnableAmount = Math.min(replacement.getMaxStackSize(), replacementAmount);
-                    replacementAmount -= returnableAmount;
-                    resultStack = replacement.clone();
-                    resultStack.setAmount(replacementAmount);
-                }
-                if (replacementAmount > 0) {
-                    replacement.setAmount(replacementAmount);
-                    Location loc = location;
-                    if (player != null) {
-                        replacement = player.getInventory().addItem(replacement).get(0);
-                        loc = player.getLocation();
-                    }
-                    if (inventory != null && replacement != null) {
-                        replacement = inventory.addItem(replacement).get(0);
-                        if (loc == null) loc = inventory.getLocation();
-                    }
-                    if (loc != null && replacement != null && loc.getWorld() != null) {
-                        loc.getWorld().dropItemNaturally(loc.add(0.5, 1.0, 0.5), replacement);
-                    }
-                }
-            }
-            return resultStack;
-        });
+        return reference.shrink(stack, count, useRemains, inventory, player, location);
     }
 
     /**

--- a/core/src/main/java/me/wolfyscript/utilities/api/inventory/custom_items/CustomItem.java
+++ b/core/src/main/java/me/wolfyscript/utilities/api/inventory/custom_items/CustomItem.java
@@ -1255,19 +1255,15 @@ public class CustomItem extends AbstractItemBuilder<CustomItem> implements Keyed
      * @return The manipulated (damaged) stack, default remain, or custom remains.
      */
     public ItemStack shrinkUnstackableItem(ItemStack stack, boolean useRemains) {
-        ItemStack result = replacement()
-                .map(StackReference::originalStack)
-                .orElseGet(() -> {
-                    if (this.isConsumed() && craftRemain != null && useRemains) {
-                        return new ItemStack(craftRemain);
-                    }
-                    return new ItemStack(Material.AIR);
-                });
-        if (this.getDurabilityCost() != 0) {
+        return reference.shrinkUnstackableItem(stack, useRemains, (stackIdentifier, itemStack) -> replacement().map(StackReference::referencedStack), result -> changeDurability(this, stack, result));
+    }
+
+    public static ItemStack changeDurability(CustomItem customItem, ItemStack stack, ItemStack result) {
+        if (customItem.getDurabilityCost() != 0) {
             // handle custom durability
             var itemBuilder = new ItemBuilder(stack);
             if (itemBuilder.hasCustomDurability()) {
-                int damage = itemBuilder.getCustomDamage() + this.getDurabilityCost();
+                int damage = itemBuilder.getCustomDamage() + customItem.getDurabilityCost();
                 if (damage > itemBuilder.getCustomDurability()) {
                     return result;
                 }
@@ -1276,8 +1272,8 @@ public class CustomItem extends AbstractItemBuilder<CustomItem> implements Keyed
             }
             // handle vanilla durability
             if (stack.getItemMeta() instanceof Damageable itemMeta) {
-                int damage = itemMeta.getDamage() + this.getDurabilityCost();
-                if (damage > type.getMaxDurability()) {
+                int damage = itemMeta.getDamage() + customItem.getDurabilityCost();
+                if (damage > customItem.type.getMaxDurability()) {
                     return result;
                 }
                 itemMeta.setDamage(damage);


### PR DESCRIPTION
This PR adds missing the functionality to make the CustomItem Replacement and Durability Cost to work inside recipes again.