### PR TITLE
Paper 1.20.5+ Mojang-Mapping Support

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -83,16 +83,15 @@ minecraftServers {
         register("spigot_1_20_6") {
             version.set("1.20.6")
             type.set("SPIGOT")
-            imageVersion.set("java21-graalvm")
-
-            extraEnv.put("BUILD_FROM_SOURCE", "true")
+            imageVersion.set("java21")
             ports.set(setOf(debugPortMapping, "25569:25565"))
         }
         // Paper test servers
         register("paper_1_20") {
-            version.set("1.20.4")
+            version.set("1.20.6")
             type.set("PAPER")
-            ports.set(setOf(debugPortMapping, "25569:25565"))
+            imageVersion.set("java21")
+            ports.set(setOf("5007:5007", "25569:25565"))
         }
         register("paper_1_19") {
             version.set("1.19.4")
@@ -106,6 +105,11 @@ tasks.named<ShadowJar>("shadowJar") {
     dependsOn(project(":nmsutil").tasks.named("shadowJar"))
     dependsOn(project(":core").tasks.named("shadowJar"))
     mustRunAfter("jar")
+    mergeServiceFiles()
+
+    manifest {
+        attributes(Pair("paperweight-mappings-namespace", "spigot"))
+    }
 
     archiveClassifier.set("")
 
@@ -143,6 +147,7 @@ tasks.named<ShadowJar>("shadowJar") {
 tasks.named("test") {
     dependsOn.add(tasks.named("shadowJar"))
 }
+
 
 artifactory {
 

--- a/buildSrc/src/main/kotlin/wolfyutils.spigot.nms.gradle.kts
+++ b/buildSrc/src/main/kotlin/wolfyutils.spigot.nms.gradle.kts
@@ -38,6 +38,8 @@ publishing {
     }
 }
 
+paperweight.reobfArtifactConfiguration = io.papermc.paperweight.userdev.ReobfArtifactConfiguration.REOBF_PRODUCTION
+
 tasks {
     withType<ArtifactoryTask> {
         skip = true

--- a/core/src/main/java/me/wolfyscript/utilities/util/version/MinecraftVersions.java
+++ b/core/src/main/java/me/wolfyscript/utilities/util/version/MinecraftVersions.java
@@ -28,6 +28,7 @@ public class MinecraftVersions {
     private MinecraftVersions() {
     }
 
+    public static final MinecraftVersion v1_20 = MinecraftVersion.parse("1.20");
     public static final MinecraftVersion v1_19 = MinecraftVersion.parse("1.19");
     public static final MinecraftVersion v1_18 = MinecraftVersion.parse("1.18");
     public static final MinecraftVersion v1_17 = MinecraftVersion.parse("1.17");

--- a/nmsutil/build.gradle.kts
+++ b/nmsutil/build.gradle.kts
@@ -1,5 +1,4 @@
 import com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar
-import org.jfrog.gradle.plugin.artifactory.task.ArtifactoryTask
 
 plugins {
     id("com.wolfyscript.wolfyutils.spigot.java-conventions")
@@ -27,6 +26,7 @@ dependencies {
 
 tasks {
     named<ShadowJar>("shadowJar") {
+        mergeServiceFiles()
         archiveClassifier.set("")
 
         // Need to run this shadowJar after the subprojects have been obfuscated


### PR DESCRIPTION
This makes it compatible with Papers new Mojang-mapped runtime.
The NMSUtils are still reobfuscated to the Spigot mapings to keep compatibility with Spigot.
That also means the plugin needs to be remapped by the runtime.