### PR TITLE
Cofigurable Stack Identifier Priorities

### DIFF
--- a/core/src/main/java/com/wolfyscript/utilities/bukkit/registry/RegistryStackIdentifierParsers.java
+++ b/core/src/main/java/com/wolfyscript/utilities/bukkit/registry/RegistryStackIdentifierParsers.java
@@ -10,10 +10,7 @@ import me.wolfyscript.utilities.registry.RegistrySimple;
 import me.wolfyscript.utilities.util.NamespacedKey;
 import org.bukkit.inventory.ItemStack;
 
-import java.util.Comparator;
-import java.util.List;
-import java.util.Objects;
-import java.util.Optional;
+import java.util.*;
 
 public class RegistryStackIdentifierParsers extends RegistrySimple<StackIdentifierParser<?>> {
 
@@ -21,7 +18,7 @@ public class RegistryStackIdentifierParsers extends RegistrySimple<StackIdentifi
     private final Registries registries;
 
     public RegistryStackIdentifierParsers(Registries registries) {
-        super(new NamespacedKey(registries.getCore(), "stack_identifier/parsers"), registries, (Class<StackIdentifierParser<?>>)(Object) StackIdentifierParser.class);
+        super(new NamespacedKey(registries.getCore(), "stack_identifier/parsers"), registries, (Class<StackIdentifierParser<?>>) (Object) StackIdentifierParser.class);
         this.registries = registries;
     }
 
@@ -51,8 +48,6 @@ public class RegistryStackIdentifierParsers extends RegistrySimple<StackIdentifi
     }
 
     /**
-     *
-     *
      * @param stack
      * @return
      */
@@ -62,6 +57,12 @@ public class RegistryStackIdentifierParsers extends RegistrySimple<StackIdentifi
     }
 
     private void reIndexParsers() {
-        priorityIndexedParsers = map.values().stream().sorted(Comparator.naturalOrder()).filter(Objects::nonNull).toList();
+        Map<NamespacedKey, Integer> customPriorities = registries.getCore().getConfig().getIdentifierParserPriorities();
+
+        priorityIndexedParsers = map.values().stream().filter(Objects::nonNull).sorted((parser, otherParser) -> {
+            int parserPriority = customPriorities.getOrDefault(parser.getNamespacedKey(), parser.priority());
+            int otherPriority = customPriorities.getOrDefault(otherParser.getNamespacedKey(), otherParser.priority());
+            return Integer.compare(otherPriority, parserPriority);
+        }).toList();
     }
 }

--- a/core/src/main/java/me/wolfyscript/utilities/api/WolfyUtilCore.java
+++ b/core/src/main/java/me/wolfyscript/utilities/api/WolfyUtilCore.java
@@ -153,6 +153,7 @@ import org.bukkit.command.Command;
 import org.bukkit.command.CommandMap;
 import org.bukkit.plugin.Plugin;
 import org.bukkit.plugin.java.JavaPlugin;
+import org.jetbrains.annotations.NotNull;
 import org.reflections.Reflections;
 import org.reflections.scanners.Scanners;
 import org.reflections.util.ConfigurationBuilder;
