### PR TITLE
Improved StackReference Serialization

### DIFF
--- a/core/src/main/java/com/wolfyscript/utilities/bukkit/registry/RegistryStackIdentifierParsers.java
+++ b/core/src/main/java/com/wolfyscript/utilities/bukkit/registry/RegistryStackIdentifierParsers.java
@@ -58,7 +58,7 @@ public class RegistryStackIdentifierParsers extends RegistrySimple<StackIdentifi
      */
     public Optional<StackReference> parseFrom(ItemStack stack) {
         if (stack == null) return Optional.empty();
-        return Optional.of(new StackReference(registries.getCore(), parseIdentifier(stack), 1, stack.getAmount(), stack));
+        return Optional.of(new StackReference(registries.getCore(), stack.getAmount(), 1d, parseIdentifier(stack), stack));
     }
 
     private void reIndexParsers() {

--- a/core/src/main/java/com/wolfyscript/utilities/bukkit/world/items/reference/BukkitStackIdentifier.java
+++ b/core/src/main/java/com/wolfyscript/utilities/bukkit/world/items/reference/BukkitStackIdentifier.java
@@ -1,5 +1,8 @@
 package com.wolfyscript.utilities.bukkit.world.items.reference;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonGetter;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.wolfyscript.utilities.KeyedStaticId;
 import me.wolfyscript.utilities.util.NamespacedKey;
 import net.kyori.adventure.text.Component;
@@ -18,10 +21,12 @@ public class BukkitStackIdentifier implements StackIdentifier {
 
     private final ItemStack stack;
 
-    public BukkitStackIdentifier(ItemStack stack) {
+    @JsonCreator
+    public BukkitStackIdentifier(@JsonProperty("stack") ItemStack stack) {
         this.stack = stack;
     }
 
+    @JsonGetter("stack")
     public ItemStack stack() {
         return stack;
     }

--- a/core/src/main/java/com/wolfyscript/utilities/bukkit/world/items/reference/BukkitStackIdentifier.java
+++ b/core/src/main/java/com/wolfyscript/utilities/bukkit/world/items/reference/BukkitStackIdentifier.java
@@ -1,5 +1,6 @@
 package com.wolfyscript.utilities.bukkit.world.items.reference;
 
+import com.wolfyscript.utilities.KeyedStaticId;
 import me.wolfyscript.utilities.util.NamespacedKey;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.format.NamedTextColor;
@@ -10,6 +11,7 @@ import org.bukkit.inventory.ItemStack;
 import java.util.Objects;
 import java.util.Optional;
 
+@KeyedStaticId(key = "bukkit")
 public class BukkitStackIdentifier implements StackIdentifier {
 
     public static final NamespacedKey ID = NamespacedKey.wolfyutilties("bukkit");

--- a/core/src/main/java/com/wolfyscript/utilities/bukkit/world/items/reference/LegacyStackReference.java
+++ b/core/src/main/java/com/wolfyscript/utilities/bukkit/world/items/reference/LegacyStackReference.java
@@ -14,7 +14,7 @@ public class LegacyStackReference extends StackReference {
     private final JsonNode data;
 
     public LegacyStackReference(WolfyUtilCore core, NamespacedKey parserKey, double weight, int amount, JsonNode data) {
-        super(core, parserKey, weight, amount, null);
+        super(core, amount, weight, parserKey, null);
         this.data = data;
     }
 
@@ -31,11 +31,11 @@ public class LegacyStackReference extends StackReference {
     }
 
     @Override
-    protected StackIdentifier parseIdentifier() {
+    protected StackIdentifier getOrParseIdentifier() {
         if (identifier != null) return identifier;
         if (parser() instanceof LegacyParser<?> legacyParser) {
             return legacyParser.from(data).orElse(null);
         }
-        return super.parseIdentifier();
+        return super.getOrParseIdentifier();
     }
 }

--- a/core/src/main/java/com/wolfyscript/utilities/bukkit/world/items/reference/StackIdentifier.java
+++ b/core/src/main/java/com/wolfyscript/utilities/bukkit/world/items/reference/StackIdentifier.java
@@ -1,5 +1,11 @@
 package com.wolfyscript.utilities.bukkit.world.items.reference;
 
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonGetter;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import com.fasterxml.jackson.databind.annotation.JsonTypeIdResolver;
+import com.fasterxml.jackson.databind.annotation.JsonTypeResolver;
 import me.wolfyscript.utilities.api.WolfyUtilCore;
 import me.wolfyscript.utilities.api.inventory.custom_items.CustomItem;
 import me.wolfyscript.utilities.api.inventory.custom_items.references.APIReference;
@@ -7,6 +13,8 @@ import me.wolfyscript.utilities.api.inventory.custom_items.references.VanillaRef
 import me.wolfyscript.utilities.util.Keyed;
 import me.wolfyscript.utilities.util.NamespacedKey;
 import me.wolfyscript.utilities.util.inventory.ItemUtils;
+import me.wolfyscript.utilities.util.json.jackson.KeyedTypeIdResolver;
+import me.wolfyscript.utilities.util.json.jackson.KeyedTypeResolver;
 import org.bukkit.Location;
 import org.bukkit.Material;
 import org.bukkit.entity.Player;
@@ -19,6 +27,11 @@ import java.util.Optional;
 import java.util.function.BiFunction;
 import java.util.function.Function;
 
+@JsonTypeResolver(KeyedTypeResolver.class)
+@JsonTypeIdResolver(KeyedTypeIdResolver.class)
+@JsonTypeInfo(use = JsonTypeInfo.Id.CUSTOM, property = "key")
+@JsonAutoDetect(fieldVisibility = JsonAutoDetect.Visibility.ANY)
+@JsonPropertyOrder(value = {"key"})
 public interface StackIdentifier extends Keyed {
 
     /**
@@ -221,6 +234,7 @@ public interface StackIdentifier extends Keyed {
         return WolfyUtilCore.getInstance().getRegistries().getStackIdentifierParsers().get(getNamespacedKey());
     }
 
+    @JsonGetter("key")
     @Override
     NamespacedKey getNamespacedKey();
 

--- a/core/src/main/java/com/wolfyscript/utilities/bukkit/world/items/reference/StackIdentifier.java
+++ b/core/src/main/java/com/wolfyscript/utilities/bukkit/world/items/reference/StackIdentifier.java
@@ -1,9 +1,6 @@
 package com.wolfyscript.utilities.bukkit.world.items.reference;
 
-import com.fasterxml.jackson.annotation.JsonAutoDetect;
-import com.fasterxml.jackson.annotation.JsonGetter;
-import com.fasterxml.jackson.annotation.JsonPropertyOrder;
-import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import com.fasterxml.jackson.annotation.*;
 import com.fasterxml.jackson.databind.annotation.JsonTypeIdResolver;
 import com.fasterxml.jackson.databind.annotation.JsonTypeResolver;
 import me.wolfyscript.utilities.api.WolfyUtilCore;
@@ -234,7 +231,8 @@ public interface StackIdentifier extends Keyed {
         return WolfyUtilCore.getInstance().getRegistries().getStackIdentifierParsers().get(getNamespacedKey());
     }
 
-    @JsonGetter("key")
+    @JsonProperty("key")
+    @JsonIgnore // Required to not include it twice in the config
     @Override
     NamespacedKey getNamespacedKey();
 

--- a/core/src/main/java/com/wolfyscript/utilities/bukkit/world/items/reference/StackReference.java
+++ b/core/src/main/java/com/wolfyscript/utilities/bukkit/world/items/reference/StackReference.java
@@ -72,7 +72,7 @@ public class StackReference implements Copyable<StackReference> {
         this.identifier = identifier;
         this.parser = identifier.parser();
         this.parserKey = parser.getNamespacedKey();
-        this.stack = itemStack == null ? referencedStack() : itemStack;
+        this.stack = itemStack;
     }
 
     public StackReference(@NotNull WolfyUtilCore core, int amount, double weight, @NotNull NamespacedKey parserKey, @Nullable ItemStack item) {
@@ -80,8 +80,8 @@ public class StackReference implements Copyable<StackReference> {
         this.weight = weight;
         this.core = core;
         this.parserKey = parserKey;
+        this.stack = item; // Set item before parsing it
         this.identifier = getOrParseIdentifier();
-        this.stack = item == null ? referencedStack() : item;
     }
 
     private StackReference(StackReference stackReference) {
@@ -360,6 +360,9 @@ public class StackReference implements Copyable<StackReference> {
                 if (hasIdentifier) {
                     // Identifier is defined, use defined identifier
                     var identifier = ctxt.readTreeAsValue(root.get("identifier"), StackIdentifier.class);
+                    if (originalStack == null) {
+                        originalStack = identifier.stack(ItemCreateContext.empty(1));
+                    }
                     return new StackReference(core, amount, weight, identifier, originalStack);
                 }
 

--- a/core/src/main/java/com/wolfyscript/utilities/bukkit/world/items/reference/StackReference.java
+++ b/core/src/main/java/com/wolfyscript/utilities/bukkit/world/items/reference/StackReference.java
@@ -33,8 +33,6 @@ import java.util.function.Function;
  * Acts as a wrapper for {@link StackIdentifier}, that links to an external ItemStack (like other Plugins).
  * This keeps track of the original ItemStack, as a fallback, and the parser used to get the wrapped {@link StackIdentifier}.
  * Additionally, it stores the amount, and other extra settings.
- * <br>
- * This is usually stored in JSON (HOCON) files, while the {@link StackIdentifier} is not.
  */
 @JsonDeserialize(using = StackReference.Deserializer.class)
 public class StackReference implements Copyable<StackReference> {
@@ -211,16 +209,6 @@ public class StackReference implements Copyable<StackReference> {
     @JsonGetter("amount")
     public int amount() {
         return amount;
-    }
-
-    /**
-     * Gets the id of the current parser
-     *
-     * @return The id of the current parser
-     */
-    @JsonGetter("parser")
-    private NamespacedKey parserId() {
-        return parserKey;
     }
 
     @Override

--- a/core/src/main/java/com/wolfyscript/utilities/bukkit/world/items/reference/WolfyUtilsStackIdentifier.java
+++ b/core/src/main/java/com/wolfyscript/utilities/bukkit/world/items/reference/WolfyUtilsStackIdentifier.java
@@ -1,5 +1,8 @@
 package com.wolfyscript.utilities.bukkit.world.items.reference;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonGetter;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.wolfyscript.utilities.KeyedStaticId;
 import me.wolfyscript.utilities.api.WolfyUtilCore;
 import me.wolfyscript.utilities.api.WolfyUtilities;
@@ -21,14 +24,16 @@ public class WolfyUtilsStackIdentifier implements StackIdentifier {
     private static final org.bukkit.NamespacedKey CUSTOM_ITEM_KEY = new org.bukkit.NamespacedKey(WolfyUtilities.getWUPlugin(), "custom_item");
     public static final NamespacedKey ID = NamespacedKey.wolfyutilties("wolfyutils");
 
-    private final NamespacedKey namespacedKey;
+    private final NamespacedKey itemKey;
 
-    public WolfyUtilsStackIdentifier(NamespacedKey namespacedKey) {
-        this.namespacedKey = namespacedKey;
+    @JsonCreator
+    public WolfyUtilsStackIdentifier(@JsonProperty("item") NamespacedKey itemKey) {
+        this.itemKey = itemKey;
     }
 
+    @JsonGetter("item")
     public NamespacedKey itemKey() {
-        return namespacedKey;
+        return itemKey;
     }
 
     /**
@@ -40,7 +45,7 @@ public class WolfyUtilsStackIdentifier implements StackIdentifier {
     @Override
     public ItemStack stack(ItemCreateContext context) {
         return customItem().map(customItem -> customItem.create(context.amount())).orElseGet(() -> {
-            WolfyUtilities.getWUCore().getConsole().warn("Couldn't find CustomItem for " + namespacedKey.toString());
+            WolfyUtilities.getWUCore().getConsole().warn("Couldn't find CustomItem for " + itemKey.toString());
             return null;
         });
     }
@@ -51,7 +56,7 @@ public class WolfyUtilsStackIdentifier implements StackIdentifier {
      * @return The referenced {@link CustomItem} of this identifier
      */
     public Optional<CustomItem> customItem() {
-        return Optional.ofNullable(WolfyUtilCore.getInstance().getRegistries().getCustomItems().get(namespacedKey));
+        return Optional.ofNullable(WolfyUtilCore.getInstance().getRegistries().getCustomItems().get(itemKey));
     }
 
     @Override
@@ -61,7 +66,7 @@ public class WolfyUtilsStackIdentifier implements StackIdentifier {
         if (itemMeta == null) return false;
         var container = itemMeta.getPersistentDataContainer();
         if (container.has(CUSTOM_ITEM_KEY, PersistentDataType.STRING)) {
-            return Objects.equals(this.namespacedKey, NamespacedKey.of(container.get(CUSTOM_ITEM_KEY, PersistentDataType.STRING)));
+            return Objects.equals(this.itemKey, NamespacedKey.of(container.get(CUSTOM_ITEM_KEY, PersistentDataType.STRING)));
         }
         return false;
     }

--- a/core/src/main/java/com/wolfyscript/utilities/bukkit/world/items/reference/WolfyUtilsStackIdentifier.java
+++ b/core/src/main/java/com/wolfyscript/utilities/bukkit/world/items/reference/WolfyUtilsStackIdentifier.java
@@ -1,5 +1,6 @@
 package com.wolfyscript.utilities.bukkit.world.items.reference;
 
+import com.wolfyscript.utilities.KeyedStaticId;
 import me.wolfyscript.utilities.api.WolfyUtilCore;
 import me.wolfyscript.utilities.api.WolfyUtilities;
 import me.wolfyscript.utilities.api.inventory.custom_items.CustomItem;
@@ -14,6 +15,7 @@ import org.bukkit.persistence.PersistentDataType;
 import java.util.Objects;
 import java.util.Optional;
 
+@KeyedStaticId(key = "wolfyutils")
 public class WolfyUtilsStackIdentifier implements StackIdentifier {
 
     private static final org.bukkit.NamespacedKey CUSTOM_ITEM_KEY = new org.bukkit.NamespacedKey(WolfyUtilities.getWUPlugin(), "custom_item");

--- a/core/src/main/java/me/wolfyscript/utilities/api/WolfyUtilCore.java
+++ b/core/src/main/java/me/wolfyscript/utilities/api/WolfyUtilCore.java
@@ -39,6 +39,7 @@ import com.wolfyscript.utilities.bukkit.persistent.player.CustomPlayerData;
 import com.wolfyscript.utilities.bukkit.persistent.player.PlayerParticleEffectData;
 import com.wolfyscript.utilities.bukkit.persistent.world.CustomBlockData;
 import com.wolfyscript.utilities.bukkit.world.items.reference.BukkitStackIdentifier;
+import com.wolfyscript.utilities.bukkit.world.items.reference.StackIdentifier;
 import com.wolfyscript.utilities.bukkit.world.items.reference.WolfyUtilsStackIdentifier;
 import com.wolfyscript.utilities.common.WolfyCore;
 import com.wolfyscript.utilities.bukkit.commands.ChatActionCommand;
@@ -383,6 +384,7 @@ public abstract class WolfyUtilCore extends JavaPlugin implements WolfyCore {
         nbtQueryNodes.register(QueryNodeListCompound.TYPE, QueryNodeListCompound.class);
 
         // Register the Registries to resolve type references in JSON
+        KeyedTypeIdResolver.registerTypeRegistry(StackIdentifier.class, registries.getStackIdentifierTypeRegistry());
         KeyedTypeIdResolver.registerTypeRegistry(CustomItemData.class, registries.getCustomItemDataTypeRegistry());
         KeyedTypeIdResolver.registerTypeRegistry(Meta.class, nbtChecks);
         KeyedTypeIdResolver.registerTypeRegistry(Animator.class, particleAnimators);

--- a/core/src/main/java/me/wolfyscript/utilities/api/WolfyUtilCore.java
+++ b/core/src/main/java/me/wolfyscript/utilities/api/WolfyUtilCore.java
@@ -269,6 +269,10 @@ public abstract class WolfyUtilCore extends JavaPlugin implements WolfyCore {
         // Create Global WUCore Mapper and apply modules
         api.getJacksonMapperUtil().setGlobalMapper(applyWolfyUtilsJsonMapperModules(new HoconMapper()));
 
+        var stackIdentifiers = getRegistries().getStackIdentifierTypeRegistry();
+        stackIdentifiers.register(BukkitStackIdentifier.class);
+        stackIdentifiers.register(WolfyUtilsStackIdentifier.class);
+
         // Initialise all the Registers
         getLogger().info("Register JSON Operators");
         var operators = getRegistries().getOperators();

--- a/core/src/main/java/me/wolfyscript/utilities/api/inventory/custom_items/CustomItem.java
+++ b/core/src/main/java/me/wolfyscript/utilities/api/inventory/custom_items/CustomItem.java
@@ -228,7 +228,7 @@ public class CustomItem extends AbstractItemBuilder<CustomItem> implements Keyed
      * @param itemStack the itemstack this CustomItem will be linked to
      */
     public CustomItem(ItemStack itemStack) {
-        this(new StackReference(WolfyUtilCore.getInstance(), BukkitStackIdentifier.ID, 1, 1, itemStack));
+        this(new StackReference(WolfyUtilCore.getInstance(), 1, 1, BukkitStackIdentifier.ID, itemStack));
     }
 
     /**
@@ -358,12 +358,12 @@ public class CustomItem extends AbstractItemBuilder<CustomItem> implements Keyed
         if (itemStack != null) {
             WolfyUtilCore core = WolfyUtilCore.getInstance();
             StackReference reference = new StackReference(
-                    core,
-                    core.getRegistries().getStackIdentifierParsers().parseIdentifier(itemStack),
-                    1d,
+                                core,
                     itemStack.getAmount(),
-                    itemStack
-            );
+                                1d,
+                    core.getRegistries().getStackIdentifierParsers().parseIdentifier(itemStack),
+                                itemStack
+                        );
             return new CustomItem(reference);
         }
         return null;
@@ -1533,7 +1533,7 @@ public class CustomItem extends AbstractItemBuilder<CustomItem> implements Keyed
     @Deprecated
     public StackReference convertToReference() {
         if (hasNamespacedKey()) {
-            return new StackReference(WolfyUtilCore.getInstance(), new WolfyUtilsStackIdentifier(getNamespacedKey()), getWeight(), getAmount(), getItemStack());
+            return new StackReference(WolfyUtilCore.getInstance(), getAmount(), getWeight(), new WolfyUtilsStackIdentifier(getNamespacedKey()), getItemStack());
         }
         return reference;
     }

--- a/core/src/main/java/me/wolfyscript/utilities/api/inventory/custom_items/references/APIReference.java
+++ b/core/src/main/java/me/wolfyscript/utilities/api/inventory/custom_items/references/APIReference.java
@@ -161,7 +161,7 @@ public abstract class APIReference {
      */
     public final StackReference convertToStackReference() {
         StackIdentifier identifier = convert();
-        return new StackReference(WolfyUtilCore.getInstance(), identifier, weight, amount, identifier.stack(ItemCreateContext.empty(amount)));
+        return new StackReference(WolfyUtilCore.getInstance(), amount, weight, identifier, identifier.stack(ItemCreateContext.empty(amount)));
     }
 
     /**

--- a/core/src/main/java/me/wolfyscript/utilities/compatibility/plugins/ExecutableBlocksIntegration.java
+++ b/core/src/main/java/me/wolfyscript/utilities/compatibility/plugins/ExecutableBlocksIntegration.java
@@ -3,10 +3,12 @@ package me.wolfyscript.utilities.compatibility.plugins;
 import java.util.List;
 import java.util.Locale;
 import java.util.Optional;
+
+import me.wolfyscript.utilities.compatibility.PluginIntegration;
 import org.bukkit.NamespacedKey;
 import org.bukkit.inventory.ItemStack;
 
-public interface ExecutableBlocksIntegration {
+public interface ExecutableBlocksIntegration extends PluginIntegration {
 
     String PLUGIN_NAME = "ExecutableBlocks";
     NamespacedKey BLOCK_ID = new NamespacedKey(PLUGIN_NAME.toLowerCase(Locale.ROOT), "eb-id");

--- a/core/src/main/java/me/wolfyscript/utilities/registry/AbstractTypeRegistry.java
+++ b/core/src/main/java/me/wolfyscript/utilities/registry/AbstractTypeRegistry.java
@@ -67,7 +67,7 @@ public abstract class AbstractTypeRegistry<M extends Map<NamespacedKey, Class<? 
     public void register(Class<? extends V> value) {
         KeyedStaticId staticIdAnnot = value.getAnnotation(KeyedStaticId.class);
         Preconditions.checkArgument(staticIdAnnot != null, "Value does not specify static id via the KeyedStaticId annotation!");
-        NamespacedKey id = NamespacedKey.of(staticIdAnnot.value());
+        NamespacedKey id = NamespacedKey.of(KeyedStaticId.KeyBuilder.createKeyString(value));
         register(id, value);
     }
 

--- a/core/src/main/java/me/wolfyscript/utilities/registry/Registries.java
+++ b/core/src/main/java/me/wolfyscript/utilities/registry/Registries.java
@@ -24,7 +24,7 @@ import com.wolfyscript.utilities.bukkit.nbt.QueryNode;
 import com.wolfyscript.utilities.bukkit.persistent.player.CustomPlayerData;
 import com.wolfyscript.utilities.bukkit.persistent.world.CustomBlockData;
 import com.wolfyscript.utilities.bukkit.registry.RegistryStackIdentifierParsers;
-import com.wolfyscript.utilities.bukkit.world.items.reference.StackIdentifierParser;
+import com.wolfyscript.utilities.bukkit.world.items.reference.StackIdentifier;
 import me.wolfyscript.utilities.api.WolfyUtilCore;
 import me.wolfyscript.utilities.api.WolfyUtilities;
 import me.wolfyscript.utilities.api.inventory.custom_items.CustomData;
@@ -96,6 +96,7 @@ public class Registries {
     private final TypeRegistry<CustomBlockData> customBlockData;
     private final TypeRegistry<CustomPlayerData> customPlayerData;
     private final TypeRegistry<CustomItemData> customItemDataTypeRegistry;
+    private final TypeRegistry<StackIdentifier> stackIdentifierTypeRegistry;
 
     private final TypeRegistry<ValueProvider<?>> valueProviders;
     private final TypeRegistry<Operator> operators;
@@ -122,6 +123,9 @@ public class Registries {
         customItemDataTypeRegistry = new UniqueTypeRegistrySimple<>(ITEM_CUSTOM_DATA, this);
         customItemActions = new UniqueTypeRegistrySimple<>(ITEM_ACTION_TYPES, this);
         customItemEvents = new UniqueTypeRegistrySimple<>(ITEM_EVENT_TYPES, this);
+
+        stackIdentifierTypeRegistry = new UniqueTypeRegistrySimple<>(new NamespacedKey(core, "stack_identifier/types"), this);
+
         valueProviders = new UniqueTypeRegistrySimple<>(new NamespacedKey(core, "value_providers"), this);
         operators = new UniqueTypeRegistrySimple<>(new NamespacedKey(core, "operators"), this);
 
@@ -286,5 +290,9 @@ public class Registries {
 
     public RegistryStackIdentifierParsers getStackIdentifierParsers() {
         return stackIdentifierParsers;
+    }
+
+    public TypeRegistry<StackIdentifier> getStackIdentifierTypeRegistry() {
+        return stackIdentifierTypeRegistry;
     }
 }

--- a/plugin-compatibility/src/main/java/me/wolfyscript/utilities/compatibility/plugins/DenizenIntegrationImpl.java
+++ b/plugin-compatibility/src/main/java/me/wolfyscript/utilities/compatibility/plugins/DenizenIntegrationImpl.java
@@ -31,6 +31,7 @@ public class DenizenIntegrationImpl extends PluginIntegrationAbstract {
     public void init(Plugin plugin) {
         core.registerAPIReference(new DenizenRefImpl.Parser());
         core.getRegistries().getStackIdentifierParsers().register(new DenizenStackIdentifier.Parser());
+        core.getRegistries().getStackIdentifierTypeRegistry().register(DenizenStackIdentifier.class);
     }
 
     @Override

--- a/plugin-compatibility/src/main/java/me/wolfyscript/utilities/compatibility/plugins/EcoIntegrationImpl.java
+++ b/plugin-compatibility/src/main/java/me/wolfyscript/utilities/compatibility/plugins/EcoIntegrationImpl.java
@@ -47,6 +47,7 @@ public class EcoIntegrationImpl extends PluginIntegrationAbstract implements Eco
     public void init(Plugin plugin) {
         core.registerAPIReference(new EcoRefImpl.Parser());
         core.getRegistries().getStackIdentifierParsers().register(new EcoStackIdentifier.Parser());
+        core.getRegistries().getStackIdentifierTypeRegistry().register(EcoStackIdentifier.class);
     }
 
     @Override

--- a/plugin-compatibility/src/main/java/me/wolfyscript/utilities/compatibility/plugins/ExecutableItemsImpl.java
+++ b/plugin-compatibility/src/main/java/me/wolfyscript/utilities/compatibility/plugins/ExecutableItemsImpl.java
@@ -32,6 +32,7 @@ public class ExecutableItemsImpl extends PluginIntegrationAbstract implements Ex
     public void init(Plugin plugin) {
         core.registerAPIReference(new ExecutableItemsRef.Parser(ExecutableItemsAPI.getExecutableItemsManager()));
         core.getRegistries().getStackIdentifierParsers().register(new ExecutableItemsStackIdentifier.Parser(ExecutableItemsAPI.getExecutableItemsManager()));
+        core.getRegistries().getStackIdentifierTypeRegistry().register(ExecutableItemsStackIdentifier.class);
     }
 
     @Override

--- a/plugin-compatibility/src/main/java/me/wolfyscript/utilities/compatibility/plugins/FancyBagsImpl.java
+++ b/plugin-compatibility/src/main/java/me/wolfyscript/utilities/compatibility/plugins/FancyBagsImpl.java
@@ -25,6 +25,7 @@ public class FancyBagsImpl extends PluginIntegrationAbstract {
     public void init(Plugin plugin) {
         core.registerAPIReference(new FancyBagsItemsRef.Parser());
         core.getRegistries().getStackIdentifierParsers().register(new FancyBagsStackIdentifier.Parser());
+        core.getRegistries().getStackIdentifierTypeRegistry().register(FancyBagsStackIdentifier.class);
     }
 
     @Override

--- a/plugin-compatibility/src/main/java/me/wolfyscript/utilities/compatibility/plugins/ItemsAdderImpl.java
+++ b/plugin-compatibility/src/main/java/me/wolfyscript/utilities/compatibility/plugins/ItemsAdderImpl.java
@@ -44,6 +44,7 @@ public class ItemsAdderImpl extends PluginIntegrationAbstract implements ItemsAd
     public void init(Plugin plugin) {
         core.registerAPIReference(new ItemsAdderRefImpl.Parser());
         core.getRegistries().getStackIdentifierParsers().register(new ItemsAdderStackIdentifier.Parser());
+        core.getRegistries().getStackIdentifierTypeRegistry().register(ItemsAdderStackIdentifier.class);
         Bukkit.getPluginManager().registerEvents(this, core);
         Bukkit.getPluginManager().registerEvents(new CustomItemListener(this), core);
     }

--- a/plugin-compatibility/src/main/java/me/wolfyscript/utilities/compatibility/plugins/MMOItemsImpl.java
+++ b/plugin-compatibility/src/main/java/me/wolfyscript/utilities/compatibility/plugins/MMOItemsImpl.java
@@ -39,6 +39,7 @@ public class MMOItemsImpl extends PluginIntegrationAbstract {
     public void init(Plugin plugin) {
         core.registerAPIReference(new MMOItemsRefImpl.Parser());
         core.getRegistries().getStackIdentifierParsers().register(new MMOItemsStackIdentifier.Parser());
+        core.getRegistries().getStackIdentifierTypeRegistry().register(MMOItemsStackIdentifier.class);
     }
 
     @Override

--- a/plugin-compatibility/src/main/java/me/wolfyscript/utilities/compatibility/plugins/MagicImpl.java
+++ b/plugin-compatibility/src/main/java/me/wolfyscript/utilities/compatibility/plugins/MagicImpl.java
@@ -44,6 +44,7 @@ public class MagicImpl extends PluginIntegrationAbstract implements Listener {
     public void init(Plugin plugin) {
         core.registerAPIReference(new MagicRefImpl.Parser());
         core.getRegistries().getStackIdentifierParsers().register(new MagicStackIdentifier.Parser(Bukkit.getPluginManager().getPlugin("Magic") instanceof MagicAPI magicAPI ? magicAPI : null));
+        core.getRegistries().getStackIdentifierTypeRegistry().register(MagicStackIdentifier.class);
         Bukkit.getPluginManager().registerEvents(this, core);
     }
 

--- a/plugin-compatibility/src/main/java/me/wolfyscript/utilities/compatibility/plugins/MythicMobsImpl.java
+++ b/plugin-compatibility/src/main/java/me/wolfyscript/utilities/compatibility/plugins/MythicMobsImpl.java
@@ -47,6 +47,7 @@ public class MythicMobsImpl extends PluginIntegrationAbstract implements MythicM
             core.registerAPIReference(new MythicMobsRefImpl.Parser());
         }
         core.getRegistries().getStackIdentifierParsers().register(new MythicMobsStackIdentifier.Parser());
+        core.getRegistries().getStackIdentifierTypeRegistry().register(MythicMobsStackIdentifier.class);
     }
 
     @Override

--- a/plugin-compatibility/src/main/java/me/wolfyscript/utilities/compatibility/plugins/denizen/DenizenStackIdentifier.java
+++ b/plugin-compatibility/src/main/java/me/wolfyscript/utilities/compatibility/plugins/denizen/DenizenStackIdentifier.java
@@ -2,6 +2,7 @@ package me.wolfyscript.utilities.compatibility.plugins.denizen;
 
 import com.denizenscript.denizen.scripts.containers.core.ItemScriptHelper;
 import com.fasterxml.jackson.databind.JsonNode;
+import com.wolfyscript.utilities.KeyedStaticId;
 import com.wolfyscript.utilities.bukkit.world.items.reference.ItemCreateContext;
 import com.wolfyscript.utilities.bukkit.world.items.reference.LegacyParser;
 import com.wolfyscript.utilities.bukkit.world.items.reference.StackIdentifier;
@@ -18,6 +19,7 @@ import org.bukkit.inventory.ItemStack;
 import java.util.Objects;
 import java.util.Optional;
 
+@KeyedStaticId(key = "denizen")
 public class DenizenStackIdentifier implements StackIdentifier {
 
     public static final NamespacedKey ID = NamespacedKey.wolfyutilties("denizen");

--- a/plugin-compatibility/src/main/java/me/wolfyscript/utilities/compatibility/plugins/denizen/DenizenStackIdentifier.java
+++ b/plugin-compatibility/src/main/java/me/wolfyscript/utilities/compatibility/plugins/denizen/DenizenStackIdentifier.java
@@ -1,6 +1,9 @@
 package me.wolfyscript.utilities.compatibility.plugins.denizen;
 
 import com.denizenscript.denizen.scripts.containers.core.ItemScriptHelper;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonGetter;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.wolfyscript.utilities.KeyedStaticId;
 import com.wolfyscript.utilities.bukkit.world.items.reference.ItemCreateContext;
@@ -26,9 +29,20 @@ public class DenizenStackIdentifier implements StackIdentifier {
     private final ItemStack displayItem;
     private final String itemScript;
 
-    public DenizenStackIdentifier(ItemStack displayItem, String itemScript) {
+    @JsonCreator
+    public DenizenStackIdentifier(@JsonProperty("displayItem") ItemStack displayItem, @JsonProperty("script") String itemScript) {
         this.displayItem = displayItem;
         this.itemScript = itemScript;
+    }
+
+    @JsonGetter("displayItem")
+    public ItemStack getDisplayItem() {
+        return displayItem;
+    }
+
+    @JsonGetter("script")
+    public String getItemScript() {
+        return itemScript;
     }
 
     @Override

--- a/plugin-compatibility/src/main/java/me/wolfyscript/utilities/compatibility/plugins/eco/EcoStackIdentifier.java
+++ b/plugin-compatibility/src/main/java/me/wolfyscript/utilities/compatibility/plugins/eco/EcoStackIdentifier.java
@@ -2,6 +2,7 @@ package me.wolfyscript.utilities.compatibility.plugins.eco;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.willfp.eco.core.items.Items;
+import com.wolfyscript.utilities.KeyedStaticId;
 import com.wolfyscript.utilities.bukkit.world.items.reference.ItemCreateContext;
 import com.wolfyscript.utilities.bukkit.world.items.reference.LegacyParser;
 import com.wolfyscript.utilities.bukkit.world.items.reference.StackIdentifier;
@@ -17,6 +18,7 @@ import org.bukkit.inventory.ItemStack;
 import java.util.Objects;
 import java.util.Optional;
 
+@KeyedStaticId(key = "eco")
 public class EcoStackIdentifier implements StackIdentifier {
 
     public static final NamespacedKey ID = NamespacedKey.wolfyutilties("eco");

--- a/plugin-compatibility/src/main/java/me/wolfyscript/utilities/compatibility/plugins/eco/EcoStackIdentifier.java
+++ b/plugin-compatibility/src/main/java/me/wolfyscript/utilities/compatibility/plugins/eco/EcoStackIdentifier.java
@@ -1,5 +1,8 @@
 package me.wolfyscript.utilities.compatibility.plugins.eco;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonGetter;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.willfp.eco.core.items.Items;
 import com.wolfyscript.utilities.KeyedStaticId;
@@ -25,8 +28,14 @@ public class EcoStackIdentifier implements StackIdentifier {
 
     private final org.bukkit.NamespacedKey itemKey;
 
-    public EcoStackIdentifier(org.bukkit.NamespacedKey itemKey) {
+    @JsonCreator
+    public EcoStackIdentifier(@JsonProperty("key") org.bukkit.NamespacedKey itemKey) {
         this.itemKey = itemKey;
+    }
+
+    @JsonGetter("key")
+    public org.bukkit.NamespacedKey getItemKey() {
+        return itemKey;
     }
 
     @Override

--- a/plugin-compatibility/src/main/java/me/wolfyscript/utilities/compatibility/plugins/executableblocks/ExecutableBlocksStackIdentifier.java
+++ b/plugin-compatibility/src/main/java/me/wolfyscript/utilities/compatibility/plugins/executableblocks/ExecutableBlocksStackIdentifier.java
@@ -2,6 +2,7 @@ package me.wolfyscript.utilities.compatibility.plugins.executableblocks;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.ssomar.executableblocks.executableblocks.ExecutableBlocksManager;
+import com.wolfyscript.utilities.KeyedStaticId;
 import com.wolfyscript.utilities.bukkit.world.items.reference.ItemCreateContext;
 import com.wolfyscript.utilities.bukkit.world.items.reference.LegacyParser;
 import com.wolfyscript.utilities.bukkit.world.items.reference.StackIdentifier;
@@ -14,6 +15,7 @@ import org.bukkit.inventory.ItemStack;
 
 import java.util.Optional;
 
+@KeyedStaticId(key = "executableblocks")
 public class ExecutableBlocksStackIdentifier implements StackIdentifier {
 
     public static final NamespacedKey ID = NamespacedKey.wolfyutilties("executableblocks");

--- a/plugin-compatibility/src/main/java/me/wolfyscript/utilities/compatibility/plugins/executableblocks/ExecutableBlocksStackIdentifier.java
+++ b/plugin-compatibility/src/main/java/me/wolfyscript/utilities/compatibility/plugins/executableblocks/ExecutableBlocksStackIdentifier.java
@@ -1,8 +1,12 @@
 package me.wolfyscript.utilities.compatibility.plugins.executableblocks;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonGetter;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.ssomar.executableblocks.executableblocks.ExecutableBlocksManager;
 import com.wolfyscript.utilities.KeyedStaticId;
+import com.wolfyscript.utilities.bukkit.WolfyCoreBukkit;
 import com.wolfyscript.utilities.bukkit.world.items.reference.ItemCreateContext;
 import com.wolfyscript.utilities.bukkit.world.items.reference.LegacyParser;
 import com.wolfyscript.utilities.bukkit.world.items.reference.StackIdentifier;
@@ -24,6 +28,13 @@ public class ExecutableBlocksStackIdentifier implements StackIdentifier {
     private final ExecutableBlocksManager manager;
     private final String id;
 
+    @JsonCreator
+    public ExecutableBlocksStackIdentifier(@JsonProperty("id") String id) {
+        this.integration = WolfyCoreBukkit.getInstance().getCompatibilityManager().getPlugins().getIntegration("ExecutableBlocks", ExecutableBlocksIntegration.class);
+        this.manager = ExecutableBlocksManager.getInstance();
+        this.id = id;
+    }
+
     public ExecutableBlocksStackIdentifier(ExecutableBlocksIntegration integration, ExecutableBlocksManager manager, String id) {
         this.id = id;
         this.manager = manager;
@@ -34,6 +45,11 @@ public class ExecutableBlocksStackIdentifier implements StackIdentifier {
         this.id = other.id;
         this.manager = other.manager;
         this.integration = other.integration;
+    }
+
+    @JsonGetter("id")
+    public String getId() {
+        return id;
     }
 
     @Override

--- a/plugin-compatibility/src/main/java/me/wolfyscript/utilities/compatibility/plugins/executableitems/ExecutableItemsStackIdentifier.java
+++ b/plugin-compatibility/src/main/java/me/wolfyscript/utilities/compatibility/plugins/executableitems/ExecutableItemsStackIdentifier.java
@@ -1,6 +1,11 @@
 package me.wolfyscript.utilities.compatibility.plugins.executableitems;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonGetter;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.JsonNode;
+import com.ssomar.score.api.executableitems.ExecutableItemsAPI;
 import com.ssomar.score.api.executableitems.config.ExecutableItemsManagerInterface;
 import com.wolfyscript.utilities.KeyedStaticId;
 import com.wolfyscript.utilities.bukkit.world.items.reference.ItemCreateContext;
@@ -19,8 +24,15 @@ public class ExecutableItemsStackIdentifier implements StackIdentifier {
 
     public static final NamespacedKey ID = NamespacedKey.wolfyutilties("executableitems");
 
+    @JsonIgnore
     private final ExecutableItemsManagerInterface manager;
     private final String id;
+
+    @JsonCreator
+    public ExecutableItemsStackIdentifier(@JsonProperty("id") String id) {
+        this.manager = ExecutableItemsAPI.getExecutableItemsManager();
+        this.id = id;
+    }
 
     public ExecutableItemsStackIdentifier(ExecutableItemsManagerInterface manager, String id) {
         this.id = id;
@@ -30,6 +42,11 @@ public class ExecutableItemsStackIdentifier implements StackIdentifier {
     private ExecutableItemsStackIdentifier(ExecutableItemsStackIdentifier other) {
         this.id = other.id;
         this.manager = other.manager;
+    }
+
+    @JsonGetter("id")
+    public String getId() {
+        return id;
     }
 
     @Override

--- a/plugin-compatibility/src/main/java/me/wolfyscript/utilities/compatibility/plugins/executableitems/ExecutableItemsStackIdentifier.java
+++ b/plugin-compatibility/src/main/java/me/wolfyscript/utilities/compatibility/plugins/executableitems/ExecutableItemsStackIdentifier.java
@@ -2,6 +2,7 @@ package me.wolfyscript.utilities.compatibility.plugins.executableitems;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.ssomar.score.api.executableitems.config.ExecutableItemsManagerInterface;
+import com.wolfyscript.utilities.KeyedStaticId;
 import com.wolfyscript.utilities.bukkit.world.items.reference.ItemCreateContext;
 import com.wolfyscript.utilities.bukkit.world.items.reference.LegacyParser;
 import com.wolfyscript.utilities.bukkit.world.items.reference.StackIdentifier;
@@ -13,6 +14,7 @@ import org.bukkit.inventory.ItemStack;
 
 import java.util.Optional;
 
+@KeyedStaticId(key = "executableitems")
 public class ExecutableItemsStackIdentifier implements StackIdentifier {
 
     public static final NamespacedKey ID = NamespacedKey.wolfyutilties("executableitems");

--- a/plugin-compatibility/src/main/java/me/wolfyscript/utilities/compatibility/plugins/fancybags/FancyBagsStackIdentifier.java
+++ b/plugin-compatibility/src/main/java/me/wolfyscript/utilities/compatibility/plugins/fancybags/FancyBagsStackIdentifier.java
@@ -1,6 +1,7 @@
 package me.wolfyscript.utilities.compatibility.plugins.fancybags;
 
 import com.fasterxml.jackson.databind.JsonNode;
+import com.wolfyscript.utilities.KeyedStaticId;
 import com.wolfyscript.utilities.bukkit.world.items.reference.ItemCreateContext;
 import com.wolfyscript.utilities.bukkit.world.items.reference.LegacyParser;
 import com.wolfyscript.utilities.bukkit.world.items.reference.StackIdentifier;
@@ -17,6 +18,7 @@ import org.bukkit.inventory.ItemStack;
 
 import java.util.Optional;
 
+@KeyedStaticId(key = "fancybags")
 public class FancyBagsStackIdentifier implements StackIdentifier {
 
     private static final String ID_TAG = "BackpackID";

--- a/plugin-compatibility/src/main/java/me/wolfyscript/utilities/compatibility/plugins/fancybags/FancyBagsStackIdentifier.java
+++ b/plugin-compatibility/src/main/java/me/wolfyscript/utilities/compatibility/plugins/fancybags/FancyBagsStackIdentifier.java
@@ -1,5 +1,8 @@
 package me.wolfyscript.utilities.compatibility.plugins.fancybags;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonGetter;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.wolfyscript.utilities.KeyedStaticId;
 import com.wolfyscript.utilities.bukkit.world.items.reference.ItemCreateContext;
@@ -26,10 +29,12 @@ public class FancyBagsStackIdentifier implements StackIdentifier {
 
     private final int id;
 
-    public FancyBagsStackIdentifier(int id) {
+    @JsonCreator
+    public FancyBagsStackIdentifier(@JsonProperty("id") int id) {
         this.id = id;
     }
 
+    @JsonGetter("id")
     public int id() {
         return id;
     }

--- a/plugin-compatibility/src/main/java/me/wolfyscript/utilities/compatibility/plugins/itemsadder/ItemsAdderStackIdentifier.java
+++ b/plugin-compatibility/src/main/java/me/wolfyscript/utilities/compatibility/plugins/itemsadder/ItemsAdderStackIdentifier.java
@@ -1,5 +1,8 @@
 package me.wolfyscript.utilities.compatibility.plugins.itemsadder;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonGetter;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.wolfyscript.utilities.KeyedStaticId;
 import com.wolfyscript.utilities.bukkit.world.items.reference.ItemCreateContext;
@@ -25,10 +28,12 @@ public class ItemsAdderStackIdentifier implements StackIdentifier {
 
     private final String itemId;
 
-    public ItemsAdderStackIdentifier(String itemId) {
+    @JsonCreator
+    public ItemsAdderStackIdentifier(@JsonProperty("id") String itemId) {
         this.itemId = itemId;
     }
 
+    @JsonGetter("id")
     public String itemId() {
         return itemId;
     }

--- a/plugin-compatibility/src/main/java/me/wolfyscript/utilities/compatibility/plugins/itemsadder/ItemsAdderStackIdentifier.java
+++ b/plugin-compatibility/src/main/java/me/wolfyscript/utilities/compatibility/plugins/itemsadder/ItemsAdderStackIdentifier.java
@@ -1,6 +1,7 @@
 package me.wolfyscript.utilities.compatibility.plugins.itemsadder;
 
 import com.fasterxml.jackson.databind.JsonNode;
+import com.wolfyscript.utilities.KeyedStaticId;
 import com.wolfyscript.utilities.bukkit.world.items.reference.ItemCreateContext;
 import com.wolfyscript.utilities.bukkit.world.items.reference.LegacyParser;
 import com.wolfyscript.utilities.bukkit.world.items.reference.StackIdentifier;
@@ -17,6 +18,7 @@ import org.bukkit.inventory.ItemStack;
 import java.util.Objects;
 import java.util.Optional;
 
+@KeyedStaticId(key = "itemsadder")
 public class ItemsAdderStackIdentifier implements StackIdentifier {
 
     public static final NamespacedKey ID = NamespacedKey.wolfyutilties("itemsadder");

--- a/plugin-compatibility/src/main/java/me/wolfyscript/utilities/compatibility/plugins/magic/MagicStackIdentifier.java
+++ b/plugin-compatibility/src/main/java/me/wolfyscript/utilities/compatibility/plugins/magic/MagicStackIdentifier.java
@@ -1,6 +1,10 @@
 package me.wolfyscript.utilities.compatibility.plugins.magic;
 
 import com.elmakers.mine.bukkit.api.magic.MagicAPI;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonGetter;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.google.common.base.Preconditions;
 import com.wolfyscript.utilities.KeyedStaticId;
@@ -22,9 +26,11 @@ public class MagicStackIdentifier implements StackIdentifier {
     public static final NamespacedKey ID = NamespacedKey.wolfyutilties("magic");
 
     private final String itemKey;
+    @JsonIgnore
     private final MagicAPI magicAPI;
 
-    public MagicStackIdentifier(String itemKey) {
+    @JsonCreator
+    public MagicStackIdentifier(@JsonProperty("itemKey") String itemKey) {
         this(Bukkit.getPluginManager().getPlugin("Magic") instanceof MagicAPI api ? api : null, itemKey);
     }
 
@@ -32,6 +38,11 @@ public class MagicStackIdentifier implements StackIdentifier {
         Preconditions.checkNotNull(magicAPI, "No MagicAPI specified when creating a MagicStackIdentifier");
         this.magicAPI = magicAPI;
         this.itemKey = itemKey;
+    }
+
+    @JsonGetter("itemKey")
+    public String getItemKey() {
+        return itemKey;
     }
 
     @Override

--- a/plugin-compatibility/src/main/java/me/wolfyscript/utilities/compatibility/plugins/magic/MagicStackIdentifier.java
+++ b/plugin-compatibility/src/main/java/me/wolfyscript/utilities/compatibility/plugins/magic/MagicStackIdentifier.java
@@ -3,6 +3,7 @@ package me.wolfyscript.utilities.compatibility.plugins.magic;
 import com.elmakers.mine.bukkit.api.magic.MagicAPI;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.google.common.base.Preconditions;
+import com.wolfyscript.utilities.KeyedStaticId;
 import com.wolfyscript.utilities.bukkit.world.items.reference.ItemCreateContext;
 import com.wolfyscript.utilities.bukkit.world.items.reference.LegacyParser;
 import com.wolfyscript.utilities.bukkit.world.items.reference.StackIdentifier;
@@ -15,6 +16,7 @@ import org.bukkit.inventory.ItemStack;
 import java.util.Objects;
 import java.util.Optional;
 
+@KeyedStaticId(key = "magic")
 public class MagicStackIdentifier implements StackIdentifier {
 
     public static final NamespacedKey ID = NamespacedKey.wolfyutilties("magic");

--- a/plugin-compatibility/src/main/java/me/wolfyscript/utilities/compatibility/plugins/mmoitems/MMOItemsStackIdentifier.java
+++ b/plugin-compatibility/src/main/java/me/wolfyscript/utilities/compatibility/plugins/mmoitems/MMOItemsStackIdentifier.java
@@ -1,5 +1,8 @@
 package me.wolfyscript.utilities.compatibility.plugins.mmoitems;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonGetter;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.wolfyscript.utilities.KeyedStaticId;
 import com.wolfyscript.utilities.bukkit.world.items.reference.ItemCreateContext;
@@ -7,6 +10,7 @@ import com.wolfyscript.utilities.bukkit.world.items.reference.LegacyParser;
 import com.wolfyscript.utilities.bukkit.world.items.reference.StackIdentifier;
 import com.wolfyscript.utilities.bukkit.world.items.reference.StackIdentifierParser;
 import io.lumine.mythic.lib.api.item.NBTItem;
+import me.wolfyscript.utilities.compatibility.plugins.mythicmobs.MythicMobsStackIdentifier;
 import me.wolfyscript.utilities.util.NamespacedKey;
 import me.wolfyscript.utilities.util.inventory.ItemUtils;
 import net.Indyuce.mmoitems.MMOItems;
@@ -29,9 +33,25 @@ public class MMOItemsStackIdentifier implements StackIdentifier {
     private final Type itemType;
     private final String itemName;
 
-    public MMOItemsStackIdentifier(Type itemType, String itemName) {
+    public MMOItemsStackIdentifier(@JsonProperty("type") Type itemType, @JsonProperty("name") String itemName) {
         this.itemType = itemType;
         this.itemName = itemName;
+    }
+
+    @JsonCreator
+    MMOItemsStackIdentifier(@JsonProperty("type") String itemType, @JsonProperty("name") String itemName) {
+        this.itemType = MMOItems.plugin.getTypes().get(itemType);
+        this.itemName = itemName;
+    }
+
+    @JsonGetter("name")
+    public String getItemName() {
+        return itemName;
+    }
+
+    @JsonGetter("type")
+    public Type getItemType() {
+        return itemType;
     }
 
     @Override

--- a/plugin-compatibility/src/main/java/me/wolfyscript/utilities/compatibility/plugins/mmoitems/MMOItemsStackIdentifier.java
+++ b/plugin-compatibility/src/main/java/me/wolfyscript/utilities/compatibility/plugins/mmoitems/MMOItemsStackIdentifier.java
@@ -1,6 +1,7 @@
 package me.wolfyscript.utilities.compatibility.plugins.mmoitems;
 
 import com.fasterxml.jackson.databind.JsonNode;
+import com.wolfyscript.utilities.KeyedStaticId;
 import com.wolfyscript.utilities.bukkit.world.items.reference.ItemCreateContext;
 import com.wolfyscript.utilities.bukkit.world.items.reference.LegacyParser;
 import com.wolfyscript.utilities.bukkit.world.items.reference.StackIdentifier;
@@ -20,6 +21,7 @@ import org.bukkit.inventory.ItemStack;
 import java.util.Objects;
 import java.util.Optional;
 
+@KeyedStaticId(key = "mmoitems")
 public class MMOItemsStackIdentifier implements StackIdentifier {
 
     public static final NamespacedKey ID = NamespacedKey.wolfyutilties("mmoitems");

--- a/plugin-compatibility/src/main/java/me/wolfyscript/utilities/compatibility/plugins/mythicmobs/MythicMobsStackIdentifier.java
+++ b/plugin-compatibility/src/main/java/me/wolfyscript/utilities/compatibility/plugins/mythicmobs/MythicMobsStackIdentifier.java
@@ -1,5 +1,9 @@
 package me.wolfyscript.utilities.compatibility.plugins.mythicmobs;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonGetter;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.wolfyscript.utilities.KeyedStaticId;
 import com.wolfyscript.utilities.bukkit.world.items.reference.ItemCreateContext;
@@ -25,12 +29,19 @@ public class MythicMobsStackIdentifier implements StackIdentifier {
     protected static final String ITEM_KEY = "MYTHIC_TYPE";
     public static final NamespacedKey ID = NamespacedKey.wolfyutilties("mythicmobs");
 
+    @JsonIgnore
     private final MythicBukkit mythicBukkit;
     private final String itemName;
 
-    public MythicMobsStackIdentifier(String itemName) {
+    @JsonCreator
+    public MythicMobsStackIdentifier(@JsonProperty("item") String itemName) {
         this.itemName = itemName;
         this.mythicBukkit = MythicBukkit.inst();
+    }
+
+    @JsonGetter("item")
+    public String getItemName() {
+        return itemName;
     }
 
     @Override

--- a/plugin-compatibility/src/main/java/me/wolfyscript/utilities/compatibility/plugins/mythicmobs/MythicMobsStackIdentifier.java
+++ b/plugin-compatibility/src/main/java/me/wolfyscript/utilities/compatibility/plugins/mythicmobs/MythicMobsStackIdentifier.java
@@ -1,6 +1,7 @@
 package me.wolfyscript.utilities.compatibility.plugins.mythicmobs;
 
 import com.fasterxml.jackson.databind.JsonNode;
+import com.wolfyscript.utilities.KeyedStaticId;
 import com.wolfyscript.utilities.bukkit.world.items.reference.ItemCreateContext;
 import com.wolfyscript.utilities.bukkit.world.items.reference.LegacyParser;
 import com.wolfyscript.utilities.bukkit.world.items.reference.StackIdentifier;
@@ -18,6 +19,7 @@ import org.bukkit.inventory.ItemStack;
 import java.util.Objects;
 import java.util.Optional;
 
+@KeyedStaticId(key = "mythicmobs")
 public class MythicMobsStackIdentifier implements StackIdentifier {
 
     protected static final String ITEM_KEY = "MYTHIC_TYPE";

--- a/plugin-compatibility/src/main/java/me/wolfyscript/utilities/compatibility/plugins/oraxen/OraxenImpl.java
+++ b/plugin-compatibility/src/main/java/me/wolfyscript/utilities/compatibility/plugins/oraxen/OraxenImpl.java
@@ -43,6 +43,7 @@ public class OraxenImpl extends PluginIntegrationAbstract implements OraxenInteg
             core.registerAPIReference(new OraxenRefImpl.Parser());
         }
         core.getRegistries().getStackIdentifierParsers().register(new OraxenStackIdentifier.Parser());
+        core.getRegistries().getStackIdentifierTypeRegistry().register(OraxenStackIdentifier.class);
     }
 
     public boolean isLatestAPI() {

--- a/plugin-compatibility/src/main/java/me/wolfyscript/utilities/compatibility/plugins/oraxen/OraxenStackIdentifier.java
+++ b/plugin-compatibility/src/main/java/me/wolfyscript/utilities/compatibility/plugins/oraxen/OraxenStackIdentifier.java
@@ -1,6 +1,7 @@
 package me.wolfyscript.utilities.compatibility.plugins.oraxen;
 
 import com.fasterxml.jackson.databind.JsonNode;
+import com.wolfyscript.utilities.KeyedStaticId;
 import com.wolfyscript.utilities.bukkit.world.items.reference.ItemCreateContext;
 import com.wolfyscript.utilities.bukkit.world.items.reference.LegacyParser;
 import com.wolfyscript.utilities.bukkit.world.items.reference.StackIdentifier;
@@ -17,6 +18,7 @@ import org.bukkit.inventory.ItemStack;
 import java.util.Objects;
 import java.util.Optional;
 
+@KeyedStaticId(key = "oraxen")
 public class OraxenStackIdentifier implements StackIdentifier {
 
     public static final NamespacedKey ID = NamespacedKey.wolfyutilties("oraxen");

--- a/plugin-compatibility/src/main/java/me/wolfyscript/utilities/compatibility/plugins/oraxen/OraxenStackIdentifier.java
+++ b/plugin-compatibility/src/main/java/me/wolfyscript/utilities/compatibility/plugins/oraxen/OraxenStackIdentifier.java
@@ -1,5 +1,8 @@
 package me.wolfyscript.utilities.compatibility.plugins.oraxen;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonGetter;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.wolfyscript.utilities.KeyedStaticId;
 import com.wolfyscript.utilities.bukkit.world.items.reference.ItemCreateContext;
@@ -25,10 +28,12 @@ public class OraxenStackIdentifier implements StackIdentifier {
 
     private final String itemID;
 
-    public OraxenStackIdentifier(String itemID) {
+    @JsonCreator
+    public OraxenStackIdentifier(@JsonProperty("item") String itemID) {
         this.itemID = itemID;
     }
 
+    @JsonGetter("item")
     public String itemId() {
         return itemID;
     }


### PR DESCRIPTION
StackReferences previously serialized the original stack, because it made it possible to change the parser afterwards. However that made it almost impossible to edit items from config.

This PR changes it so that StackIdentifiers can be serialized too so that the parsed information can be stored in the config and can easily be edited.

However, it has one downside. Once the recipe has been saved, the original stack you put into the slot is lost.
It now only exists in the form it was saved in, like the bukkit format, or another plugin item id.
When loaded back into the GUI that item will be the new "original item".