### PR TITLE
Migrate Publishing Repo To Artifactory

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -2,9 +2,9 @@ import com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar
 
 plugins {
     id("com.wolfyscript.wolfyutils.spigot.java-conventions")
-    id("com.github.johnrengelman.shadow") version ("8.1.1")
-    id("com.wolfyscript.devtools.docker.run") version ("2.0-SNAPSHOT")
-    id("com.wolfyscript.devtools.docker.minecraft_servers") version ("2.0-SNAPSHOT")
+    id("com.github.johnrengelman.shadow") version "8.1.1"
+    id("com.wolfyscript.devtools.docker.run") version "2.0-SNAPSHOT"
+    id("com.wolfyscript.devtools.docker.minecraft_servers") version "2.0-SNAPSHOT"
 }
 
 description = "wolfyutils-spigot"
@@ -126,4 +126,23 @@ tasks.named<ShadowJar>("shadowJar") {
 
 tasks.named("test") {
     dependsOn.add(tasks.named("shadowJar"))
+}
+
+artifactory {
+
+    publish {
+        contextUrl = "https://artifacts.wolfyscript.com/artifactory"
+        repository {
+            repoKey = "gradle-dev-local"
+            username = project.properties["wolfyRepoPublishUsername"].toString()
+            password = project.properties["wolfyRepoPublishToken"].toString()
+        }
+        defaults {
+            publications("lib")
+            setPublishArtifacts(true)
+            setPublishPom(true)
+            isPublishBuildInfo = false
+        }
+    }
+
 }

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -9,6 +9,10 @@ repositories {
     mavenCentral()
 }
 
+dependencies {
+    implementation("org.jfrog.buildinfo:build-info-extractor-gradle:5.2.0")
+}
+
 gradlePlugin {
 
 }

--- a/buildSrc/src/main/kotlin/com.wolfyscript.wolfyutils.spigot.java-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/com.wolfyscript.wolfyutils.spigot.java-conventions.gradle.kts
@@ -1,17 +1,19 @@
 plugins {
     `java-library`
     `maven-publish`
+    id("com.jfrog.artifactory")
 }
 
 repositories {
     mavenLocal()
     mavenCentral()
-    maven {
-        url = uri("https://maven.enginehub.org/repo/")
+
+    maven{
+        url = uri("https://artifacts.wolfyscript.com/artifactory/gradle-dev-local")
     }
 
     maven {
-        url = uri("https://maven.wolfyscript.com/repository/public/")
+        url = uri("https://maven.enginehub.org/repo/")
     }
 
     maven {
@@ -58,13 +60,7 @@ publishing {
     publications {
         create<MavenPublication>("lib") {
             from(components.getByName("java"))
-        }
-    }
-    repositories {
-        maven {
-            name = "wolfyRepo"
-            credentials(PasswordCredentials::class)
-            url = uri("https://maven.wolfyscript.com/repository/${if (project.version.toString().endsWith("-SNAPSHOT")) "snapshots" else "releases"}/")
+            artifact(file("$rootDir/gradle.properties"))
         }
     }
 }

--- a/buildSrc/src/main/kotlin/com.wolfyscript.wolfyutils.spigot.java-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/com.wolfyscript.wolfyutils.spigot.java-conventions.gradle.kts
@@ -8,29 +8,16 @@ repositories {
     mavenLocal()
     mavenCentral()
 
-    maven{
-        url = uri("https://artifacts.wolfyscript.com/artifactory/gradle-dev-local")
-    }
+    maven(url = "https://artifacts.wolfyscript.com/artifactory/gradle-dev")
 
-    maven {
-        url = uri("https://maven.enginehub.org/repo/")
-    }
-
-    maven {
-        url = uri("https://repo.maven.apache.org/maven2/")
-    }
-
-    maven {
-        url = uri("https://jitpack.io")
-    }
-
-    maven {
-        url = uri("https://repo.citizensnpcs.co")
-    }
-
-    maven {
-        url = uri("https://nexus.phoenixdevt.fr/repository/maven-public/")
-    }
+    maven(url = "https://repo.codemc.io/repository/maven-public/")
+    maven(url = "https://maven.enginehub.org/repo/")
+    maven(url = "https://repo.maven.apache.org/maven2/")
+    maven(url = "https://jitpack.io")
+    maven(url = "https://repo.citizensnpcs.co")
+    maven(url = "https://nexus.phoenixdevt.fr/repository/maven-public/")
+    maven(url = "https://repo.extendedclip.com/content/repositories/placeholderapi/")
+    maven(url = "https://libraries.minecraft.net/")
 }
 
 java {

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,2 @@
 group=com.wolfyscript.wolfyutils.spigot
-version=4.16.15.1
+version=4.17-SNAPSHOT

--- a/nmsutil/build.gradle.kts
+++ b/nmsutil/build.gradle.kts
@@ -1,4 +1,5 @@
 import com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar
+import org.jfrog.gradle.plugin.artifactory.task.ArtifactoryTask
 
 plugins {
     id("com.wolfyscript.wolfyutils.spigot.java-conventions")
@@ -22,6 +23,13 @@ dependencies {
     compileOnly("net.kyori:adventure-api:4.14.0")
     compileOnly("net.kyori:adventure-platform-bukkit:4.1.2")
     compileOnly("net.kyori:adventure-text-minimessage:4.14.0")
+}
+
+subprojects.forEach {
+    // Do not publish all the version specific subprojects!
+    it.tasks.withType<ArtifactoryTask> {
+        skip = true
+    }
 }
 
 tasks {


### PR DESCRIPTION
This moves the repository on which WolfyUtils artifacts are stored to the new https://artifacts.wolfyscript.com repo.
Artifactory provides a better Web UI, better integration with gradle, and better security than Nexus.