@@ -212,6 +213,7 @@ public abstract class WolfyUtilCore extends JavaPlugin implements WolfyCore {
         this.messageFactory = new MessageFactory(this);
         this.persistentStorage = new PersistentStorage(this);
         this.functionalRecipeGenerator = FunctionalRecipeGenerator.create(this);
+        this.config = new WUConfig(api.getConfigAPI(), this);
 
         // Data that needs to be registered
         getLogger().info("Register Default StackIdentifiers");
@@ -410,7 +412,6 @@ public abstract class WolfyUtilCore extends JavaPlugin implements WolfyCore {
         console.info("Minecraft version: " + ServerVersion.getVersion().getVersion());
         console.info("WolfyUtils version: " + ServerVersion.getWUVersion().getVersion());
         console.info("Environment: " + WolfyUtilities.getENVIRONMENT());
-        this.config = new WUConfig(api.getConfigAPI(), this);
         compatibilityManager.init();
 
         // Register ReferenceParser
@@ -589,6 +590,12 @@ public abstract class WolfyUtilCore extends JavaPlugin implements WolfyCore {
         if (parser instanceof VanillaRef.Parser || parser instanceof WolfyUtilitiesRef.Parser || config.isAPIReferenceEnabled(parser)) {
             CustomItem.registerAPIReferenceParser(parser);
         }
+    }
+
+    @NotNull
+    @Override
+    public WUConfig getConfig() {
+        return config;
     }
 
     public MessageHandler getMessageHandler() {

--- a/core/src/main/java/me/wolfyscript/utilities/main/configs/WUConfig.java
+++ b/core/src/main/java/me/wolfyscript/utilities/main/configs/WUConfig.java
@@ -22,6 +22,13 @@ import me.wolfyscript.utilities.api.WolfyUtilCore;
 import me.wolfyscript.utilities.api.config.ConfigAPI;
 import me.wolfyscript.utilities.api.config.YamlConfiguration;
 import me.wolfyscript.utilities.api.inventory.custom_items.references.APIReference;
+import me.wolfyscript.utilities.util.NamespacedKey;
+import org.bukkit.configuration.ConfigurationSection;
+
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 public class WUConfig extends YamlConfiguration {
 
@@ -31,6 +38,24 @@ public class WUConfig extends YamlConfiguration {
 
     public boolean isAPIReferenceEnabled(APIReference.Parser<?> parser) {
         return getBoolean("api_references." + parser.getId(), true);
+    }
+
+    public Map<NamespacedKey, Integer> getIdentifierParserPriorities() {
+        ConfigurationSection section = getConfigurationSection("stack_identifiers.priorities");
+        if (section == null) return Map.of();
+
+        Set<String> keys = section.getKeys(false);
+        if (keys.isEmpty()) return Map.of();
+
+        return keys.stream().map(key -> {
+            int priority = section.getInt(key, 0);
+            NamespacedKey namespacedKey = NamespacedKey.of(key);
+            if (namespacedKey == null) {
+                plugin.getLogger().warning("Cannot load priority for stack identifier \" " + key + "\"! Invalid key format (<namespace>:<name>)!");
+                return null;
+            }
+            return Map.entry(namespacedKey, priority);
+        }).filter(Objects::nonNull).collect(Collectors.toUnmodifiableMap(Map.Entry::getKey, Map.Entry::getValue));
     }
 
 }

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -1,5 +1,15 @@
-api_references:
-  mmoitems: true
-  oraxen: true
-  mythicmobs: true
-  itemsadder: true
+stack_identifiers:
+  priorities:
+    "wolfyutilities:mmoitems": 2000
+    "wolfyutilities:oraxen": 1900
+    "wolfyutilities:executableitems": 1800
+    "wolfyutilities:executableblocks": 1700
+    "wolfyutilities:mythicmobs": 1600
+    "wolfyutilities:itemsadder": 1500
+    "wolfyutilities:magic": 600
+    "wolfyutilities:eco": 100
+    "wolfyutilities:fancybags": 0
+    "wolfyutilities:denizen": 0
+    "wolfyutilities:wolfyutils": 0
+    # Make sure the bukkit identifier has the lowest priority at all times! This will otherwise overwrite everything
+    "wolfyutilities:bukkit": -4096


### PR DESCRIPTION
This adds the possibility to configure the stack identifier parser priority.

You may notice that the item changes its NBT/Data Components when placing it into the GUI, which exactly happens because a parser detected the item as an item linked to another plugin. 
The parsers check for the present of plugin specific identifiers and link it if detected. 
* The parser with the higher priority checks the item stack first. 
* The `bukkit` parser will accept **all item stacks** and stores them as is.

The config is loaded on startup and cannot be edited while the plugin is running, so edit it while the server is stopped and start the server to load the new config.

The `config.yml` contains the default priorities:
```yml
stack_identifiers:
  priorities:
    "wolfyutilities:mmoitems": 2000
    "wolfyutilities:oraxen": 1900
    "wolfyutilities:executableitems": 1800
    "wolfyutilities:executableblocks": 1700
    "wolfyutilities:mythicmobs": 1600
    "wolfyutilities:itemsadder": 1500
    "wolfyutilities:magic": 600
    "wolfyutilities:eco": 100
    "wolfyutilities:fancybags": 0
    "wolfyutilities:denizen": 0
    "wolfyutilities:wolfyutils": 0
    # Make sure the bukkit identifier has the lowest priority at all times! This will otherwise overwrite everything
    "wolfyutilities:bukkit": -4096
```